### PR TITLE
Load games list from JSON

### DIFF
--- a/games.json
+++ b/games.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "3D Box Playground",
+    "slug": "box3d",
+    "badge": "3D",
+    "blurb": "WASD + Space to jump. Orbit the camera with your mouse."
+  },
+  {
+    "title": "Pong Classic",
+    "slug": "pong",
+    "badge": "2D",
+    "blurb": "Arrow keys to move. Keep the ball in play, beat the AI."
+  }
+]

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
   <script>
     // Load game definitions and render cards dynamically
-    fetch('games.json')
+    fetch('./games.json')
       .then(r => {
         if (!r.ok) throw new Error('Network response was not ok');
         return r.json();

--- a/index.html
+++ b/index.html
@@ -69,5 +69,28 @@
     </section>
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
+  <script>
+    // Load game definitions and render cards dynamically
+    fetch('games.json')
+      .then(r => {
+        if (!r.ok) throw new Error('Network response was not ok');
+        return r.json();
+      })
+      .then(games => {
+        const grid = document.querySelector('.grid');
+        grid.innerHTML = games.map(game => `
+          <a class="card" href="./games/${game.slug}/" aria-label="Play ${game.title}">
+            <div class="badge">${game.badge}</div>
+            <h3>${game.title}</h3>
+            <p>${game.blurb}</p>
+            <div class="play">Play →</div>
+          </a>
+        `).join('');
+      })
+      .catch(err => {
+        console.warn('Failed to load games.json', err);
+        // Fallback: keep existing static cards
+      });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `games.json` listing available games
- fetch `games.json` on the hub page and render cards dynamically
- fallback to existing static cards if loading fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a919918ab083278f0f33004494ee14