### PR TITLE
Add optional thumbnail images to game cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,15 +71,17 @@
           a.dataset.badge = g.badge;
           a.setAttribute('aria-label', `Play ${g.title}`);
 
+          const thumb = document.createElement('div');
+          thumb.className = 'thumb';
           if (g.thumb) {
             const img = document.createElement('img');
-            img.className = 'thumb';
             img.src = g.thumb;
-            img.alt = g.title;
+            img.alt = g.name;
             img.loading = 'lazy';
             img.onerror = () => img.remove();
-            a.appendChild(img);
+            thumb.appendChild(img);
           }
+          a.appendChild(thumb);
 
           const h3 = document.createElement('h3');
           h3.textContent = g.title;

--- a/styles.css
+++ b/styles.css
@@ -33,7 +33,8 @@ a.card:hover{ transform: translateY(-2px); border-color:#2a334a; box-shadow: 0 6
 a.card::after{position:absolute; top:12px; right:12px; font-size:11px; padding:4px 8px; border-radius:999px; background:#0e1422; border:1px solid #27314b; color:#c3d7ff; content:attr(data-badge); z-index:2;}
 .card h3{margin:0 0 8px 0; font-size:18px}
 .card p{margin:0; color:var(--muted); font-size:14px; line-height:1.35}
-.card img.thumb{width:100%; border-radius:12px; display:block; margin-bottom:8px;}
+.card .thumb{margin-bottom:8px;}
+.card .thumb img{width:100%; border-radius:12px; display:block;}
 .card .tags{display:flex; flex-wrap:wrap; gap:4px; margin:8px 0;}
 .card .tags span{background:#0e1422; border:1px solid #27314b; color:#c3d7ff; padding:2px 6px; border-radius:8px; font-size:11px;}
 .card .best{position:absolute; bottom:42px; right:12px; font-size:12px; color:#c3d7ff;}


### PR DESCRIPTION
## Summary
- Render game card thumbnails when available with lazy-loaded `<img>` elements
- Style `.thumb` wrapper and nested images for proper display

## Testing
- `npm test` *(fails: Cannot resolve import '../shared/controls.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a9346de8e88327bb36897dce6c29b5