### PR TITLE
Track game plays to unlock themes

### DIFF
--- a/shared/ui.js
+++ b/shared/ui.js
@@ -53,7 +53,16 @@ export function injectBackButton(href = '../../') {
   a.href = href;
 }
 
+export function incrementPlay(slug) {
+  try {
+    const key = `plays:${slug}`;
+    const prev = Number(localStorage.getItem(key) || 0);
+    localStorage.setItem(key, String(prev + 1));
+  } catch {}
+}
+
 export function recordLastPlayed(slug) {
+  incrementPlay(slug);
   try {
     const raw = localStorage.getItem('lastPlayed');
     const arr = Array.isArray(JSON.parse(raw)) ? JSON.parse(raw) : [];

--- a/tests/themes.unlock.test.js
+++ b/tests/themes.unlock.test.js
@@ -1,0 +1,23 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { recordLastPlayed } from '../shared/ui.js';
+import { getUnlocks } from '../shared/themes.js';
+
+describe('theme unlocks based on plays', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('unlocks themes at defined play thresholds', () => {
+    let unlocks = getUnlocks();
+    expect(unlocks).toEqual({ minimal: true, neon: false, retro: false });
+
+    for (let i = 0; i < 5; i++) recordLastPlayed('runner');
+    unlocks = getUnlocks();
+    expect(unlocks).toEqual({ minimal: true, neon: true, retro: false });
+
+    for (let i = 0; i < 5; i++) recordLastPlayed('runner');
+    unlocks = getUnlocks();
+    expect(unlocks).toEqual({ minimal: true, neon: true, retro: true });
+  });
+});

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -64,4 +64,10 @@ describe('recordLastPlayed', () => {
     expect(truncated.length).toBe(10);
     expect(truncated[0]).toBe('new');
   });
+
+  it('increments play counts for each launch', () => {
+    recordLastPlayed('pong');
+    recordLastPlayed('pong');
+    expect(localStorage.getItem('plays:pong')).toBe('2');
+  });
 });


### PR DESCRIPTION
## Summary
- add `incrementPlay` helper to persist `plays:<slug>` counters
- count each game launch via `recordLastPlayed`
- test play tracking and theme unlock thresholds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aceaa92d248327a27532b55ba50aa1