### PR TITLE
Add service worker and back button injection to Box3D game

### DIFF
--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -24,9 +24,6 @@
     <div>Score: <span id="score">0</span></div>
   </div>
   <script type="module" src="./main.js"></script>
-  <script type="module">
-    import { injectBackButton } from '../../shared/ui.js';
-    injectBackButton();
-  </script>
+  <!-- Back to hub button and service worker are injected by main.js -->
 </body>
 </html>

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -1,5 +1,10 @@
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 import { PointerLockControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/PointerLockControls.js';
+import { registerSW } from '../../shared/sw.js';
+import { injectBackButton } from '../../shared/ui.js';
+
+registerSW();
+injectBackButton();
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));

--- a/shared/sw.js
+++ b/shared/sw.js
@@ -1,0 +1,8 @@
+export function registerSW() {
+  if ('serviceWorker' in navigator) {
+    const swUrl = new URL('../sw.js', import.meta.url);
+    navigator.serviceWorker.register(swUrl.href).catch(err => {
+      console.warn('Service worker registration failed', err);
+    });
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,2 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());


### PR DESCRIPTION
## Summary
- register service worker and back button directly in Box3D game script
- add minimal service worker helper and file

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a91bf3a4a083279ca3f3dcdef08f54