### PR TITLE
handle invalid saved filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,20 @@
   </main>
   <footer>Static, framework-free. Host anywhere (GitHub Pages ready).</footer>
   <script>
+    let savedFilters = [];
+    try {
+      const raw = localStorage.getItem('hub:filters');
+      if (raw) {
+        savedFilters = JSON.parse(raw);
+        if (!Array.isArray(savedFilters)) {
+          savedFilters = [];
+        }
+      }
+    } catch {
+      savedFilters = [];
+      localStorage.removeItem('hub:filters');
+    }
+
     fetch('games.json')
       .then(r => r.json())
       .then(games => {
@@ -61,6 +75,9 @@
         if (!grid) return;
         grid.innerHTML = '';
         for (const g of games) {
+          if (savedFilters.length && !g.tags?.some(t => savedFilters.includes(t))) {
+            continue;
+          }
           const a = document.createElement('a');
           a.className = 'card';
 


### PR DESCRIPTION
## Summary
- Safeguard localStorage parsing for hub:filters
- Ignore games without matching saved filters when rendering

## Testing
- `npm test` *(fails: Failed to resolve import "../shared/controls.js" from "tests/controls.test.js". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68a9346e200083278210fba39f2aad6c