### PR TITLE
feat: add localStorage high scores to hub

### DIFF
--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -58,6 +58,9 @@ const velocity = new THREE.Vector3();
 let onGround = true;
 const HS_KEY = 'highscore:box3d';
 let highScore = Number(localStorage.getItem(HS_KEY) || 0);
+let pickup = null;
+let score = 0;
+const scoreEl = document.getElementById('score');
 const keys = new Map();
 addEventListener('keydown', (e) => keys.set(e.code, true));
 addEventListener('keyup', (e) => keys.set(e.code, false));
@@ -89,6 +92,13 @@ function update(dt){
 
   if (onGround){ velocity.x *= 0.88; velocity.z *= 0.88; }
 
+  if (pickup && player.position.distanceTo(pickup.position) < 1){
+    score++;
+    if (scoreEl) scoreEl.textContent = score;
+    scene.remove(pickup);
+    pickup = null;
+  }
+
   const dist = Math.hypot(player.position.x, player.position.z);
   if (dist > highScore) {
     highScore = dist;
@@ -104,6 +114,7 @@ function update(dt){
 function animate(){
   const dt = Math.min(clock.getDelta(), 0.05);
   update(dt);
+  if (pickup){ pickup.rotation.y += dt * 2; }
   renderer.render(scene, camera);
   requestAnimationFrame(animate);
 }

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -56,6 +56,8 @@ const MAX_SPEED = 10;
 
 const velocity = new THREE.Vector3();
 let onGround = true;
+const HS_KEY = 'highscore:box3d';
+let highScore = Number(localStorage.getItem(HS_KEY) || 0);
 const keys = new Map();
 addEventListener('keydown', (e) => keys.set(e.code, true));
 addEventListener('keyup', (e) => keys.set(e.code, false));
@@ -86,6 +88,12 @@ function update(dt){
   if (player.position.y <= floorY){ player.position.y = floorY; velocity.y = 0; onGround = true; }
 
   if (onGround){ velocity.x *= 0.88; velocity.z *= 0.88; }
+
+  const dist = Math.hypot(player.position.x, player.position.z);
+  if (dist > highScore) {
+    highScore = dist;
+    localStorage.setItem(HS_KEY, Math.floor(highScore));
+  }
 
   const idealOffset = new THREE.Vector3(8,6,8).add(player.position);
   camera.position.lerp(idealOffset, 0.08);

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -25,10 +25,12 @@
 
     const W = cvs.width, H = cvs.height;
     const paddleW = 100, paddleH = 14, margin = 28;
-    const player = { x: (W-paddleW)/2, y: H - margin - paddleH, vx: 0, speed: 520, score: 0 };
-    const ai = { x: (W-paddleW)/2, y: margin, vx: 0, speed: 360, score: 0 };
-    const ball = { x: W/2, y: H/2, r: 8, vx: 260, vy: 260 };
-    let paused = false;
+      const player = { x: (W-paddleW)/2, y: H - margin - paddleH, vx: 0, speed: 520, score: 0 };
+      const ai = { x: (W-paddleW)/2, y: margin, vx: 0, speed: 360, score: 0 };
+      const ball = { x: W/2, y: H/2, r: 8, vx: 260, vy: 260 };
+      const HS_KEY = 'highscore:pong';
+      let highScore = Number(localStorage.getItem(HS_KEY) || 0);
+      let paused = false;
 
     const keys = new Map();
     addEventListener('keydown', e => { keys.set(e.code, true); if(e.code==='KeyP') paused = !paused; });
@@ -83,7 +85,14 @@
       }
 
       // scoring
-      if (ball.y < -20) { player.score++; resetBall(-1); }
+      if (ball.y < -20) {
+        player.score++;
+        if (player.score > highScore) {
+          highScore = player.score;
+          localStorage.setItem(HS_KEY, highScore);
+        }
+        resetBall(-1);
+      }
       if (ball.y > H + 20) { ai.score++; resetBall(1); }
     }
 

--- a/index.html
+++ b/index.html
@@ -38,16 +38,17 @@
     }
     a.card:hover{ transform: translateY(-2px); border-color:#2a334a; box-shadow: 0 6px 22px rgba(0,0,0,.35); }
     .badge{position:absolute; top:12px; right:12px; font-size:11px; padding:4px 8px; border-radius:999px; background:#0e1422; border:1px solid #27314b; color:#c3d7ff}
-    .card h3{margin:0 0 8px 0; font-size:18px}
-    .card p{margin:0; color:var(--muted); font-size:14px; line-height:1.35}
-    .play{
-      position:absolute; bottom:12px; right:12px; font-weight:700; font-size:13px; padding:8px 10px;
-      border-radius:10px; border:1px solid #27314b; background:#0e1422; color:#cfe6ff;
-    }
-    footer{margin-top:auto; padding:16px; text-align:center; color:#7f8b99; font-size:12px; border-top:1px solid #1e2431}
-  </style>
-</head>
-<body>
+      .card h3{margin:0 0 8px 0; font-size:18px}
+      .card p{margin:0; color:var(--muted); font-size:14px; line-height:1.35}
+      .play{
+        position:absolute; bottom:12px; right:12px; font-weight:700; font-size:13px; padding:8px 10px;
+        border-radius:10px; border:1px solid #27314b; background:#0e1422; color:#cfe6ff;
+      }
+      .best{position:absolute; bottom:12px; left:12px; font-size:13px; color:var(--muted);}
+      footer{margin-top:auto; padding:16px; text-align:center; color:#7f8b99; font-size:12px; border-top:1px solid #1e2431}
+    </style>
+  </head>
+  <body>
   <header>
     <div class="brand">🎮 <span>Arcade</span> Hub</div>
     <div class="hint">Click a game to play • Add more by copying a folder in <code>/games</code></div>
@@ -69,5 +70,17 @@
     </section>
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
+  <script>
+    document.querySelectorAll('a.card').forEach(card => {
+      const slug = card.getAttribute('href').replace(/\/$/, '').split('/').filter(Boolean).pop();
+      const score = localStorage.getItem(`highscore:${slug}`);
+      if (score !== null) {
+        const best = document.createElement('div');
+        best.className = 'best';
+        best.textContent = `Best: ${score}`;
+        card.appendChild(best);
+      }
+    });
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -55,13 +55,13 @@
   </header>
   <main>
     <section class="grid">
-      <a class="card" href="./games/box3d/" aria-label="Play 3D Box Playground">
+      <a class="card" href="./games/box3d/" data-slug="box3d" aria-label="Play 3D Box Playground">
         <div class="badge">3D</div>
         <h3>3D Box Playground</h3>
         <p>WASD + Space to jump. Orbit the camera with your mouse.</p>
         <div class="play">Play →</div>
       </a>
-      <a class="card" href="./games/pong/" aria-label="Play Pong Classic">
+      <a class="card" href="./games/pong/" data-slug="pong" aria-label="Play Pong Classic">
         <div class="badge">2D</div>
         <h3>Pong Classic</h3>
         <p>Arrow keys to move. Keep the ball in play, beat the AI.</p>
@@ -72,7 +72,7 @@
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
   <script>
     document.querySelectorAll('a.card').forEach(card => {
-      const slug = card.getAttribute('href').replace(/\/$/, '').split('/').filter(Boolean).pop();
+      const slug = card.dataset.slug;
       const score = localStorage.getItem(`highscore:${slug}`);
       if (score !== null) {
         const best = document.createElement('div');


### PR DESCRIPTION
## Summary
- track player high scores in localStorage for Pong and 3D Box Playground
- surface stored high scores on hub tiles via a new `Best:` label

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9196724e08327bbe0be114521fb0f