### PR TITLE
Switch to pointer lock and add pickups

### DIFF
--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -21,8 +21,8 @@
 <body>
   <div id="info">
     <div><strong>3D Box Playground</strong></div>
-    <div>Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Jump: <kbd>Space</kbd> • Reset: <kbd>R</kbd></div>
-    <div>Mouse orbit + wheel zoom.</div>
+    <div>Click to lock pointer. Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Jump: <kbd>Space</kbd> • Reset: <kbd>R</kbd></div>
+    <div>Score: <span id="score">0</span></div>
   </div>
   <a class="back" href="../../">← Back to Hub</a>
   <script type="module" src="./main.js"></script>

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+import { PointerLockControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/PointerLockControls.js';
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
@@ -11,10 +11,12 @@ const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x0e0f12);
 
 const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
-camera.position.set(8, 6, 8);
-const controls = new OrbitControls(camera, renderer.domElement);
-controls.enableDamping = true;
-controls.target.set(0, 1, 0);
+const controls = new PointerLockControls(camera, document.body);
+const player = controls.getObject();
+player.position.set(0, 1, 5);
+scene.add(player);
+
+document.body.addEventListener('click', () => controls.lock());
 
 const hemi = new THREE.HemisphereLight(0xbcc7ff, 0x20242c, 0.6);
 scene.add(hemi);
@@ -33,14 +35,6 @@ ground.rotation.x = -Math.PI * 0.5;
 ground.receiveShadow = true;
 scene.add(ground);
 
-const player = new THREE.Mesh(
-  new THREE.BoxGeometry(1, 2, 1),
-  new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.7, metalness: 0.1 })
-);
-player.position.set(0, 1, 0);
-player.castShadow = true;
-scene.add(player);
-
 const box = new THREE.Mesh(
   new THREE.BoxGeometry(1.5, 1.5, 1.5),
   new THREE.MeshStandardMaterial({ color: 0x6aa9ff })
@@ -48,6 +42,18 @@ const box = new THREE.Mesh(
 box.position.set(4, 0.75, -3);
 box.castShadow = true;
 scene.add(box);
+
+let pickup = new THREE.Mesh(
+  new THREE.SphereGeometry(0.3, 16, 16),
+  new THREE.MeshStandardMaterial({ color: 0xffdd00, emissive: 0xffaa00, emissiveIntensity: 1.5 })
+);
+pickup.position.set(-3, 0.3, 4);
+pickup.castShadow = true;
+pickup.add(new THREE.PointLight(0xffaa00, 1, 3));
+scene.add(pickup);
+
+const scoreEl = document.getElementById('score');
+let score = 0;
 
 const GRAVITY = -20;
 const ACCEL = 28;
@@ -59,7 +65,12 @@ let onGround = true;
 const keys = new Map();
 addEventListener('keydown', (e) => keys.set(e.code, true));
 addEventListener('keyup', (e) => keys.set(e.code, false));
-addEventListener('keydown', (e) => { if (e.code === 'KeyR'){ player.position.set(0,1,0); velocity.set(0,0,0);} });
+addEventListener('keydown', (e) => {
+  if (e.code === 'KeyR'){
+    player.position.set(0,1,5);
+    velocity.set(0,0,0);
+  }
+});
 
 addEventListener('resize', () => {
   camera.aspect = innerWidth / innerHeight;
@@ -67,30 +78,50 @@ addEventListener('resize', () => {
   renderer.setSize(innerWidth, innerHeight);
 });
 
+const forward = new THREE.Vector3();
+const right = new THREE.Vector3();
+const accel = new THREE.Vector3();
+const up = new THREE.Vector3(0,1,0);
+
 const clock = new THREE.Clock();
 function update(dt){
-  const ax = (keys.get('KeyD') ? 1 : 0) - (keys.get('KeyA') ? 1 : 0);
-  const az = (keys.get('KeyS') ? 1 : 0) - (keys.get('KeyW') ? 1 : 0);
-  velocity.x += ax * ACCEL * dt;
-  velocity.z += az * ACCEL * dt;
+  if (controls.isLocked){
+    const moveX = (keys.get('KeyD') ? 1 : 0) - (keys.get('KeyA') ? 1 : 0);
+    const moveZ = (keys.get('KeyS') ? 1 : 0) - (keys.get('KeyW') ? 1 : 0);
 
-  const speed = Math.hypot(velocity.x, velocity.z);
-  if (speed > MAX_SPEED){ const s = MAX_SPEED / speed; velocity.x *= s; velocity.z *= s; }
+    camera.getWorldDirection(forward);
+    forward.y = 0;
+    forward.normalize();
+    right.crossVectors(forward, up).normalize();
 
-  if (onGround && keys.get('Space')) { velocity.y = JUMP_SPEED; onGround = false; }
-  else { velocity.y += GRAVITY * dt; }
+    accel.set(0,0,0);
+    accel.addScaledVector(forward, moveZ * ACCEL);
+    accel.addScaledVector(right, moveX * ACCEL);
+    velocity.x += accel.x * dt;
+    velocity.z += accel.z * dt;
 
-  player.position.addScaledVector(velocity, dt);
+    const speed = Math.hypot(velocity.x, velocity.z);
+    if (speed > MAX_SPEED){ const s = MAX_SPEED / speed; velocity.x *= s; velocity.z *= s; }
 
-  const floorY = 1.0;
-  if (player.position.y <= floorY){ player.position.y = floorY; velocity.y = 0; onGround = true; }
+    if (onGround && keys.get('Space')) { velocity.y = JUMP_SPEED; onGround = false; }
+    else { velocity.y += GRAVITY * dt; }
 
-  if (onGround){ velocity.x *= 0.88; velocity.z *= 0.88; }
+    player.position.addScaledVector(velocity, dt);
 
-  const idealOffset = new THREE.Vector3(8,6,8).add(player.position);
-  camera.position.lerp(idealOffset, 0.08);
-  controls.target.lerp(player.position.clone().setY(player.position.y + 0.8), 0.15);
-  controls.update();
+    const floorY = 1.0;
+    if (player.position.y <= floorY){ player.position.y = floorY; velocity.y = 0; onGround = true; }
+
+    if (onGround){ velocity.x *= 0.88; velocity.z *= 0.88; }
+
+    if (pickup && player.position.distanceTo(pickup.position) < 1){
+      score++;
+      scoreEl.textContent = score;
+      scene.remove(pickup);
+      pickup = null;
+    }
+  }
+
+  if (pickup){ pickup.rotation.y += dt * 2; }
 }
 
 function animate(){
@@ -102,3 +133,4 @@ function animate(){
 animate();
 
 scene.add(new THREE.AxesHelper(2.5));
+


### PR DESCRIPTION
## Summary
- Replace OrbitControls with click-to-lock PointerLockControls for first-person navigation
- Add rotating glowing pickup that increments HUD score on collection
- Maintain WASD + jump movement with ground collision and speed clamp

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9196d9d1c8327a1685baca07eb075