### PR TITLE
Handle invalid best score values

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,9 @@
 
     function card(g) {
       const best = getBestScore(g.slug);
-      const bestBadge = Number.isFinite(best) ? `<span class="badge best">Best: ${best}</span>` : '';
+      const bestBadge = best == null || Number.isNaN(best)
+        ? ''
+        : `<span class="badge best">Best: ${best}</span>`;
       const isNew = showNew && /\?new=true$/.test(g.path || '');
       return `
       <a class="card" href="${g.path || `./games/${g.slug}/`}">

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -71,8 +71,13 @@ export function saveBestScore(slug, score) {
 }
 
 export function getBestScore(slug) {
-  try { return Number(localStorage.getItem(`bestScore:${slug}`) || ''); }
-  catch { return null; }
+  try {
+    const raw = localStorage.getItem(`bestScore:${slug}`);
+    const num = Number(raw);
+    return raw !== null && Number.isFinite(num) ? num : null;
+  } catch {
+    return null;
+  }
 }
 
 export function attachPauseOverlay({ onResume, onRestart }) {

--- a/tests/ui.bestscore.test.js
+++ b/tests/ui.bestscore.test.js
@@ -1,7 +1,13 @@
+/* @vitest-environment jsdom */
 import { saveBestScore, getBestScore } from '../shared/ui.js';
 
 describe('best score', () => {
   beforeEach(() => localStorage.clear());
+  it('returns null when missing or invalid', () => {
+    expect(getBestScore('pong')).toBeNull();
+    localStorage.setItem('bestScore:pong', 'not-a-number');
+    expect(getBestScore('pong')).toBeNull();
+  });
   it('only saves when higher', () => {
     saveBestScore('pong', 10);
     saveBestScore('pong', 5);


### PR DESCRIPTION
## Summary
- Return `null` when best score is missing or invalid
- Avoid rendering a best score badge when no valid score exists
- Add tests covering missing and invalid best scores

## Testing
- `npm test -- --globals` *(fails: enableGamepadHint/virtualButtons not a function, service worker cache mismatch, injectBackButton href mismatch, localStorage not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68acdc149a5883278f337ad0797d8172