### PR TITLE
Add gamepad hint and mobile virtual controls

### DIFF
--- a/shared/controls.js
+++ b/shared/controls.js
@@ -1,0 +1,109 @@
+export function enableGamepadHint(el) {
+  if (!el) return;
+  const update = () => {
+    const pads = navigator.getGamepads ? Array.from(navigator.getGamepads()) : [];
+    const any = pads.some(p => p);
+    el.style.display = any ? '' : 'none';
+  };
+  window.addEventListener('gamepadconnected', update);
+  window.addEventListener('gamepaddisconnected', update);
+  update();
+}
+
+function ensureStyles() {
+  if (document.getElementById('virtual-buttons-style')) return;
+  const style = document.createElement('style');
+  style.id = 'virtual-buttons-style';
+  style.textContent = `
+.virtual-buttons {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  padding: 10px;
+  pointer-events: none;
+  z-index: 9999;
+}
+.virtual-buttons .vb-group {
+  display: flex;
+  gap: 10px;
+}
+.virtual-buttons button {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.3);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: #fff;
+  font-size: 20px;
+  pointer-events: auto;
+  touch-action: none;
+}
+`; 
+  document.head.appendChild(style);
+}
+
+export function virtualButtons(config = {}) {
+  const state = {};
+  for (const key of Object.keys(config)) state[key] = false;
+
+  const coarse = typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
+  if (!coarse) {
+    return {
+      read: () => ({ ...state })
+    };
+  }
+
+  ensureStyles();
+
+  const container = document.createElement('div');
+  container.className = 'virtual-buttons';
+
+  const leftGroup = document.createElement('div');
+  leftGroup.className = 'vb-group vb-left';
+  const rightGroup = document.createElement('div');
+  rightGroup.className = 'vb-group vb-right';
+  container.append(leftGroup, rightGroup);
+
+  const addButton = (key, parent) => {
+    const label = config[key] === true || config[key] == null ? key : config[key];
+    const btn = document.createElement('button');
+    btn.className = `vb-btn vb-${key}`;
+    btn.textContent = label;
+    btn.addEventListener('pointerdown', e => {
+      e.preventDefault();
+      state[key] = true;
+      if (btn.setPointerCapture && e.pointerId != null) {
+        btn.setPointerCapture(e.pointerId);
+      }
+    });
+    const clear = e => {
+      e.preventDefault();
+      state[key] = false;
+      if (btn.releasePointerCapture && e.pointerId != null) {
+        btn.releasePointerCapture(e.pointerId);
+      }
+    };
+    btn.addEventListener('pointerup', clear);
+    btn.addEventListener('pointercancel', clear);
+    parent.appendChild(btn);
+  };
+
+  if (config.left) addButton('left', leftGroup);
+  if (config.right) addButton('right', leftGroup);
+
+  for (const key of Object.keys(config)) {
+    if (key === 'left' || key === 'right') continue;
+    addButton(key, rightGroup);
+  }
+
+  document.body.appendChild(container);
+
+  return {
+    read: () => ({ ...state })
+  };
+}
+
+export default { enableGamepadHint, virtualButtons };

--- a/tests/controls.test.js
+++ b/tests/controls.test.js
@@ -1,0 +1,47 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { enableGamepadHint, virtualButtons } from '../shared/controls.js';
+
+describe('enableGamepadHint', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    navigator.getGamepads = undefined;
+  });
+
+  it('toggles visibility based on connected gamepads', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    navigator.getGamepads = () => [null];
+    enableGamepadHint(el);
+    expect(el.style.display).toBe('none');
+
+    navigator.getGamepads = () => [{}];
+    window.dispatchEvent(new Event('gamepadconnected'));
+    expect(el.style.display).toBe('');
+
+    navigator.getGamepads = () => [null];
+    window.dispatchEvent(new Event('gamepaddisconnected'));
+    expect(el.style.display).toBe('none');
+  });
+});
+
+describe('virtualButtons', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    window.matchMedia = () => ({ matches: true });
+  });
+
+  it('creates buttons and reports pressed state', () => {
+    const controls = virtualButtons({ left: true, jump: 'A' });
+    const left = document.querySelector('button.vb-left');
+    const jump = document.querySelector('button.vb-jump');
+    expect(left).toBeTruthy();
+    expect(jump).toBeTruthy();
+
+    left.dispatchEvent(new Event('pointerdown'));
+    expect(controls.read().left).toBe(true);
+    left.dispatchEvent(new Event('pointerup'));
+    expect(controls.read().left).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `enableGamepadHint` to show a connected controller hint
- add `virtualButtons` for on-screen controls on touch devices
- cover new utilities with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a932288eac8327b5d9003da698d303