### PR TITLE
feat: load games dynamically

### DIFF
--- a/games.json
+++ b/games.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "3D Box Playground",
+    "slug": "box3d",
+    "badge": "3D",
+    "blurb": "WASD + Space to jump. Orbit the camera with your mouse."
+  },
+  {
+    "title": "Pong Classic",
+    "slug": "pong",
+    "badge": "2D",
+    "blurb": "Arrow keys to move. Keep the ball in play, beat the AI."
+  }
+]

--- a/index.html
+++ b/index.html
@@ -69,5 +69,40 @@
     </section>
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
+  <script>
+    fetch('games.json')
+      .then(r => r.json())
+      .then(games => {
+        const grid = document.querySelector('.grid');
+        if (!grid) return;
+        grid.innerHTML = '';
+        for (const g of games) {
+          const a = document.createElement('a');
+          a.className = 'card';
+          a.href = `./games/${g.slug}/`;
+          a.setAttribute('aria-label', `Play ${g.title}`);
+
+          const badge = document.createElement('div');
+          badge.className = 'badge';
+          badge.textContent = g.badge;
+
+          const h3 = document.createElement('h3');
+          h3.textContent = g.title;
+
+          const p = document.createElement('p');
+          p.textContent = g.blurb;
+
+          const play = document.createElement('div');
+          play.className = 'play';
+          play.textContent = 'Play →';
+
+          a.append(badge, h3, p, play);
+          grid.appendChild(a);
+        }
+      })
+      .catch(err => {
+        console.warn('Failed to load games.json', err);
+      });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `games.json` with game metadata
- dynamically render hub game cards by fetching `games.json`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a91954c00c8327822882e7d6e58eff