### PR TITLE
refactor: reuse back button

### DIFF
--- a/shared/ui.js
+++ b/shared/ui.js
@@ -1,9 +1,31 @@
 export function injectBackButton(relativePathToHub = '../../') {
+  const head = document.head;
+  let link = head.querySelector('.back-to-hub');
+  const style = head.querySelector('style[data-back-to-hub]');
+
+  // If both link and style already exist, just update the link's href
+  if (!link) {
+    link = document.body.querySelector('.back-to-hub');
+  }
+  if (link && style) {
+    link.href = relativePathToHub;
+    return;
+  }
+
+  // Create the link if it doesn't exist
+  if (!link) {
+    link = document.createElement('a');
+    link.className = 'back-to-hub';
+    link.textContent = '← Back to Hub';
+    document.body.appendChild(link);
+  }
+  link.href = relativePathToHub;
+
   // Inject styles once
-  if (!document.head.querySelector('style[data-back-to-hub]')) {
-    const style = document.createElement('style');
-    style.dataset.backToHub = 'true';
-    style.textContent = `
+  if (!style) {
+    const styleEl = document.createElement('style');
+    styleEl.dataset.backToHub = 'true';
+    styleEl.textContent = `
       .back-to-hub {
         position: fixed;
         left: 12px;
@@ -17,12 +39,6 @@ export function injectBackButton(relativePathToHub = '../../') {
         text-decoration: none;
       }
     `;
-    document.head.appendChild(style);
+    head.appendChild(styleEl);
   }
-
-  const link = document.createElement('a');
-  link.href = relativePathToHub;
-  link.className = 'back-to-hub';
-  link.textContent = '← Back to Hub';
-  document.body.appendChild(link);
 }

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -30,11 +30,15 @@ describe('injectBackButton', () => {
     expect(link.getAttribute('href')).toBe('../');
   });
 
-  it('does not append duplicate styles on subsequent calls', () => {
+  it('updates existing link without duplicating elements on subsequent calls', () => {
     injectBackButton();
-    injectBackButton();
+    injectBackButton('../');
 
-    const styles = document.head.querySelectorAll('style');
+    const links = document.querySelectorAll('a.back-to-hub');
+    expect(links.length).toBe(1);
+    expect(links[0].getAttribute('href')).toBe('../');
+
+    const styles = document.head.querySelectorAll('style[data-back-to-hub]');
     expect(styles.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- update `injectBackButton` to reuse existing link and styles and update href when called again
- add tests ensuring back button and styles are not duplicated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a92bbdf6b0832793dad30d13c63a23