### PR TITLE
Enhance game tiles with metadata and scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,21 +63,62 @@
         for (const g of games) {
           const a = document.createElement('a');
           a.className = 'card';
-          a.href = g.path;
+
+          const url = new URL(g.path, location.href);
+          const isNew = url.searchParams.get('new') === 'true';
+          url.search = '';
+          a.href = url.toString();
           a.dataset.badge = g.badge;
-          a.setAttribute('aria-label', `Play ${g.name}`);
+          a.setAttribute('aria-label', `Play ${g.title}`);
+
+          if (g.thumb) {
+            const img = document.createElement('img');
+            img.className = 'thumb';
+            img.src = g.thumb;
+            img.alt = g.title;
+            img.loading = 'lazy';
+            img.onerror = () => img.remove();
+            a.appendChild(img);
+          }
 
           const h3 = document.createElement('h3');
-          h3.textContent = g.name;
+          h3.textContent = g.title;
+          a.appendChild(h3);
 
           const p = document.createElement('p');
-          p.textContent = g.description;
+          p.textContent = g.blurb;
+          a.appendChild(p);
+
+          const tagWrap = document.createElement('div');
+          tagWrap.className = 'tags';
+          g.tags?.forEach(t => {
+            const span = document.createElement('span');
+            span.textContent = t;
+            tagWrap.appendChild(span);
+          });
+          a.appendChild(tagWrap);
+
+          const score = localStorage.getItem('highscore:' + g.slug);
+          const time = localStorage.getItem('besttime:' + g.slug);
+          if (score || time) {
+            const best = document.createElement('div');
+            best.className = 'best';
+            best.textContent = 'Best: ' + (score ?? `${time}s`);
+            a.appendChild(best);
+          }
+
+          if (isNew) {
+            const ribbon = document.createElement('div');
+            ribbon.className = 'ribbon';
+            ribbon.textContent = 'NEW';
+            a.appendChild(ribbon);
+          }
 
           const play = document.createElement('div');
           play.className = 'play';
           play.textContent = 'Play →';
+          a.appendChild(play);
 
-          a.append(h3, p, play);
           grid.appendChild(a);
         }
       })


### PR DESCRIPTION
## Summary
- Parse game URLs to strip `new=true` query and show a NEW ribbon
- Display thumbnails, titles, blurbs, tags, and best scores for each game
- Retain the existing Play button and badge metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9321d923c8327a21ac19519b7f9ca