### PR TITLE
feat: track last played games in localStorage

### DIFF
--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -1,3 +1,7 @@
+import { recordLastPlayed } from '../../shared/ui.js';
+
+recordLastPlayed('asteroids');
+
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
 

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -2,10 +2,11 @@ import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 import { PointerLockControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/PointerLockControls.js';
 import { Sky } from 'https://unpkg.com/three@0.160.0/examples/jsm/objects/Sky.js';
 import { registerSW } from '../../shared/sw.js';
-import { injectBackButton } from '../../shared/ui.js';
+import { injectBackButton, recordLastPlayed } from '../../shared/ui.js';
 
 registerSW();
 injectBackButton();
+recordLastPlayed('box3d');
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.75));

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -1,3 +1,7 @@
+import { recordLastPlayed } from '../../shared/ui.js';
+
+recordLastPlayed('maze3d');
+
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x0e0f12);
 

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1,3 +1,7 @@
+import { recordLastPlayed } from '../../shared/ui.js';
+
+recordLastPlayed('platformer');
+
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
 const W = cvs.width, H = cvs.height;

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -121,8 +121,9 @@
     requestAnimationFrame(loop);
   </script>
   <script type="module">
-    import { injectBackButton } from "../../shared/ui.js";
+    import { injectBackButton, recordLastPlayed } from "../../shared/ui.js";
     injectBackButton();
+    recordLastPlayed('pong');
   </script>
 </body>
 </html>

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -1,3 +1,7 @@
+import { recordLastPlayed } from '../../shared/ui.js';
+
+recordLastPlayed('runner');
+
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
 

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1,4 +1,4 @@
-import { injectBackButton } from '../../shared/ui.js';
+import { injectBackButton, recordLastPlayed } from '../../shared/ui.js';
 
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
@@ -8,6 +8,7 @@ const scoreEl = document.getElementById('score');
 const bestEl  = document.getElementById('best');
 
 injectBackButton();
+recordLastPlayed('shooter');
 
 const state = {
   running: true,

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -42,3 +42,23 @@ export function injectBackButton(relativePathToHub = '../../') {
     head.appendChild(styleEl);
   }
 }
+
+export function recordLastPlayed(id) {
+  let list = [];
+  try {
+    const raw = localStorage.getItem('lastPlayed');
+    if (raw) {
+      list = JSON.parse(raw);
+    }
+  } catch {
+    list = [];
+  }
+
+  list = list.filter((entry) => entry !== id);
+  list.unshift(id);
+  if (list.length > 10) {
+    list = list.slice(0, 10);
+  }
+
+  localStorage.setItem('lastPlayed', JSON.stringify(list));
+}

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { injectBackButton } from '../shared/ui.js';
+import { injectBackButton, recordLastPlayed } from '../shared/ui.js';
 
 describe('injectBackButton', () => {
   beforeEach(() => {
@@ -40,5 +40,28 @@ describe('injectBackButton', () => {
 
     const styles = document.head.querySelectorAll('style[data-back-to-hub]');
     expect(styles.length).toBe(1);
+  });
+});
+
+describe('recordLastPlayed', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('prepends id, removes duplicates, and truncates to 10 items', () => {
+    localStorage.setItem('lastPlayed', JSON.stringify(['a', 'b', 'c']));
+    recordLastPlayed('b');
+    recordLastPlayed('d');
+
+    const result = JSON.parse(localStorage.getItem('lastPlayed'));
+    expect(result).toEqual(['d', 'b', 'a', 'c']);
+
+    const many = Array.from({ length: 10 }, (_, i) => `g${i}`);
+    localStorage.setItem('lastPlayed', JSON.stringify(many));
+    recordLastPlayed('new');
+
+    const truncated = JSON.parse(localStorage.getItem('lastPlayed'));
+    expect(truncated.length).toBe(10);
+    expect(truncated[0]).toBe('new');
   });
 });


### PR DESCRIPTION
## Summary
- add `recordLastPlayed` utility to manage recent game list in `localStorage`
- invoke `recordLastPlayed` from each game so visits are tracked
- cover new helper with Vitest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a932231a508327aa79b72e069e1563