### PR TITLE
Cap favorites and recents to unique top 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,9 @@
     <div class="hint">Click a game to play • Add more by copying a folder in <code>/games</code></div>
   </header>
   <main>
-    <section class="grid">
+    <section class="grid favorites"></section>
+    <section class="grid recents"></section>
+    <section class="grid all">
       <a class="card" href="./games/box3d/" aria-label="Play 3D Box Playground" data-badge="3D">
         <h3>3D Box Playground</h3>
         <p>WASD + Space to jump. Orbit the camera with your mouse.</p>
@@ -54,13 +56,19 @@
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
   <script>
+    function uniqueCap(arr) {
+      return [...new Set(arr)].slice(0, 10);
+    }
+
     fetch('games.json')
       .then(r => r.json())
       .then(games => {
-        const grid = document.querySelector('.grid');
-        if (!grid) return;
-        grid.innerHTML = '';
-        for (const g of games) {
+        const allGrid = document.querySelector('.grid.all');
+        const favGrid = document.querySelector('.grid.favorites');
+        const recentGrid = document.querySelector('.grid.recents');
+        const byId = new Map(games.map(g => [g.id, g]));
+
+        function buildCard(g) {
           const a = document.createElement('a');
           a.className = 'card';
           a.href = g.path;
@@ -78,8 +86,32 @@
           play.textContent = 'Play →';
 
           a.append(h3, p, play);
-          grid.appendChild(a);
+          return a;
         }
+
+        function buildFromIds(ids, container) {
+          if (!container) return;
+          container.innerHTML = '';
+          for (const id of ids) {
+            const g = byId.get(id);
+            if (g) container.appendChild(buildCard(g));
+          }
+        }
+
+        const favIds = uniqueCap(JSON.parse(localStorage.getItem('favorites') || '[]'));
+        const recentIds = uniqueCap(JSON.parse(localStorage.getItem('lastPlayed') || '[]'));
+        buildFromIds(favIds, favGrid);
+        buildFromIds(recentIds, recentGrid);
+
+        if (allGrid) {
+          allGrid.innerHTML = '';
+          for (const g of games) {
+            allGrid.appendChild(buildCard(g));
+          }
+        }
+
+        localStorage.setItem('favorites', JSON.stringify(favIds));
+        localStorage.setItem('lastPlayed', JSON.stringify(recentIds));
       })
       .catch(err => {
         console.warn('Failed to load games.json', err);

--- a/shared/recents.js
+++ b/shared/recents.js
@@ -1,0 +1,11 @@
+export function recordLastPlayed(id) {
+  const key = 'lastPlayed';
+  const existing = JSON.parse(localStorage.getItem(key) || '[]');
+  const updated = uniqueCap([id, ...existing]);
+  localStorage.setItem(key, JSON.stringify(updated));
+  return updated;
+}
+
+function uniqueCap(arr) {
+  return [...new Set(arr)].slice(0, 10);
+}

--- a/tests/recents.test.js
+++ b/tests/recents.test.js
@@ -1,0 +1,23 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { recordLastPlayed } from '../shared/recents.js';
+
+describe('recordLastPlayed', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('keeps unique ids and caps at 10', () => {
+    recordLastPlayed('a');
+    recordLastPlayed('b');
+    recordLastPlayed('a');
+    let arr = JSON.parse(localStorage.getItem('lastPlayed'));
+    expect(arr).toEqual(['a', 'b']);
+
+    for (let i = 0; i < 15; i++) {
+      recordLastPlayed(String(i));
+    }
+    arr = JSON.parse(localStorage.getItem('lastPlayed'));
+    expect(arr).toEqual(['14', '13', '12', '11', '10', '9', '8', '7', '6', '5']);
+  });
+});


### PR DESCRIPTION
## Summary
- Deduplicate and limit favorites and recents lists when rendering the hub
- Introduce `recordLastPlayed` helper to enforce unique, capped recents persistence
- Add unit tests for `recordLastPlayed`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a93223b248832791f82195ebba1cc7