### PR TITLE
Update service worker cache cleanup test

### DIFF
--- a/tests/sw.test.js
+++ b/tests/sw.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import makeServiceWorkerEnv from 'service-worker-mock';
 
-const CURRENT_CACHE = 'static-v2';
+const CACHE_VERSION = 'fresh-v1';
+const PRECACHE = `precache-${CACHE_VERSION}`;
+const RUNTIME = `runtime-${CACHE_VERSION}`;
 
 describe('service worker cache management', () => {
   beforeEach(() => {
@@ -13,10 +15,12 @@ describe('service worker cache management', () => {
 
   it('removes outdated caches on activate', async () => {
     // populate with old caches
-    await caches.open('static');
-    await caches.open('old-cache');
-    // open current cache
-    await caches.open(CURRENT_CACHE);
+    await caches.open('precache-old');
+    await caches.open('runtime-old');
+    await caches.open('unused-cache');
+    // open current caches
+    await caches.open(PRECACHE);
+    await caches.open(RUNTIME);
 
     // import service worker to register listeners
     await import('../sw.js?cache-bust=' + Date.now());
@@ -25,6 +29,6 @@ describe('service worker cache management', () => {
     await self.trigger('activate');
 
     const keys = await caches.keys();
-    expect(keys).toEqual([CURRENT_CACHE]);
+    expect(keys.sort()).toEqual([PRECACHE, RUNTIME].sort());
   });
 });


### PR DESCRIPTION
## Summary
- adjust service worker test to expect versioned precache and runtime caches
- verify that old caches are removed on activation

## Testing
- `npm test` *(fails: enableGamepadHint is not a function, localStorage is not defined, and other existing test failures)*
- `npx vitest run tests/sw.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68acdc17fb90832793f5e28d35b11d86