### PR TITLE
Support deep linking to games via URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ A tiny Miniclip-style hub with multiple games. Static files only — perfect for
 /games/pong/    → Simple Pong (canvas 2D)
 ```
 
+## Deep link to a game
+Link directly to a game from the hub using a query parameter:
+
+```
+/?game=pong   → /games/pong/
+/?game=box3d  → /games/box3d/
+```
+
+If `game` is present in the URL, the hub will redirect straight to that game's folder.
+
 ## Run locally
 - VS Code: use **Live Server** on `index.html`, or
 - Python: `python -m http.server 5173` then open http://localhost:5173

--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Arcade Hub</title>
   <meta name="description" content="A tiny arcade hub with multiple games. Click a tile to play." />
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const slug = params.get('game');
+    if (slug) {
+      const target = `./games/${encodeURIComponent(slug)}/`;
+      window.location.replace(target);
+    }
+  </script>
   <style>
     :root{
       --bg:#0b0d11; --card:#131722; --card2:#181c27; --text:#e8ecf1; --muted:#9aa7b2; --accent:#8cc8ff;


### PR DESCRIPTION
## Summary
- Redirect the hub to a game when `?game=<slug>` is in the URL
- Document deep-linking usage in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a919a17304832794ce4c67eaf521b5