### PR TITLE
Prevent duplicate styles for back button

### DIFF
--- a/shared/ui.js
+++ b/shared/ui.js
@@ -1,20 +1,24 @@
 export function injectBackButton(relativePathToHub = '../../') {
-  const style = document.createElement('style');
-  style.textContent = `
-    .back-to-hub {
-      position: fixed;
-      left: 12px;
-      bottom: 12px;
-      color: #cfe6ff;
-      background: #0e1422;
-      border: 1px solid #27314b;
-      padding: 8px 10px;
-      border-radius: 10px;
-      font-weight: 700;
-      text-decoration: none;
-    }
-  `;
-  document.head.appendChild(style);
+  // Inject styles once
+  if (!document.head.querySelector('style[data-back-to-hub]')) {
+    const style = document.createElement('style');
+    style.dataset.backToHub = 'true';
+    style.textContent = `
+      .back-to-hub {
+        position: fixed;
+        left: 12px;
+        bottom: 12px;
+        color: #cfe6ff;
+        background: #0e1422;
+        border: 1px solid #27314b;
+        padding: 8px 10px;
+        border-radius: 10px;
+        font-weight: 700;
+        text-decoration: none;
+      }
+    `;
+    document.head.appendChild(style);
+  }
 
   const link = document.createElement('a');
   link.href = relativePathToHub;

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -21,4 +21,20 @@ describe('injectBackButton', () => {
     expect(style).toBeTruthy();
     expect(style.textContent).toContain('.back-to-hub');
   });
+
+  it('uses custom href when provided', () => {
+    injectBackButton('../');
+
+    const link = document.querySelector('a.back-to-hub');
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('../');
+  });
+
+  it('does not append duplicate styles on subsequent calls', () => {
+    injectBackButton();
+    injectBackButton();
+
+    const styles = document.head.querySelectorAll('style');
+    expect(styles.length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Ensure back button styles are injected only once
- Test custom href for injected back button
- Verify multiple injections do not add multiple style tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9278d3ec48327af29bd83af89c697