### PR TITLE
Add mobile touch controls for 3D Box Playground

### DIFF
--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -15,6 +15,25 @@
     kbd { padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px; }
     a { color: #8cc8ff; text-decoration: none; }
     canvas{display:block}
+
+    /* On-screen touch controls */
+    #touch { position: fixed; bottom: 12px; left: 12px; display: none; user-select: none; }
+    #touch .pad { position: relative; width: 96px; height: 96px; }
+    #touch .pad button {
+      position: absolute; width: 32px; height: 32px;
+      border: 1px solid #27314b; border-radius: 8px;
+      background: #111319; color: #cfe6ff; font-size: 16px;
+    }
+    #touch .up { top: 0; left: 32px; }
+    #touch .down { bottom: 0; left: 32px; }
+    #touch .left { left: 0; top: 32px; }
+    #touch .right { right: 0; top: 32px; }
+    #touch .jump {
+      margin-left: 12px; width: 48px; height: 48px;
+      border: 1px solid #27314b; border-radius: 50%;
+      background: #111319; color: #cfe6ff; font-size: 20px;
+    }
+    @media (pointer: coarse) { #touch { display: flex; align-items: center; } }
   </style>
 </head>
 <body>
@@ -22,6 +41,15 @@
     <div><strong>3D Box Playground</strong></div>
     <div>Click to lock pointer. Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Jump: <kbd>Space</kbd> • Reset: <kbd>R</kbd></div>
     <div>Score: <span id="score">0</span></div>
+  </div>
+  <div id="touch">
+    <div class="pad">
+      <button class="up" data-k="KeyW">▲</button>
+      <button class="left" data-k="KeyA">◀</button>
+      <button class="down" data-k="KeyS">▼</button>
+      <button class="right" data-k="KeyD">▶</button>
+    </div>
+    <button class="jump" data-k="Space">⤒</button>
   </div>
   <script type="module" src="./main.js"></script>
   <script type="module">

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -72,6 +72,22 @@ addEventListener('keydown', (e) => {
   }
 });
 
+// Touch buttons map to key presses for mobile play
+const touch = document.getElementById('touch');
+if (touch) {
+  for (const btn of touch.querySelectorAll('button[data-k]')) {
+    const code = btn.dataset.k;
+    const press = (e) => { e.preventDefault(); keys.set(code, true); };
+    const release = (e) => { e.preventDefault(); keys.set(code, false); };
+    btn.addEventListener('touchstart', press);
+    btn.addEventListener('touchend', release);
+    btn.addEventListener('touchcancel', release);
+    btn.addEventListener('mousedown', press);
+    btn.addEventListener('mouseup', release);
+    btn.addEventListener('mouseleave', release);
+  }
+}
+
 addEventListener('resize', () => {
   camera.aspect = innerWidth / innerHeight;
   camera.updateProjectionMatrix();


### PR DESCRIPTION
## Summary
- add on-screen touch controller for mobile players
- wire touch buttons to game key map

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a91bfe32a08327b3beb0639ffca334