### PR TITLE
Purge outdated caches during service worker activation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "jsdom": "^24.0.0",
+        "service-worker-mock": "^2.0.5",
         "vitest": "^1.6.0"
       }
     },
@@ -986,6 +987,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1168,6 +1176,19 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+      "integrity": "sha512-LNxCeExaNbczqMVfQUyLdd+r+smG7ixIa+doeyiJ7nTmL8aZRrJhHkEYBEYVGvYv7k2DOEBh2eKthoCmWpfICg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "urijs": "^1.16.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -1635,6 +1656,50 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha512-P4wZnho5curNqeEq/x292Pb57e1v+woR7DJ84DURelKB46lby8aDEGVobSaYtzHdQBWQrJSdxcCwjlGOvvdIyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha512-YDB/5xkL3fBKFMDaC+cfGV00pbiJ6XoJIfRmBhv7aR6wWtbCW6IzkiWnTfkiHTF6ALD7ff83dAtB3OEaSoyQPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -1976,6 +2041,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/realistic-structured-clone": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-1.0.1.tgz",
+      "integrity": "sha512-UnQGgXdxTg+vwonhBz6VvfNFeqn/DUk0ntL/rSrN1mBOR261ZzLP3LQAFSBfIytyZYn4yue/64pZ7aN0x/RpiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.isplainobject": "^3.0.2"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -2050,6 +2125,19 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/service-worker-mock": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.5.tgz",
+      "integrity": "sha512-yk6NCFnRWGfbOlP+IS4hEbJnGU8dVgtodAAKLxhkTPsOmaES44XVSWTNozK6KwI+p/0PDRrFsb2RjTMhvXiNkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dom-urls": "^1.1.0",
+        "shelving-mock-indexeddb": "^1.1.0",
+        "url-search-params": "^0.10.0",
+        "w3c-hr-time": "^1.0.1"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2071,6 +2159,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shelving-mock-event": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/shelving-mock-event/-/shelving-mock-event-1.0.12.tgz",
+      "integrity": "sha512-2F+IZ010rwV3sA/Kd2hnC1vGNycsxeBJmjkXR8+4IOlv5e+Wvj+xH+A8Cv8/Z0lUyCut/HcxSpeDccYTVtnuaQ==",
+      "dev": true,
+      "license": "0BSD",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/shelving-mock-indexeddb": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shelving-mock-indexeddb/-/shelving-mock-indexeddb-1.1.0.tgz",
+      "integrity": "sha512-akHJAmGL/dplJ4FZNxPxVbOxMw8Ey6wAnB9+3+GCUNqPUcJaskS55GijxZtarTfAYB4XQyu+FLtjcq2Oa3e2Lg==",
+      "dev": true,
+      "license": "0BSD",
+      "dependencies": {
+        "realistic-structured-clone": "^1.0.1",
+        "shelving-mock-event": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/siginfo": {
@@ -2233,6 +2345,13 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -2243,6 +2362,14 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/url-search-params": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-0.10.2.tgz",
+      "integrity": "sha512-d6GYsr992Bo9rzTZFc9BUw3UFAAg3prE9JGVBgW2TLTbI3rSvg4VDa0BFXHMzKkWbAuhrmaFWpucpRJl+3W7Jg==",
+      "deprecated": "now available as @ungap/url-search-params",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.19",
@@ -2391,6 +2518,17 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-process-hrtime": "^1.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "^1.6.0",
-    "jsdom": "^24.0.0"
+    "jsdom": "^24.0.0",
+    "service-worker-mock": "^2.0.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'static';
+const CACHE = 'static-v2';
 const ASSETS = [
   'index.html',
   'styles.css',
@@ -18,7 +18,15 @@ self.addEventListener('install', (e) => {
 });
 
 self.addEventListener('activate', (e) => {
-  e.waitUntil(self.clients.claim());
+  e.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys.filter((key) => key !== CACHE).map((key) => caches.delete(key)),
+      );
+      await self.clients.claim();
+    })(),
+  );
 });
 
 self.addEventListener('fetch', (e) => {

--- a/tests/sw.test.js
+++ b/tests/sw.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import makeServiceWorkerEnv from 'service-worker-mock';
+
+const CURRENT_CACHE = 'static-v2';
+
+describe('service worker cache management', () => {
+  beforeEach(() => {
+    Object.assign(global, makeServiceWorkerEnv());
+    self.clients = {
+      claim: () => Promise.resolve(),
+    };
+  });
+
+  it('removes outdated caches on activate', async () => {
+    // populate with old caches
+    await caches.open('static');
+    await caches.open('old-cache');
+    // open current cache
+    await caches.open(CURRENT_CACHE);
+
+    // import service worker to register listeners
+    await import('../sw.js?cache-bust=' + Date.now());
+
+    // trigger activation and wait for cleanup
+    await self.trigger('activate');
+
+    const keys = await caches.keys();
+    expect(keys).toEqual([CURRENT_CACHE]);
+  });
+});


### PR DESCRIPTION
## Summary
- version service worker cache as `static-v2`
- clean up old caches on activation and claim clients
- add unit test verifying outdated caches are removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab53c3ce14832795ab698e0161be96