### PR TITLE
Add orb pickups with scoring HUD

### DIFF
--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -7,10 +7,15 @@
   <style>
     html, body { height:100%; margin:0; background:#0e0f12; overflow:hidden; }
     #info {
-      position: fixed; left: 12px; top: 12px; padding: 10px 12px;
+      position: fixed; left: 12px; top: 60px; padding: 10px 12px;
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
       font-size: 14px; line-height: 1.35; color: #e6e6e6; background: #1b1e24c0; border-radius: 10px;
       box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+    }
+    #score {
+      position: fixed; left: 12px; top: 12px; padding: 6px 10px;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+      font-size: 16px; font-weight:700; color:#fff; background:#0e1422c0; border:1px solid #27314b; border-radius:8px;
     }
     kbd { padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px; }
     a { color: #8cc8ff; text-decoration: none; }
@@ -19,6 +24,7 @@
   </style>
 </head>
 <body>
+  <div id="score">Score: 0</div>
   <div id="info">
     <div><strong>3D Box Playground</strong></div>
     <div>Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Jump: <kbd>Space</kbd> • Reset: <kbd>R</kbd></div>


### PR DESCRIPTION
## Summary
- Add top-left score HUD and reposition instruction overlay
- Implement five rotating orb pickups that give 10 points, glow, and respawn after 10s

## Testing
- `node --check games/box3d/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a919d708448327b5c1f159e9708dc3