### PR TITLE
Add touch controls to Pong with shared virtual buttons

### DIFF
--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -17,7 +17,10 @@
   <div class="wrap">
     <canvas id="game" width="720" height="420" aria-label="Pong game"></canvas>
   </div>
-  <script>
+  <script type="module">
+    import { virtualButtons } from "../../shared/controls.js";
+    import { injectBackButton } from "../../shared/ui.js";
+
     const cvs = document.getElementById('game');
     const ctx = cvs.getContext('2d');
 
@@ -32,6 +35,11 @@
     addEventListener('keydown', e => { keys.set(e.code, true); if(e.code==='KeyP') paused = !paused; });
     addEventListener('keyup', e => keys.set(e.code, false));
 
+    const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    if (isTouch) {
+      virtualButtons({ left: true, right: true });
+    }
+
     let last = 0;
     function loop(ts){
       const dt = Math.min((ts - last)/1000, 0.033);
@@ -43,7 +51,8 @@
 
     function update(dt){
       // input
-      const dir = (keys.get('ArrowRight')?1:0) - (keys.get('ArrowLeft')?1:0);
+      const buttons = virtualButtons.read();
+      const dir = ((keys.get('ArrowRight') || buttons.right)?1:0) - ((keys.get('ArrowLeft') || buttons.left)?1:0);
       player.vx = dir * player.speed;
       player.x += player.vx * dt;
 
@@ -119,9 +128,6 @@
     }
 
     requestAnimationFrame(loop);
-  </script>
-  <script type="module">
-    import { injectBackButton } from "../../shared/ui.js";
     injectBackButton();
   </script>
 </body>

--- a/shared/controls.js
+++ b/shared/controls.js
@@ -1,0 +1,61 @@
+export function virtualButtons(opts = {}) {
+  if (virtualButtons._mounted) return;
+  virtualButtons._mounted = true;
+
+  const state = virtualButtons._state;
+
+  const container = document.createElement('div');
+  container.className = 'virtual-buttons';
+
+  function addButton(name, label) {
+    const btn = document.createElement('button');
+    btn.className = `vb-btn vb-${name}`;
+    btn.textContent = label;
+    btn.addEventListener('pointerdown', (e) => {
+      state[name] = true;
+      e.preventDefault();
+    });
+    const reset = () => { state[name] = false; };
+    btn.addEventListener('pointerup', reset);
+    btn.addEventListener('pointercancel', reset);
+    btn.addEventListener('pointerleave', reset);
+    container.appendChild(btn);
+  }
+
+  if (opts.left) addButton('left', '◀');
+  if (opts.right) addButton('right', '▶');
+
+  document.body.appendChild(container);
+
+  if (!document.getElementById('virtual-buttons-style')) {
+    const style = document.createElement('style');
+    style.id = 'virtual-buttons-style';
+    style.textContent = `
+      .virtual-buttons {
+        position: fixed;
+        left: 12px;
+        right: 12px;
+        bottom: 12px;
+        display: flex;
+        justify-content: space-between;
+        pointer-events: none;
+      }
+      .virtual-buttons .vb-btn {
+        width: 64px;
+        height: 64px;
+        border-radius: 50%;
+        background: #1b1e24c0;
+        border: 1px solid #27314b;
+        color: #cfe6ff;
+        font-size: 32px;
+        pointer-events: auto;
+        touch-action: none;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+}
+
+virtualButtons._state = { left: false, right: false };
+virtualButtons._mounted = false;
+virtualButtons.read = () => ({ ...virtualButtons._state });


### PR DESCRIPTION
## Summary
- integrate virtual button controls into Pong and merge with keyboard input
- provide shared `virtualButtons` helper for touch devices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a93228217c83279fc1890affa52836