### PR TITLE
feat: cache navigated pages

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,2 +1,40 @@
-self.addEventListener('install', () => self.skipWaiting());
-self.addEventListener('activate', () => self.clients.claim());
+const CACHE = 'static';
+const ASSETS = [
+  'index.html',
+  'main.js',
+  'styles.css',
+  'games/box3d/index.html',
+  'games/pong/index.html',
+];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(
+    (async () => {
+      const cache = await caches.open(CACHE);
+      await cache.addAll(ASSETS);
+      await self.skipWaiting();
+    })(),
+  );
+});
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (e) => {
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      (async () => {
+        const cache = await caches.open(CACHE);
+        let path = new URL(e.request.url).pathname;
+        if (path.endsWith('/')) {
+          path += 'index.html';
+        }
+        path = path.replace(/^\//, '');
+        const cached = await cache.match(path);
+        return cached || fetch(e.request);
+      })(),
+    );
+  }
+});
+


### PR DESCRIPTION
## Summary
- precache core assets and game pages in service worker
- serve cached pages for navigation requests when available, falling back to network

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a92345aa4883278af02bb2991c67e8