### PR TITLE
Use relative service worker registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,13 +88,14 @@
 
     await loadCatalog();
 
-    // Register a single worker at /sw.js; clean any legacy ones
+    // Register a single worker at ./sw.js; clean any legacy ones
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(console.error);
+        const swUrl = new URL('./sw.js', location.href).href;
+        navigator.serviceWorker.register('./sw.js').catch(console.error);
         navigator.serviceWorker.getRegistrations?.().then(regs => {
           regs.forEach(r => {
-            if (r.active && !r.active.scriptURL.endsWith('/sw.js')) r.unregister();
+            if (r.active && r.active.scriptURL !== swUrl) r.unregister();
           });
         });
       });


### PR DESCRIPTION
## Summary
- register service worker using a relative path so deployments in subdirectories work
- drop explicit scope option and clean up any workers not matching the current sw.js

## Testing
- `npm test` *(fails: ReferenceError: test is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acdc166d788327bb40366653c03a47