### PR TITLE
feat: add configurable controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ A tiny Miniclip-style hub with multiple games. Static files only — perfect for
 - VS Code: use **Live Server** on `index.html`, or
 - Python: `python -m http.server 5173` then open http://localhost:5173
 
+## Controls
+Each game includes a **Controls** button for remapping keys. Custom bindings are stored in localStorage per game.
+
 ## Add a new game
 1. Copy one of the folders in `/games/` and rename it, e.g. `/games/maze/`
 2. Update its HTML/JS. The hub automatically links via your new folder if you add a tile in the root `index.html`.

--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -13,6 +13,13 @@
       box-shadow: 0 2px 10px rgba(0,0,0,0.3);
     }
     kbd { padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px; }
+    .controls-btn{position:fixed; top:12px; right:12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700}
+    .modal{position:fixed; inset:0; background:rgba(0,0,0,.6); display:none; align-items:center; justify-content:center}
+    .modal.show{display:flex}
+    .modal .panel{background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:20px; color:#e6e6e6; font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; min-width:260px}
+    .modal .row{display:flex; align-items:center; margin-bottom:8px}
+    .modal .row span{flex:1}
+    .modal .row button{padding:4px 8px; border:1px solid #2f3542; background:#111319; color:#d3d7de; border-radius:6px; min-width:60px}
     a { color: #8cc8ff; text-decoration: none; }
     .back { position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; }
     canvas{display:block}
@@ -21,8 +28,16 @@
 <body>
   <div id="info">
     <div><strong>3D Box Playground</strong></div>
-    <div>Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Jump: <kbd>Space</kbd> • Reset: <kbd>R</kbd></div>
+    <div id="help"></div>
     <div>Mouse orbit + wheel zoom.</div>
+  </div>
+  <button id="controls-btn" class="controls-btn">Controls</button>
+  <div id="controls-modal" class="modal">
+    <div class="panel">
+      <h2>Controls</h2>
+      <div id="controls-list"></div>
+      <button id="controls-close" class="controls-btn" style="position:static; margin-top:10px">Done</button>
+    </div>
   </div>
   <a class="back" href="../../">← Back to Hub</a>
   <script type="module" src="./main.js"></script>

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -1,6 +1,80 @@
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 
+const slug = 'box3d';
+const defaultBindings = {
+  forward: 'KeyW',
+  left: 'KeyA',
+  back: 'KeyS',
+  right: 'KeyD',
+  jump: 'Space',
+  reset: 'KeyR'
+};
+let bindings = JSON.parse(localStorage.getItem('controls-' + slug)) || { ...defaultBindings };
+
+const help = document.getElementById('help');
+const modal = document.getElementById('controls-modal');
+const list = document.getElementById('controls-list');
+const btnOpen = document.getElementById('controls-btn');
+const btnClose = document.getElementById('controls-close');
+let capturing = false;
+
+function codeLabel(code){
+  if(code.startsWith('Key')) return code.slice(3);
+  if(code.startsWith('Digit')) return code.slice(5);
+  const special = { ArrowLeft:'←', ArrowRight:'→', ArrowUp:'↑', ArrowDown:'↓', Space:'Space' };
+  return special[code] || code;
+}
+
+function updateHelp(){
+  help.innerHTML = `Move: <kbd>${codeLabel(bindings.forward)}</kbd><kbd>${codeLabel(bindings.left)}</kbd><kbd>${codeLabel(bindings.back)}</kbd><kbd>${codeLabel(bindings.right)}</kbd> • Jump: <kbd>${codeLabel(bindings.jump)}</kbd> • Reset: <kbd>${codeLabel(bindings.reset)}</kbd>`;
+}
+
+function saveBindings(){
+  localStorage.setItem('controls-' + slug, JSON.stringify(bindings));
+  updateHelp();
+}
+
+function buildList(){
+  list.innerHTML = '';
+  const items = [
+    ['forward', 'Forward'],
+    ['back', 'Backward'],
+    ['left', 'Left'],
+    ['right', 'Right'],
+    ['jump', 'Jump'],
+    ['reset', 'Reset']
+  ];
+  for(const [action,label] of items){
+    const row = document.createElement('div');
+    row.className = 'row';
+    const span = document.createElement('span');
+    span.textContent = label;
+    const b = document.createElement('button');
+    b.textContent = codeLabel(bindings[action]);
+    b.onclick = () => {
+      if(capturing) return;
+      capturing = true;
+      b.textContent = '...';
+      const handler = (e) => {
+        e.preventDefault();
+        bindings[action] = e.code;
+        capturing = false;
+        saveBindings();
+        buildList();
+      };
+      window.addEventListener('keydown', handler, { once:true });
+    };
+    row.append(span, b);
+    list.appendChild(row);
+  }
+}
+
+btnOpen.onclick = () => { buildList(); modal.classList.add('show'); };
+btnClose.onclick = () => modal.classList.remove('show');
+
+updateHelp();
+
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -57,9 +131,15 @@ const MAX_SPEED = 10;
 const velocity = new THREE.Vector3();
 let onGround = true;
 const keys = new Map();
-addEventListener('keydown', (e) => keys.set(e.code, true));
-addEventListener('keyup', (e) => keys.set(e.code, false));
-addEventListener('keydown', (e) => { if (e.code === 'KeyR'){ player.position.set(0,1,0); velocity.set(0,0,0);} });
+addEventListener('keydown', (e) => {
+  if(capturing) return;
+  keys.set(e.code, true);
+  if(e.code === bindings.reset){
+    player.position.set(0,1,0);
+    velocity.set(0,0,0);
+  }
+});
+addEventListener('keyup', (e) => { if(!capturing) keys.set(e.code, false); });
 
 addEventListener('resize', () => {
   camera.aspect = innerWidth / innerHeight;
@@ -69,15 +149,15 @@ addEventListener('resize', () => {
 
 const clock = new THREE.Clock();
 function update(dt){
-  const ax = (keys.get('KeyD') ? 1 : 0) - (keys.get('KeyA') ? 1 : 0);
-  const az = (keys.get('KeyS') ? 1 : 0) - (keys.get('KeyW') ? 1 : 0);
+  const ax = (keys.get(bindings.right) ? 1 : 0) - (keys.get(bindings.left) ? 1 : 0);
+  const az = (keys.get(bindings.back) ? 1 : 0) - (keys.get(bindings.forward) ? 1 : 0);
   velocity.x += ax * ACCEL * dt;
   velocity.z += az * ACCEL * dt;
 
   const speed = Math.hypot(velocity.x, velocity.z);
   if (speed > MAX_SPEED){ const s = MAX_SPEED / speed; velocity.x *= s; velocity.z *= s; }
 
-  if (onGround && keys.get('Space')) { velocity.y = JUMP_SPEED; onGround = false; }
+  if (onGround && keys.get(bindings.jump)) { velocity.y = JUMP_SPEED; onGround = false; }
   else { velocity.y += GRAVITY * dt; }
 
   player.position.addScaledVector(velocity, dt);

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -11,15 +11,90 @@
     .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
     .back{position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none}
     kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
+    .controls-btn{position:fixed; top:12px; right:12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700}
+    .modal{position:fixed; inset:0; background:rgba(0,0,0,.6); display:none; align-items:center; justify-content:center}
+    .modal.show{display:flex}
+    .modal .panel{background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:20px; color:#e6e6e6; font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; min-width:260px}
+    .modal .row{display:flex; align-items:center; margin-bottom:8px}
+    .modal .row span{flex:1}
+    .modal .row button{padding:4px 8px; border:1px solid #2f3542; background:#111319; color:#d3d7de; border-radius:6px; min-width:60px}
   </style>
 </head>
 <body>
-  <div class="hud">Move: <kbd>←</kbd><kbd>→</kbd> • Pause: <kbd>P</kbd></div>
+  <div class="hud" id="hud"></div>
+  <button id="controls-btn" class="controls-btn">Controls</button>
+  <div id="controls-modal" class="modal">
+    <div class="panel">
+      <h2>Controls</h2>
+      <div id="controls-list"></div>
+      <button id="controls-close" class="controls-btn" style="position:static; margin-top:10px">Done</button>
+    </div>
+  </div>
   <a class="back" href="../../">← Back to Hub</a>
   <div class="wrap">
     <canvas id="game" width="720" height="420" aria-label="Pong game"></canvas>
   </div>
   <script>
+    const slug = 'pong';
+    const defaultBindings = { left:'ArrowLeft', right:'ArrowRight', pause:'KeyP' };
+    let bindings = JSON.parse(localStorage.getItem('controls-'+slug)) || { ...defaultBindings };
+
+    const hud = document.getElementById('hud');
+    const modal = document.getElementById('controls-modal');
+    const list = document.getElementById('controls-list');
+    const btnOpen = document.getElementById('controls-btn');
+    const btnClose = document.getElementById('controls-close');
+    let capturing = false;
+
+    function codeLabel(code){
+      if(code.startsWith('Key')) return code.slice(3);
+      if(code.startsWith('Digit')) return code.slice(5);
+      const special = { ArrowLeft:'←', ArrowRight:'→', ArrowUp:'↑', ArrowDown:'↓', Space:'Space' };
+      return special[code] || code;
+    }
+
+    function updateHUD(){
+      hud.innerHTML = `Move: <kbd>${codeLabel(bindings.left)}</kbd><kbd>${codeLabel(bindings.right)}</kbd> • Pause: <kbd>${codeLabel(bindings.pause)}</kbd>`;
+    }
+
+    function saveBindings(){
+      localStorage.setItem('controls-'+slug, JSON.stringify(bindings));
+      updateHUD();
+    }
+
+    function buildList(){
+      list.innerHTML='';
+      const items = [ ['left','Move Left'], ['right','Move Right'], ['pause','Pause'] ];
+      for(const [action,label] of items){
+        const row = document.createElement('div');
+        row.className='row';
+        const span = document.createElement('span');
+        span.textContent = label;
+        const b = document.createElement('button');
+        b.textContent = codeLabel(bindings[action]);
+        b.onclick = () => {
+          if(capturing) return;
+          capturing = true;
+          b.textContent = '...';
+          const handler = (e) => {
+            e.preventDefault();
+            bindings[action] = e.code;
+            capturing = false;
+            saveBindings();
+            buildList();
+          };
+          window.addEventListener('keydown', handler, { once:true });
+        };
+        row.append(span, b);
+        list.appendChild(row);
+      }
+    }
+
+    btnOpen.onclick = () => { buildList(); modal.classList.add('show'); };
+    btnClose.onclick = () => modal.classList.remove('show');
+
+    updateHUD();
+
     const cvs = document.getElementById('game');
     const ctx = cvs.getContext('2d');
 
@@ -31,8 +106,8 @@
     let paused = false;
 
     const keys = new Map();
-    addEventListener('keydown', e => { keys.set(e.code, true); if(e.code==='KeyP') paused = !paused; });
-    addEventListener('keyup', e => keys.set(e.code, false));
+    addEventListener('keydown', e => { if(capturing) return; keys.set(e.code, true); if(e.code===bindings.pause) paused = !paused; });
+    addEventListener('keyup', e => { if(capturing) return; keys.set(e.code, false); });
 
     let last = 0;
     function loop(ts){
@@ -44,34 +119,27 @@
     }
 
     function update(dt){
-      // input
-      const dir = (keys.get('ArrowRight')?1:0) - (keys.get('ArrowLeft')?1:0);
+      const dir = (keys.get(bindings.right)?1:0) - (keys.get(bindings.left)?1:0);
       player.vx = dir * player.speed;
       player.x += player.vx * dt;
 
-      // constrain
       player.x = Math.max(0, Math.min(W - paddleW, player.x));
 
-      // AI follows ball with dampened speed
       const target = ball.x - paddleW/2;
       const dx = target - ai.x;
       ai.vx = Math.max(-ai.speed, Math.min(ai.speed, dx * 5));
       ai.x += ai.vx * dt;
       ai.x = Math.max(0, Math.min(W - paddleW, ai.x));
 
-      // ball movement
       ball.x += ball.vx * dt;
       ball.y += ball.vy * dt;
 
-      // walls
       if (ball.x < ball.r) { ball.x = ball.r; ball.vx *= -1; }
       if (ball.x > W - ball.r) { ball.x = W - ball.r; ball.vx *= -1; }
 
-      // paddle collisions
       if (ball.y + ball.r >= player.y && ball.y - ball.r <= player.y + paddleH && ball.x > player.x && ball.x < player.x + paddleW) {
         ball.y = player.y - ball.r;
         ball.vy = -Math.abs(ball.vy);
-        // add spin based on where it hits the paddle
         const hit = (ball.x - (player.x + paddleW/2)) / (paddleW/2);
         ball.vx += hit * 180;
       }
@@ -82,38 +150,32 @@
         ball.vx += hit * 140;
       }
 
-      // scoring
       if (ball.y < -20) { player.score++; resetBall(-1); }
       if (ball.y > H + 20) { ai.score++; resetBall(1); }
     }
 
     function resetBall(dir){
       ball.x = W/2; ball.y = H/2;
-      const angle = (Math.random()*0.6 - 0.3); // -0.3..0.3 rad
+      const angle = (Math.random()*0.6 - 0.3);
       const speed = 360;
       ball.vx = Math.cos(angle) * speed;
       ball.vy = Math.sin(angle) * speed * dir;
     }
 
     function draw(){
-      // clear
       ctx.clearRect(0,0,W,H);
 
-      // midline
       ctx.fillStyle = '#1e2636';
       for(let y=0; y<H; y+=18){ ctx.fillRect(W/2 - 2, y, 4, 10); }
 
-      // paddles
       ctx.fillStyle = '#e6eef9';
       ctx.fillRect(player.x, player.y, paddleW, paddleH);
       ctx.fillRect(ai.x, ai.y, paddleW, paddleH);
 
-      // ball
       ctx.beginPath();
       ctx.arc(ball.x, ball.y, ball.r, 0, Math.PI*2);
       ctx.fill();
 
-      // scores
       ctx.font = 'bold 32px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial';
       ctx.textAlign = 'center'; ctx.fillStyle = '#cfe6ff';
       ctx.fillText(player.score, W/2 + 60, H/2 + 36);


### PR DESCRIPTION
## Summary
- add configurable controls modals for Pong and 3D Box Playground
- persist key bindings per game via `localStorage`
- document remappable controls in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a919b502148327bd67ee64275b9e25