### PR TITLE
Add gamepad hint and virtual button helpers

### DIFF
--- a/shared/controls.js
+++ b/shared/controls.js
@@ -33,3 +33,36 @@ export function standardAxesToDir(pad, dead = 0.2) {
   const dy = Math.abs(ly) > dead ? ly : 0;
   return { dx, dy };
 }
+
+export function enableGamepadHint(hintEl) {
+  const show = () => { hintEl.style.display = ''; };
+  const hide = () => { hintEl.style.display = 'none'; };
+  window.addEventListener('gamepadconnected', show);
+  window.addEventListener('gamepaddisconnected', hide);
+  hide();
+  return {
+    destroy: () => {
+      window.removeEventListener('gamepadconnected', show);
+      window.removeEventListener('gamepaddisconnected', hide);
+    }
+  };
+}
+
+export function virtualButtons(codes) {
+  const element = document.createElement('div');
+  const state = new Map();
+  const up = code => () => state.set(code, false);
+  for (const code of codes) {
+    const btn = document.createElement('button');
+    btn.dataset.k = code;
+    state.set(code, false);
+    btn.addEventListener('touchstart', e => { state.set(code, true); e.preventDefault(); }, { passive: false });
+    btn.addEventListener('touchend', up(code));
+    btn.addEventListener('touchcancel', up(code));
+    element.appendChild(btn);
+  }
+  return {
+    element,
+    read: () => new Map(state)
+  };
+}


### PR DESCRIPTION
## Summary
- Add `enableGamepadHint` to show or hide hints based on gamepad connection events
- Implement `virtualButtons` helper for touch-based button state mapping

## Testing
- `npm test` *(fails: ReferenceError: test is not defined, AssertionError: expected[] to deeply equal ['static-v2'], etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68acdc0f780883278ea85c6b72327b9f