### PR TITLE
refactor: show tag chips before descriptions in game cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,10 +85,6 @@
           h3.textContent = g.title;
           a.appendChild(h3);
 
-          const p = document.createElement('p');
-          p.textContent = g.blurb;
-          a.appendChild(p);
-
           const tagWrap = document.createElement('div');
           tagWrap.className = 'tags';
           g.tags?.forEach(t => {
@@ -97,6 +93,10 @@
             tagWrap.appendChild(span);
           });
           a.appendChild(tagWrap);
+
+          const p = document.createElement('p');
+          p.textContent = g.blurb;
+          a.appendChild(p);
 
           const score = localStorage.getItem('highscore:' + g.slug);
           const time = localStorage.getItem('besttime:' + g.slug);


### PR DESCRIPTION
## Summary
- render tag chips above each game's description

## Testing
- `npm test` *(fails: Failed to resolve import "../shared/controls.js")*

------
https://chatgpt.com/codex/tasks/task_e_68a9346f43088327815c3bff63301288