### PR TITLE
Add touch controls for web games

### DIFF
--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -16,6 +16,11 @@
     a { color: #8cc8ff; text-decoration: none; }
     .back { position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; }
     canvas{display:block}
+    .touch{display:none}
+    #joystick{position:fixed;bottom:24px;left:24px;width:90px;height:90px;border:2px solid #27314b;border-radius:50%;background:#1b1e24c0;}
+    #stick{position:absolute;top:50%;left:50%;width:40px;height:40px;margin:-20px 0 0 -20px;border-radius:50%;background:#cfe6ff;}
+    #jumpBtn{position:fixed;bottom:40px;right:32px;width:64px;height:64px;border-radius:50%;border:1px solid #27314b;background:#1b1e24c0;color:#cfe6ff;font-size:24px;font-weight:700;}
+    @media (hover:none) and (pointer:coarse){.touch{display:block}}
   </style>
 </head>
 <body>
@@ -25,6 +30,8 @@
     <div>Mouse orbit + wheel zoom.</div>
   </div>
   <a class="back" href="../../">← Back to Hub</a>
+  <div id="joystick" class="touch"><div id="stick"></div></div>
+  <button id="jumpBtn" class="touch" aria-label="Jump">⤴</button>
   <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -61,6 +61,34 @@ addEventListener('keydown', (e) => keys.set(e.code, true));
 addEventListener('keyup', (e) => keys.set(e.code, false));
 addEventListener('keydown', (e) => { if (e.code === 'KeyR'){ player.position.set(0,1,0); velocity.set(0,0,0);} });
 
+const joy = { x:0, y:0 };
+const joyEl = document.getElementById('joystick');
+if (joyEl){
+  const stick = document.getElementById('stick');
+  const max = joyEl.clientWidth/2 - stick.clientWidth/2;
+  function setStick(dx,dy){
+    const clampedX = Math.max(-max, Math.min(max, dx));
+    const clampedY = Math.max(-max, Math.min(max, dy));
+    joy.x = clampedX / max;
+    joy.y = clampedY / max;
+    stick.style.transform = `translate(${clampedX}px, ${clampedY}px)`;
+  }
+  function eventPos(e){
+    const rect = joyEl.getBoundingClientRect();
+    const t = e.touches[0];
+    return [t.clientX - (rect.left + rect.width/2), t.clientY - (rect.top + rect.height/2)];
+  }
+  joyEl.addEventListener('touchstart', (e)=>{ setStick(...eventPos(e)); e.preventDefault(); });
+  joyEl.addEventListener('touchmove', (e)=>{ setStick(...eventPos(e)); e.preventDefault(); });
+  ['touchend','touchcancel'].forEach(ev=>joyEl.addEventListener(ev, ()=>setStick(0,0)));
+}
+
+const jumpBtn = document.getElementById('jumpBtn');
+if (jumpBtn){
+  jumpBtn.addEventListener('touchstart', e=>{ e.preventDefault(); keys.set('Space', true); });
+  ['touchend','touchcancel'].forEach(ev=>jumpBtn.addEventListener(ev, ()=>keys.set('Space', false)));
+}
+
 addEventListener('resize', () => {
   camera.aspect = innerWidth / innerHeight;
   camera.updateProjectionMatrix();
@@ -69,8 +97,8 @@ addEventListener('resize', () => {
 
 const clock = new THREE.Clock();
 function update(dt){
-  const ax = (keys.get('KeyD') ? 1 : 0) - (keys.get('KeyA') ? 1 : 0);
-  const az = (keys.get('KeyS') ? 1 : 0) - (keys.get('KeyW') ? 1 : 0);
+  const ax = (keys.get('KeyD') ? 1 : 0) - (keys.get('KeyA') ? 1 : 0) + joy.x;
+  const az = (keys.get('KeyS') ? 1 : 0) - (keys.get('KeyW') ? 1 : 0) + joy.y;
   velocity.x += ax * ACCEL * dt;
   velocity.z += az * ACCEL * dt;
 

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -11,6 +11,11 @@
     .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
     .back{position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none}
     kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
+    .controls{display:none}
+    .btn{width:64px;height:64px;border-radius:50%;border:1px solid #27314b;background:#1b1e24c0;color:#cfe6ff;font-size:28px;font-weight:700}
+    @media (hover:none) and (pointer:coarse){
+      .controls{display:flex;gap:40px;position:fixed;bottom:24px;left:50%;transform:translateX(-50%);}
+    }
   </style>
 </head>
 <body>
@@ -18,6 +23,10 @@
   <a class="back" href="../../">← Back to Hub</a>
   <div class="wrap">
     <canvas id="game" width="720" height="420" aria-label="Pong game"></canvas>
+  </div>
+  <div class="controls">
+    <button id="btnL" class="btn" aria-label="Move left">◄</button>
+    <button id="btnR" class="btn" aria-label="Move right">►</button>
   </div>
   <script>
     const cvs = document.getElementById('game');
@@ -33,6 +42,14 @@
     const keys = new Map();
     addEventListener('keydown', e => { keys.set(e.code, true); if(e.code==='KeyP') paused = !paused; });
     addEventListener('keyup', e => keys.set(e.code, false));
+    const touch = {left:false,right:false};
+    function bind(id,key){
+      const el=document.getElementById(id);
+      el.addEventListener('pointerdown',e=>{e.preventDefault();touch[key]=true;});
+      ['pointerup','pointercancel','pointerleave'].forEach(ev=>el.addEventListener(ev,()=>touch[key]=false));
+    }
+    bind('btnL','left');
+    bind('btnR','right');
 
     let last = 0;
     function loop(ts){
@@ -45,7 +62,7 @@
 
     function update(dt){
       // input
-      const dir = (keys.get('ArrowRight')?1:0) - (keys.get('ArrowLeft')?1:0);
+      const dir = ((keys.get('ArrowRight')||touch.right)?1:0) - ((keys.get('ArrowLeft')||touch.left)?1:0);
       player.vx = dir * player.speed;
       player.x += player.vx * dt;
 


### PR DESCRIPTION
## Summary
- add left/right touch buttons to Pong and wire them into existing input
- introduce virtual joystick and jump button for the 3D box demo
- hide touch controls on desktop using CSS media queries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a919af8c608327b65e1ae0829b10f7