### PR TITLE
Add reusable back to hub button for games

### DIFF
--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -14,7 +14,6 @@
     }
     kbd { padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px; }
     a { color: #8cc8ff; text-decoration: none; }
-    .back { position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; }
     canvas{display:block}
   </style>
 </head>
@@ -24,7 +23,10 @@
     <div>Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Jump: <kbd>Space</kbd> • Reset: <kbd>R</kbd></div>
     <div>Mouse orbit + wheel zoom.</div>
   </div>
-  <a class="back" href="../../">← Back to Hub</a>
   <script type="module" src="./main.js"></script>
+  <script type="module">
+    import { injectBackButton } from '../../shared/ui.js';
+    injectBackButton();
+  </script>
 </body>
 </html>

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -9,13 +9,11 @@
     .wrap{display:grid; place-items:center; height:100%; padding:16px}
     canvas{background:#0a0d13; border:1px solid #1f2431; border-radius:12px; box-shadow:0 6px 22px rgba(0,0,0,.35)}
     .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
-    .back{position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none}
     kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
   </style>
 </head>
 <body>
   <div class="hud">Move: <kbd>←</kbd><kbd>→</kbd> • Pause: <kbd>P</kbd></div>
-  <a class="back" href="../../">← Back to Hub</a>
   <div class="wrap">
     <canvas id="game" width="720" height="420" aria-label="Pong game"></canvas>
   </div>
@@ -121,6 +119,10 @@
     }
 
     requestAnimationFrame(loop);
+  </script>
+  <script type="module">
+    import { injectBackButton } from "../../shared/ui.js";
+    injectBackButton();
   </script>
 </body>
 </html>

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -1,0 +1,24 @@
+export function injectBackButton(relativePathToHub = '../../') {
+  const style = document.createElement('style');
+  style.textContent = `
+    .back-to-hub {
+      position: fixed;
+      left: 12px;
+      bottom: 12px;
+      color: #cfe6ff;
+      background: #0e1422;
+      border: 1px solid #27314b;
+      padding: 8px 10px;
+      border-radius: 10px;
+      font-weight: 700;
+      text-decoration: none;
+    }
+  `;
+  document.head.appendChild(style);
+
+  const link = document.createElement('a');
+  link.href = relativePathToHub;
+  link.className = 'back-to-hub';
+  link.textContent = '← Back to Hub';
+  document.body.appendChild(link);
+}


### PR DESCRIPTION
## Summary
- Add `shared/ui.js` with `injectBackButton` helper that injects a styled "Back to Hub" link
- Use new helper in `box3d` and `pong` pages via module script import

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a91961179c8327972172b8bb3ce6d1