### PR TITLE
feat: show thumbs, tags, and best scores on hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,73 +13,107 @@
     <div class="hint">Click a game to play • Add more by copying a folder in <code>/games</code></div>
   </header>
   <main>
-    <section class="grid">
-      <a class="card" href="./games/box3d/" aria-label="Play 3D Box Playground" data-badge="3D">
-        <h3>3D Box Playground</h3>
-        <p>WASD + Space to jump. Orbit the camera with your mouse.</p>
-        <div class="play">Play →</div>
-      </a>
-      <a class="card" href="./games/pong/" aria-label="Play Pong Classic" data-badge="2D">
-        <h3>Pong Classic</h3>
-        <p>Arrow keys to move. Keep the ball in play, beat the AI.</p>
-        <div class="play">Play →</div>
-      </a>
-      <a class="card" href="./games/runner/" aria-label="Play Endless Runner">
-        <div class="badge">2D</div>
-        <h3>Endless Runner</h3>
-        <p>Space to jump • Dodge obstacles • Compete for a high score.</p>
-        <div class="play">Play →</div>
-      </a>
-      <a class="card" href="./games/asteroids/" aria-label="Play Asteroids" data-badge="2D">
-        <h3>Asteroids</h3>
-        <p>Rotate, thrust, and shoot to clear the field.</p>
-        <div class="play">Play →</div>
-      </a>
-      <a class="card" href="./games/shooter/" aria-label="Play Space Shooter" data-badge="2D">
-        <h3>Space Shooter</h3>
-        <p>WASD to move, mouse to aim. Survive waves of enemies.</p>
-        <div class="play">Play →</div>
-      </a>
-      <a class="card" href="./games/platformer/" aria-label="Play Retro Platformer" data-badge="2D">
-        <h3>Retro Platformer</h3>
-        <p>Run and jump through classic levels to reach the goal.</p>
-        <div class="play">Play →</div>
-      </a>
-      <a class="card" href="./games/maze3d/" aria-label="Play 3D Maze Explorer" data-badge="3D">
-        <h3>3D Maze Explorer</h3>
-        <p>Navigate a 3D labyrinth and find the exit.</p>
-        <div class="play">Play →</div>
-      </a>
-      </section>
+    <div class="filters"></div>
+    <section class="grid"></section>
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
   <script>
+    const savedFilters = JSON.parse(localStorage.getItem('hub:filters') || '[]');
+
     fetch('games.json')
       .then(r => r.json())
       .then(games => {
         const grid = document.querySelector('.grid');
-        if (!grid) return;
+        const filterBar = document.querySelector('.filters');
+        if (!grid || !filterBar) return;
         grid.innerHTML = '';
+
+        // Collect unique tags
+        const tagSet = new Set();
+        for (const g of games) {
+          const tags = g.tags || (g.badge ? [g.badge] : []);
+          tags.forEach(t => tagSet.add(t));
+        }
+
+        // Render filter chips
+        for (const tag of Array.from(tagSet).sort()) {
+          const chip = document.createElement('button');
+          chip.type = 'button';
+          chip.className = 'filter-chip';
+          chip.textContent = tag;
+          chip.dataset.tag = tag;
+          if (savedFilters.includes(tag)) chip.classList.add('active');
+          chip.addEventListener('click', () => {
+            chip.classList.toggle('active');
+            updateFilters();
+          });
+          filterBar.appendChild(chip);
+        }
+
+        // Render game cards
         for (const g of games) {
           const a = document.createElement('a');
           a.className = 'card';
           a.href = g.path;
-          a.dataset.badge = g.badge;
           a.setAttribute('aria-label', `Play ${g.name}`);
+
+          const tags = g.tags || (g.badge ? [g.badge] : []);
+          a.dataset.tags = tags.join(',');
+
+          const thumb = document.createElement('div');
+          thumb.className = 'thumb';
+          if (g.thumb) thumb.style.backgroundImage = `url(${g.thumb})`;
+          a.appendChild(thumb);
 
           const h3 = document.createElement('h3');
           h3.textContent = g.name;
+          a.appendChild(h3);
+
+          if (tags.length) {
+            const tagWrap = document.createElement('div');
+            tagWrap.className = 'tags';
+            for (const t of tags) {
+              const span = document.createElement('span');
+              span.className = 'tag';
+              span.textContent = t;
+              tagWrap.appendChild(span);
+            }
+            a.appendChild(tagWrap);
+          }
 
           const p = document.createElement('p');
           p.textContent = g.description;
+          a.appendChild(p);
+
+          const best = localStorage.getItem(`highscore:${g.id}`) ??
+                       localStorage.getItem(`besttime:${g.id}`);
+          if (best) {
+            const bestDiv = document.createElement('div');
+            bestDiv.className = 'best';
+            bestDiv.textContent = `Best: ${best}`;
+            a.appendChild(bestDiv);
+          }
 
           const play = document.createElement('div');
           play.className = 'play';
           play.textContent = 'Play →';
+          a.appendChild(play);
 
-          a.append(h3, p, play);
           grid.appendChild(a);
         }
+
+        function updateFilters() {
+          const active = Array.from(filterBar.querySelectorAll('.filter-chip.active'))
+            .map(el => el.dataset.tag);
+          localStorage.setItem('hub:filters', JSON.stringify(active));
+          for (const card of grid.querySelectorAll('.card')) {
+            const cardTags = card.dataset.tags ? card.dataset.tags.split(',') : [];
+            const match = active.length === 0 || active.some(t => cardTags.includes(t));
+            card.style.display = match ? '' : 'none';
+          }
+        }
+
+        updateFilters();
       })
       .catch(err => {
         console.warn('Failed to load games.json', err);

--- a/styles.css
+++ b/styles.css
@@ -19,20 +19,26 @@ header{
 .brand span{color:var(--accent)}
 .hint{color:var(--muted); font-size:13px}
 main{max-width:1100px; width:100%; margin:24px auto; padding:0 16px 36px}
+.filters{display:flex; gap:8px; flex-wrap:wrap; margin-bottom:24px}
+.filter-chip{background:#0e1422; border:1px solid #27314b; color:#c3d7ff; font-size:13px; padding:6px 10px; border-radius:999px; cursor:pointer}
+.filter-chip.active{background:#18213a; border-color:var(--accent); color:var(--accent)}
 .grid{
   display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap:16px;
 }
 a.card{
   position:relative; text-decoration:none; color:inherit; display:block; background:linear-gradient(180deg,var(--card),var(--card2));
-  border:1px solid #222838; border-radius:16px; padding:16px; min-height:160px; overflow:hidden;
+  border:1px solid #222838; border-radius:16px; padding:16px 16px 60px; min-height:160px; overflow:hidden;
   transition: transform .12s ease, box-shadow .12s ease, border-color .12s ease;
   box-shadow: 0 2px 14px rgba(0,0,0,.25);
 }
 a.card:hover{ transform: translateY(-2px); border-color:#2a334a; box-shadow: 0 6px 22px rgba(0,0,0,.35); }
-a.card::after{position:absolute; top:12px; right:12px; font-size:11px; padding:4px 8px; border-radius:999px; background:#0e1422; border:1px solid #27314b; color:#c3d7ff; content:attr(data-badge);}
+.thumb{width:100%; height:120px; border-radius:8px; background:#1e2431 center/cover no-repeat; margin-bottom:12px}
 .card h3{margin:0 0 8px 0; font-size:18px}
+.tags{display:flex; flex-wrap:wrap; gap:6px; margin-bottom:8px}
+.tag{background:#0e1422; border:1px solid #27314b; color:#c3d7ff; font-size:11px; padding:2px 6px; border-radius:8px}
 .card p{margin:0; color:var(--muted); font-size:14px; line-height:1.35}
+.best{margin-top:8px; font-size:13px; color:var(--accent)}
 .play{
   position:absolute; bottom:12px; right:12px; font-weight:700; font-size:13px; padding:8px 10px;
   border-radius:10px; border:1px solid #27314b; background:#0e1422; color:#cfe6ff;


### PR DESCRIPTION
## Summary
- render game thumbs, tags, and best scores in hub cards
- add tag filters with localStorage persistence
- style filters and cards with graceful thumb fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a931df81e88327a183eddfe4639629