### PR TITLE
Add destroy cleanup for gamepad polling

### DIFF
--- a/shared/controls.js
+++ b/shared/controls.js
@@ -24,7 +24,12 @@ export function createGamepad(fn) {
   window.addEventListener('gamepadconnected', start);
   window.addEventListener('gamepaddisconnected', stop);
   start();
-  return { start, stop };
+  const destroy = () => {
+    stop();
+    window.removeEventListener('gamepadconnected', start);
+    window.removeEventListener('gamepaddisconnected', stop);
+  };
+  return { start, stop, destroy };
 }
 
 export function standardAxesToDir(pad, dead = 0.2) {

--- a/tests/controls.gamepad.test.js
+++ b/tests/controls.gamepad.test.js
@@ -1,7 +1,35 @@
-import { test, expect } from 'vitest';
-import { standardAxesToDir } from '../shared/controls.js';
+/* @vitest-environment jsdom */
+import { test, expect, vi } from 'vitest';
+import { standardAxesToDir, createGamepad } from '../shared/controls.js';
 
 test('deadzone', () => {
   const pad = { axes: [0.1, 0.05] };
   expect(standardAxesToDir(pad)).toEqual({ dx:0, dy:0 });
+});
+
+test('createGamepad destroy stops polling and removes listeners', () => {
+  const raf = vi.fn(() => 1);
+  const caf = vi.fn();
+  const origRAF = window.requestAnimationFrame;
+  const origCAF = window.cancelAnimationFrame;
+  window.requestAnimationFrame = raf;
+  window.cancelAnimationFrame = caf;
+
+  const addSpy = vi.spyOn(window, 'addEventListener');
+  const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+  const { destroy } = createGamepad(() => {});
+  destroy();
+
+  const startFn = addSpy.mock.calls.find(c => c[0] === 'gamepadconnected')[1];
+  const stopFn = addSpy.mock.calls.find(c => c[0] === 'gamepaddisconnected')[1];
+
+  expect(caf).toHaveBeenCalledWith(1);
+  expect(removeSpy).toHaveBeenCalledWith('gamepadconnected', startFn);
+  expect(removeSpy).toHaveBeenCalledWith('gamepaddisconnected', stopFn);
+
+  addSpy.mockRestore();
+  removeSpy.mockRestore();
+  window.requestAnimationFrame = origRAF;
+  window.cancelAnimationFrame = origCAF;
 });


### PR DESCRIPTION
## Summary
- expose a `destroy` function from `createGamepad` to cancel polling and remove event listeners
- add unit test ensuring gamepad polling cleanup occurs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aceaa80fc4832786c1530548177e76