### PR TITLE
Rename hub to Gurjot's Games

### DIFF
--- a/cabinet.html
+++ b/cabinet.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Arcade Cabinet Mode</title>
+  <title>Gurjot's Games Cabinet Mode</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Arcade Hub</title>
+  <title>Gurjot's Games</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>
@@ -18,7 +18,7 @@
 </head>
 <body>
   <header class="site-header header-bar">
-    <h1 style="margin:0">Arcade Hub</h1>
+    <h1 style="margin:0">Gurjot's Games</h1>
     <nav style="display:flex;gap:8px;align-items:center">
       <a class="btn" href="./stats.html" title="Stats Dashboard">📈 Stats</a>
       <a class="btn" href="./cabinet.html" title="Cabinet Mode">🕹️ Cabinet</a>
@@ -49,7 +49,7 @@
     </section>
   </main>
 
-  <footer class="site-footer"><small>Hub • Works on GitHub Pages & offline</small></footer>
+  <footer class="site-footer"><small>Gurjot's Games • Works on GitHub Pages & offline</small></footer>
 
   <script type="module">
     import { getLastPlayed, getBestScore } from './shared/ui.js';

--- a/stats.html
+++ b/stats.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Arcade Stats</title>
+  <title>Gurjot's Games Stats</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>


### PR DESCRIPTION
## Summary
- Rebrand the hub as "Gurjot's Games" across main pages
- Update index footer to reflect new name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ace93632bc8327873a6daba627d28f