### PR TITLE
refactor: parse lastPlayed once

### DIFF
--- a/shared/ui.js
+++ b/shared/ui.js
@@ -56,7 +56,8 @@ export function injectBackButton(href = '../../') {
 export function recordLastPlayed(slug) {
   try {
     const raw = localStorage.getItem('lastPlayed');
-    const arr = Array.isArray(JSON.parse(raw)) ? JSON.parse(raw) : [];
+    const parsed = JSON.parse(raw);
+    const arr = Array.isArray(parsed) ? parsed : [];
     const next = [slug, ...arr.filter(s => s !== slug)].slice(0, 10);
     localStorage.setItem('lastPlayed', JSON.stringify(next));
   } catch {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -64,4 +64,11 @@ describe('recordLastPlayed', () => {
     expect(truncated.length).toBe(10);
     expect(truncated[0]).toBe('new');
   });
+
+  it('handles non-array stored value gracefully', () => {
+    localStorage.setItem('lastPlayed', '"oops"');
+    recordLastPlayed('x');
+    const result = JSON.parse(localStorage.getItem('lastPlayed'));
+    expect(result).toEqual(['x']);
+  });
 });


### PR DESCRIPTION
## Summary
- avoid double JSON parsing in `recordLastPlayed`
- handle non-array stored values when recording
- test that non-array stored values reset list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aceaa5674083278655084adb2783da