### PR TITLE
Add keyboard-accessible pause overlay

### DIFF
--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -16,15 +16,36 @@
     a { color: #8cc8ff; text-decoration: none; }
     .back { position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; }
     canvas{display:block}
-  </style>
-</head>
-<body>
+    #pause {
+      position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
+      background:#1b1e24; padding:20px; border-radius:12px;
+      display:flex; flex-direction:column; gap:12px; box-shadow:0 4px 20px rgba(0,0,0,0.5);
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+    }
+    #pause button {
+      padding:10px 16px; border:none; border-radius:8px; background:#27314b;
+      color:#cfe6ff; font-weight:700; cursor:pointer;
+    }
+    #pause button:focus { outline:2px solid #8cc8ff; outline-offset:2px; }
+    #controlsText { font-size:14px; color:#e6e6e6; line-height:1.4; }
+    </style>
+  </head>
+  <body>
   <div id="info">
     <div><strong>3D Box Playground</strong></div>
     <div>Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Jump: <kbd>Space</kbd> • Reset: <kbd>R</kbd></div>
     <div>Mouse orbit + wheel zoom.</div>
   </div>
   <a class="back" href="../../">← Back to Hub</a>
+  <div id="pause" hidden>
+    <button id="resumeBtn">Resume</button>
+    <button id="restartBtn">Restart</button>
+    <button id="controlsBtn">Controls</button>
+    <button id="exitBtn">Exit to Hub</button>
+    <div id="controlsText" hidden>
+      Move: W/A/S/D<br/>Jump: Space<br/>Reset: R
+    </div>
+  </div>
   <script type="module" src="./main.js"></script>
-</body>
+  </body>
 </html>

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -57,9 +57,48 @@ const MAX_SPEED = 10;
 const velocity = new THREE.Vector3();
 let onGround = true;
 const keys = new Map();
-addEventListener('keydown', (e) => keys.set(e.code, true));
-addEventListener('keyup', (e) => keys.set(e.code, false));
-addEventListener('keydown', (e) => { if (e.code === 'KeyR'){ player.position.set(0,1,0); velocity.set(0,0,0);} });
+let paused = false;
+
+const pauseOverlay = document.getElementById('pause');
+const resumeBtn = document.getElementById('resumeBtn');
+const restartBtn = document.getElementById('restartBtn');
+const controlsBtn = document.getElementById('controlsBtn');
+const exitBtn = document.getElementById('exitBtn');
+const controlsText = document.getElementById('controlsText');
+const info = document.getElementById('info');
+
+function reset(){
+  player.position.set(0,1,0);
+  velocity.set(0,0,0);
+}
+
+function setPaused(v){
+  paused = v;
+  pauseOverlay.hidden = !v;
+  if(info) info.style.display = v ? 'none' : '';
+  if(v){ resumeBtn.focus(); }
+}
+
+addEventListener('keydown', (e) => {
+  if(paused) return;
+  keys.set(e.code, true);
+});
+addEventListener('keyup', (e) => {
+  if(paused) return;
+  keys.set(e.code, false);
+});
+addEventListener('keydown', (e) => {
+  if(paused) return;
+  if (e.code === 'KeyR'){ reset(); }
+});
+addEventListener('keydown', (e) => {
+  if (e.code === 'Escape'){ setPaused(!paused); }
+});
+
+resumeBtn.addEventListener('click', () => setPaused(false));
+restartBtn.addEventListener('click', () => { reset(); setPaused(false); });
+controlsBtn.addEventListener('click', () => { controlsText.hidden = !controlsText.hidden; });
+exitBtn.addEventListener('click', () => { window.location.href = '../../'; });
 
 addEventListener('resize', () => {
   camera.aspect = innerWidth / innerHeight;
@@ -95,7 +134,7 @@ function update(dt){
 
 function animate(){
   const dt = Math.min(clock.getDelta(), 0.05);
-  update(dt);
+  if(!paused) update(dt);
   renderer.render(scene, camera);
   requestAnimationFrame(animate);
 }


### PR DESCRIPTION
## Summary
- add centered pause overlay with Resume, Restart, Controls, Exit to Hub options
- wire up Escape key and buttons for pausing, restarting, and navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a919d1495c8327b1b7a9b0c4cbf129