### PR TITLE
Add Endless Runner game

### DIFF
--- a/games.json
+++ b/games.json
@@ -14,5 +14,13 @@
     "badge": "2D",
     "path": "./games/pong/",
     "hasScore": true
+  },
+  {
+    "id": "runner",
+    "name": "Endless Runner",
+    "description": "Space to jump • Dodge obstacles • Compete for a high score.",
+    "badge": "2D",
+    "path": "./games/runner/",
+    "hasScore": true
   }
 ]

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Endless Runner</title>
+  <style>
+    html, body{height:100%; margin:0; background:#0e0f12; color:#e6e6e6; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;}
+    .wrap{display:grid; place-items:center; height:100%; padding:16px}
+    canvas{background:#0a0d13; border:1px solid #1f2431; border-radius:12px; box-shadow:0 6px 22px rgba(0,0,0,.35)}
+    .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
+    .back{position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none}
+    kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
+    .overlay{position:fixed; inset:0; display:none; place-items:center; background:rgba(0,0,0,.35); font-weight:800; letter-spacing:.4px; text-align:center;}
+    .overlay.show{display:grid}
+    .panel{background:#111522; border:1px solid #27314b; padding:18px 22px; border-radius:16px; box-shadow:0 10px 40px rgba(0,0,0,.5)}
+    .panel h2{margin:0 0 6px 0}
+    .btn{display:inline-block; padding:8px 12px; border:1px solid #27314b; background:#0e1422; color:#cfe6ff; border-radius:10px; text-decoration:none; cursor:pointer; font-weight:700}
+  </style>
+</head>
+<body>
+  <div class="hud">Jump: <kbd>Space</kbd> or tap • Pause: <kbd>P</kbd> • Restart: <kbd>R</kbd></div>
+  <a class="back" href="../../">← Back to Hub</a>
+  <div class="wrap">
+    <canvas id="game" width="800" height="450" aria-label="Endless Runner game"></canvas>
+  </div>
+  <div id="overlay" class="overlay"><div class="panel">
+    <h2 id="over-title">Game Over</h2>
+    <div id="over-info" style="margin-bottom:10px"></div>
+    <div class="btn" id="restartBtn">Restart</div>
+  </div></div>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -1,0 +1,148 @@
+const cvs = document.getElementById('game');
+const ctx = cvs.getContext('2d');
+
+const W = cvs.width, H = cvs.height;
+const GROUND_Y = H - 64;
+
+const state = {
+  running: true,
+  time: 0,
+  score: 0,
+  hiscore: Number(localStorage.getItem('highscore:runner') || 0),
+  speed: 300, // px/s, increases over time
+};
+
+const player = { x: 100, y: GROUND_Y - 40, w: 34, h: 40, vy: 0, onGround: true };
+const gravity = 1800;
+const jumpV = -750;
+
+let obstacles = [];
+let spawnTimer = 0;
+
+const keys = new Map();
+addEventListener('keydown', e => {
+  keys.set(e.code, true);
+  if (e.code === 'Space') jump();
+  if (e.code === 'KeyP') state.running = !state.running;
+  if (e.code === 'KeyR') restart();
+});
+addEventListener('keyup', e => keys.set(e.code, false));
+
+// mobile/touch support
+addEventListener('pointerdown', () => { if (state.running) jump(); else restart(); });
+document.getElementById('restartBtn').addEventListener('click', () => restart());
+
+function jump(){
+  if (player.onGround){
+    player.vy = jumpV;
+    player.onGround = false;
+  }
+}
+
+function restart(){
+  state.running = true;
+  document.getElementById('overlay').classList.remove('show');
+  state.time = 0; state.score = 0; state.speed = 300;
+  player.x = 100; player.y = GROUND_Y - player.h; player.vy = 0; player.onGround = true;
+  obstacles = []; spawnTimer = 0;
+}
+
+let last = 0;
+requestAnimationFrame(loop);
+function loop(ts){
+  const dt = Math.min((ts - last)/1000, 0.05);
+  last = ts;
+  if (state.running) update(dt);
+  draw();
+  requestAnimationFrame(loop);
+}
+
+function update(dt){
+  state.time += dt;
+  state.score = Math.floor(state.time * 10);
+  state.speed = 300 + state.time * 25; // ramp up
+
+  // spawn obstacles
+  spawnTimer -= dt;
+  if (spawnTimer <= 0){
+    spawnTimer = 0.9 + Math.random() * 0.8; // every 0.9–1.7s
+    const h = 24 + Math.floor(Math.random()*30);
+    const w = 20 + Math.floor(Math.random()*28);
+    obstacles.push({ x: W + 20, y: GROUND_Y - h, w, h });
+  }
+
+  // physics
+  player.vy += gravity * dt;
+  player.y  += player.vy * dt;
+  if (player.y >= GROUND_Y - player.h){
+    player.y = GROUND_Y - player.h;
+    player.vy = 0;
+    player.onGround = true;
+  }
+
+  // move obstacles & cull
+  obstacles.forEach(o => o.x -= state.speed * dt);
+  obstacles = obstacles.filter(o => o.x + o.w > -30);
+
+  // collisions
+  for (const o of obstacles){
+    if (!(player.x + player.w < o.x || player.x > o.x + o.w || player.y + player.h < o.y || player.y > o.y + o.h)){
+      return gameOver();
+    }
+  }
+}
+
+function gameOver(){
+  state.running = false;
+  state.hiscore = Math.max(state.hiscore, state.score);
+  localStorage.setItem('highscore:runner', String(state.hiscore));
+  const over = document.getElementById('overlay');
+  over.querySelector('#over-title').textContent = 'Game Over';
+  over.querySelector('#over-info').textContent  = `Score: ${state.score} • Best: ${state.hiscore}`;
+  over.classList.add('show');
+}
+
+function draw(){
+  // clear + sky
+  ctx.clearRect(0,0,W,H);
+  const g = ctx.createLinearGradient(0,0,0,H);
+  g.addColorStop(0,'#0f1422'); g.addColorStop(1,'#0a0d13');
+  ctx.fillStyle = g; ctx.fillRect(0,0,W,H);
+
+  // parallax hills
+  drawHills('#12192a', 0.2, 120);
+  drawHills('#0f1728', 0.35, 180);
+
+  // ground
+  ctx.fillStyle = '#101520'; ctx.fillRect(0, GROUND_Y, W, H - GROUND_Y);
+  ctx.strokeStyle = '#1e2433'; ctx.lineWidth = 2; ctx.beginPath();
+  for(let x=0; x<W; x+=18){ ctx.moveTo(x, GROUND_Y + 0.5); ctx.lineTo(x+8, GROUND_Y + 0.5); }
+  ctx.stroke();
+
+  // player
+  ctx.fillStyle = '#e6eef9';
+  ctx.fillRect(player.x, Math.round(player.y), player.w, player.h);
+  ctx.fillStyle = '#0a0d13'; // tiny eye
+  ctx.fillRect(player.x + player.w - 10, Math.round(player.y + 10), 4, 4);
+
+  // obstacles
+  ctx.fillStyle = '#8cc8ff';
+  for (const o of obstacles) ctx.fillRect(Math.round(o.x), o.y, o.w, o.h);
+
+  // HUD
+  ctx.font = 'bold 20px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial';
+  ctx.fillStyle = '#cfe6ff'; ctx.textAlign = 'left';
+  ctx.fillText('Score: ' + state.score, 16, 32);
+  ctx.fillText('Best: ' + state.hiscore, 16, 58);
+}
+
+function drawHills(color, factor, height){
+  ctx.fillStyle = color;
+  const t = (state.time * state.speed * factor) % (W*2);
+  ctx.beginPath(); ctx.moveTo(-t, GROUND_Y);
+  for(let x=-t; x<=W*2; x+=80){
+    const y = GROUND_Y - height + Math.sin((x + t) * 0.01) * 10;
+    ctx.quadraticCurveTo(x + 40, y - 30, x + 80, y);
+  }
+  ctx.lineTo(W, GROUND_Y); ctx.lineTo(0, GROUND_Y); ctx.closePath(); ctx.fill();
+}

--- a/index.html
+++ b/index.html
@@ -24,7 +24,13 @@
         <p>Arrow keys to move. Keep the ball in play, beat the AI.</p>
         <div class="play">Play →</div>
       </a>
-    </section>
+      <a class="card" href="./games/runner/" aria-label="Play Endless Runner">
+        <div class="badge">2D</div>
+        <h3>Endless Runner</h3>
+        <p>Space to jump • Dodge obstacles • Compete for a high score.</p>
+        <div class="play">Play →</div>
+      </a>
+      </section>
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
   <script>


### PR DESCRIPTION
## Summary
- add Endless Runner game with standalone HTML canvas and JS
- expose high-score runner entry via games.json and hub card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a91da2a694832786bde7e41c16e4fb