### PR TITLE
Show gamepad connection hint on hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <header>
     <div class="brand">🎮 Gurjot's Games</div>
     <div class="hint">Click a game to play • Add more by copying a folder in <code>/games</code></div>
+    <span id="padHint" class="pad-hint" hidden>🎮</span>
   </header>
   <main>
     <section class="grid">
@@ -53,7 +54,12 @@
       </section>
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
-  <script>
+  <script type="module">
+    import { enableGamepadHint } from './shared/controls.js';
+
+    const padIcon = document.getElementById('padHint');
+    enableGamepadHint(padIcon);
+
     fetch('games.json')
       .then(r => r.json())
       .then(games => {

--- a/shared/controls.js
+++ b/shared/controls.js
@@ -11,3 +11,25 @@ export function enableGamepadHint(el) {
 
   update();
 }
+
+export function virtualButtons(codes) {
+  const state = new Map(codes.map((c) => [c, false]));
+  const element = document.createElement('div');
+  for (const code of codes) {
+    const btn = document.createElement('button');
+    btn.dataset.k = code;
+    btn.addEventListener('touchstart', (e) => {
+      e.preventDefault();
+      state.set(code, true);
+    });
+    btn.addEventListener('touchend', (e) => {
+      e.preventDefault();
+      state.set(code, false);
+    });
+    element.appendChild(btn);
+  }
+  return {
+    element,
+    read: () => new Map(state)
+  };
+}

--- a/shared/controls.js
+++ b/shared/controls.js
@@ -1,0 +1,13 @@
+export function enableGamepadHint(el) {
+  if (!el) return;
+
+  function update() {
+    const pads = navigator.getGamepads ? Array.from(navigator.getGamepads()).filter(Boolean) : [];
+    el.hidden = pads.length === 0;
+  }
+
+  window.addEventListener('gamepadconnected', update);
+  window.addEventListener('gamepaddisconnected', update);
+
+  update();
+}

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,7 @@ body{
   display:flex; flex-direction:column;
 }
 header{
+  position:relative;
   display:flex; align-items:center; justify-content:space-between;
   padding:18px 22px; border-bottom:1px solid #1e2431;
   backdrop-filter: blur(6px);
@@ -18,6 +19,9 @@ header{
 .brand{font-weight:800; letter-spacing:.4px; font-size:18px;}
 .brand span{color:var(--accent)}
 .hint{color:var(--muted); font-size:13px}
+.pad-hint{
+  position:absolute; top:12px; right:12px;
+}
 main{max-width:1100px; width:100%; margin:24px auto; padding:0 16px 36px}
 .grid{
   display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));

--- a/tests/controls.test.js
+++ b/tests/controls.test.js
@@ -1,0 +1,31 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { enableGamepadHint } from '../shared/controls.js';
+
+describe('enableGamepadHint', () => {
+  let el;
+  let mockPads;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<span id="pad" hidden></span>';
+    el = document.getElementById('pad');
+    mockPads = [];
+    Object.defineProperty(navigator, 'getGamepads', {
+      configurable: true,
+      value: () => mockPads
+    });
+  });
+
+  it('toggles hidden based on gamepad connection', () => {
+    enableGamepadHint(el);
+    expect(el.hidden).toBe(true);
+
+    mockPads = [{}];
+    window.dispatchEvent(new Event('gamepadconnected'));
+    expect(el.hidden).toBe(false);
+
+    mockPads = [];
+    window.dispatchEvent(new Event('gamepaddisconnected'));
+    expect(el.hidden).toBe(true);
+  });
+});

--- a/tests/controls.test.js
+++ b/tests/controls.test.js
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { enableGamepadHint } from '../shared/controls.js';
+import { enableGamepadHint, virtualButtons } from '../shared/controls.js';
 
 describe('enableGamepadHint', () => {
   let el;
@@ -27,5 +27,21 @@ describe('enableGamepadHint', () => {
     mockPads = [];
     window.dispatchEvent(new Event('gamepaddisconnected'));
     expect(el.hidden).toBe(true);
+  });
+});
+
+describe('virtualButtons', () => {
+  it('reflects button states via read()', () => {
+    const codes = ['KeyW', 'KeyA', 'KeyS', 'KeyD', 'Space'];
+    const { element, read } = virtualButtons(codes);
+    document.body.appendChild(element);
+
+    for (const code of codes) {
+      const button = element.querySelector(`button[data-k="${code}"]`);
+      button.dispatchEvent(new Event('touchstart', { bubbles: true }));
+      expect(read().get(code)).toBe(true);
+      button.dispatchEvent(new Event('touchend', { bubbles: true }));
+      expect(read().get(code)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add hidden gamepad icon to hub and show it when a controller connects
- Provide `enableGamepadHint` helper to manage icon visibility
- Style icon in header and cover with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a93229e9308327b3bfc42e0598be8e