### PR TITLE
Use shared back button for classic games

### DIFF
--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -9,7 +9,6 @@
     .wrap{display:grid; place-items:center; height:100%; padding:16px}
     canvas{background:#0a0d13; border:1px solid #1f2431; border-radius:12px; box-shadow:0 6px 22px rgba(0,0,0,.35)}
     .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
-    .back{position:fixed; left:12px; bottom:12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none}
     kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
     .overlay{position:fixed; inset:0; display:none; place-items:center; background:rgba(0,0,0,.35); font-weight:800; letter-spacing:.4px; text-align:center;}
     .overlay.show{display:grid}
@@ -20,7 +19,6 @@
 </head>
 <body>
   <div class="hud">Rotate: <kbd>←</kbd><kbd>→</kbd> • Thrust: <kbd>↑</kbd> • Fire: <kbd>Space</kbd> • Pause: <kbd>P</kbd> • Restart: <kbd>R</kbd></div>
-  <a class="back" href="../../">← Back to Hub</a>
   <div class="wrap">
     <canvas id="game" width="800" height="600" aria-label="Asteroids game"></canvas>
   </div>

--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -1,5 +1,9 @@
+import { injectBackButton } from '../../shared/ui.js';
+
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
+
+injectBackButton();
 
 const W = cvs.width, H = cvs.height;
 

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -8,7 +8,6 @@
     html, body { margin:0; height:100%; overflow:hidden; background:#0e0f12; }
     canvas { display:block; }
     #hud { position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; color:#e6e6e6; font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; font-size:14px; }
-    a.back { position:fixed; left:12px; bottom:12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none; }
     #overlay { position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,0.4); font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
     #overlay.hidden { display:none; }
     #overlay .panel { background:#111522; border:1px solid #27314b; padding:18px 22px; border-radius:16px; text-align:center; color:#e6e6e6; }
@@ -17,7 +16,6 @@
 </head>
 <body>
   <div id="hud">Time: <span id="time">0.00</span> • Best: <span id="best">--</span></div>
-  <a class="back" href="../../">← Back to Hub</a>
   <div id="overlay" class="">
     <div class="panel">
       <div id="message">Click Start to play.<br/>WASD to move • Mouse to look<br/>P to pause • R to restart<br/>Esc to release pointer lock.</div>

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -1,3 +1,5 @@
+import { injectBackButton } from '../../shared/ui.js';
+
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x0e0f12);
 
@@ -20,6 +22,8 @@ const startBtn = document.getElementById('startBtn');
 const restartBtn = document.getElementById('restartBtn');
 const timeEl = document.getElementById('time');
 const bestEl = document.getElementById('best');
+
+injectBackButton();
 
 let running = false;
 let paused = true;

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -9,7 +9,6 @@
     .wrap{display:grid; place-items:center; height:100%; padding:16px}
     canvas{background:#0a0d13; border:1px solid #1f2431; border-radius:12px; box-shadow:0 6px 22px rgba(0,0,0,.35)}
     .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
-    .back{position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none}
     kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
     .overlay{position:fixed; inset:0; display:none; place-items:center; background:rgba(0,0,0,.35); font-weight:800; letter-spacing:.4px; text-align:center;}
     .overlay.show{display:grid}
@@ -20,7 +19,6 @@
 </head>
 <body>
   <div class="hud">Move: <kbd>←</kbd>/<kbd>→</kbd> • Jump: <kbd>Space</kbd> or <kbd>↑</kbd> • Pause: <kbd>P</kbd> • Restart: <kbd>R</kbd></div>
-  <a class="back" href="../../">← Back to Hub</a>
   <div class="wrap">
     <canvas id="game" width="800" height="450" aria-label="Platformer game"></canvas>
   </div>

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1,6 +1,10 @@
+import { injectBackButton } from '../../shared/ui.js';
+
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
 const W = cvs.width, H = cvs.height;
+
+injectBackButton();
 const TILE = 50;
 
 // level definition: 40x9 tiles

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -9,7 +9,6 @@
     .wrap{display:grid; place-items:center; height:100%; padding:16px}
     canvas{background:#0a0d13; border:1px solid #1f2431; border-radius:12px; box-shadow:0 6px 22px rgba(0,0,0,.35)}
     .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
-    .back{position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none}
     kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
     .overlay{position:fixed; inset:0; display:none; place-items:center; background:rgba(0,0,0,.35); font-weight:800; letter-spacing:.4px; text-align:center;}
     .overlay.show{display:grid}
@@ -20,7 +19,6 @@
 </head>
 <body>
   <div class="hud">Jump: <kbd>Space</kbd> or tap • Pause: <kbd>P</kbd> • Restart: <kbd>R</kbd></div>
-  <a class="back" href="../../">← Back to Hub</a>
   <div class="wrap">
     <canvas id="game" width="800" height="450" aria-label="Endless Runner game"></canvas>
   </div>

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -1,5 +1,9 @@
+import { injectBackButton } from '../../shared/ui.js';
+
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
+
+injectBackButton();
 
 const W = cvs.width, H = cvs.height;
 const GROUND_Y = H - 64;


### PR DESCRIPTION
## Summary
- remove inline back links from runner, asteroids, platformer and maze3d
- invoke shared `injectBackButton` helper in each game's module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a93231abdc8327b5c4d533d1961b01