### PR TITLE
Add explicit vitest imports in tests

### DIFF
--- a/tests/controls.gamepad.test.js
+++ b/tests/controls.gamepad.test.js
@@ -1,3 +1,4 @@
+import { test, expect } from 'vitest';
 import { standardAxesToDir } from '../shared/controls.js';
 
 test('deadzone', () => {

--- a/tests/ui.bestscore.test.js
+++ b/tests/ui.bestscore.test.js
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
 import { saveBestScore, getBestScore } from '../shared/ui.js';
 
 describe('best score', () => {


### PR DESCRIPTION
## Summary
- add vitest imports for controls gamepad test
- add vitest imports for best score test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ace762d9fc83278c0fedc5a78db34f