### PR TITLE
Cache game pages dynamically and register service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
       </section>
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
+  <script type="module">
+    import { registerSW } from './shared/sw.js';
+    registerSW();
+  </script>
   <script>
     fetch('games.json')
       .then(r => r.json())

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,10 @@
 const CACHE = 'static';
 
 async function getAssets() {
-  const assets = ['index.html', 'styles.css', 'games.json'];
+  const assets = ['index.html', 'styles.css'];
   try {
     const res = await fetch('games.json');
+    assets.push('games.json');
     const games = await res.json();
     for (const g of games) {
       let path = g.path.replace(/^\.\//, '');

--- a/sw.js
+++ b/sw.js
@@ -1,18 +1,27 @@
 const CACHE = 'static';
-const ASSETS = [
-  'index.html',
-  'main.js',
-  'styles.css',
-  'games/box3d/index.html',
-  'games/pong/index.html',
-  'games/runner/index.html',
-];
+
+async function getAssets() {
+  const assets = ['index.html', 'styles.css', 'games.json'];
+  try {
+    const res = await fetch('games.json');
+    const games = await res.json();
+    for (const g of games) {
+      let path = g.path.replace(/^\.\//, '');
+      if (!path.endsWith('/')) path += '/';
+      assets.push(`${path}index.html`);
+    }
+  } catch (err) {
+    console.warn('Failed to load games.json', err);
+  }
+  return assets;
+}
 
 self.addEventListener('install', (e) => {
   e.waitUntil(
     (async () => {
       const cache = await caches.open(CACHE);
-      await cache.addAll(ASSETS);
+      const assets = await getAssets();
+      await cache.addAll(assets);
       await self.skipWaiting();
     })(),
   );


### PR DESCRIPTION
## Summary
- Build service worker asset list from `games.json` so each game's `index.html` is cached
- Register the service worker from the hub to cover all game pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9322fbaa08327a9bbcb963b40fbe5