### PR TITLE
fix: add missing postprocessing imports

### DIFF
--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -1,6 +1,11 @@
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 import { PointerLockControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/PointerLockControls.js';
-import { RGBELoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/RGBELoader.js';
+import { EffectComposer } from 'https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/UnrealBloomPass.js';
+import { ShaderPass } from 'https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/ShaderPass.js';
+import { FXAAShader } from 'https://unpkg.com/three@0.160.0/examples/jsm/shaders/FXAAShader.js';
+import { Sky } from 'https://unpkg.com/three@0.160.0/examples/jsm/objects/Sky.js';
 import { registerSW } from '../../shared/sw.js';
 import { injectBackButton, recordLastPlayed } from '../../shared/ui.js';
 


### PR DESCRIPTION
## Summary
- add missing post-processing and sky imports for box3d
- remove unused `RGBELoader` import

## Testing
- `npm test`
- `NODE_OPTIONS=--dns-result-order=ipv4first node --experimental-network-imports games/box3d/main.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68aceaaaa0a483279c846a7077fcd3d7