### PR TITLE
Fix session timer to record time when switching games

### DIFF
--- a/shared/metrics.js
+++ b/shared/metrics.js
@@ -6,7 +6,7 @@ function today(){ return new Date().toISOString().slice(0,10); }
 let session = null;
 
 export function startSessionTimer(slug){
-  endSessionTimer(slug); // end any prior without losing data
+  endSessionTimer(session?.slug); // end any prior without losing data
   session = { slug, start: performance.now() };
 }
 

--- a/tests/controls.gamepad.test.js
+++ b/tests/controls.gamepad.test.js
@@ -1,3 +1,4 @@
+import { test, expect } from 'vitest';
 import { standardAxesToDir } from '../shared/controls.js';
 
 test('deadzone', () => {

--- a/tests/metrics.test.js
+++ b/tests/metrics.test.js
@@ -1,0 +1,29 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { startSessionTimer, endSessionTimer } from '../shared/metrics.js';
+
+describe('metrics session timing', () => {
+  let originalNow;
+  beforeEach(() => {
+    localStorage.clear();
+    originalNow = performance.now;
+  });
+  afterEach(() => {
+    performance.now = originalNow;
+  });
+
+  it('records time when switching between sessions', () => {
+    let now = 0;
+    performance.now = () => now;
+
+    startSessionTimer('first');
+    now = 500;
+    startSessionTimer('second');
+    now = 800;
+    endSessionTimer('second');
+    endSessionTimer('first');
+
+    expect(localStorage.getItem('time:first')).toBe('500');
+    expect(localStorage.getItem('time:second')).toBe('300');
+  });
+});

--- a/tests/ui.bestscore.test.js
+++ b/tests/ui.bestscore.test.js
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
 import { saveBestScore, getBestScore } from '../shared/ui.js';
 
 describe('best score', () => {


### PR DESCRIPTION
## Summary
- ensure new sessions end previous ones before starting timing
- add regression test covering session switching
- clean up tests to explicitly import vitest helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ace7648bdc8327b1129bb6e5764318