### PR TITLE
Handle metrics session end without slug

### DIFF
--- a/shared/metrics.js
+++ b/shared/metrics.js
@@ -11,9 +11,12 @@ export function startSessionTimer(slug){
 }
 
 export function endSessionTimer(slug){
-  if (!session || session.slug !== slug) return;
+  if (!session) return;
+  // Allow ending the current session without explicitly passing the slug.
+  if (slug && session.slug !== slug) return;
+
   const ms = performance.now() - session.start;
-  const key = `time:${slug}`;
+  const key = `time:${session.slug}`;
   const prev = Number(localStorage.getItem(key) || 0);
   localStorage.setItem(key, String(prev + Math.round(ms)));
 

--- a/tests/metrics.test.js
+++ b/tests/metrics.test.js
@@ -26,4 +26,15 @@ describe('metrics session timing', () => {
     expect(localStorage.getItem('time:first')).toBe('500');
     expect(localStorage.getItem('time:second')).toBe('300');
   });
+
+  it('ends the current session when slug is omitted', () => {
+    let now = 0;
+    performance.now = () => now;
+
+    startSessionTimer('only');
+    now = 250;
+    endSessionTimer();
+
+    expect(localStorage.getItem('time:only')).toBe('250');
+  });
 });


### PR DESCRIPTION
## Summary
- allow `endSessionTimer` to end active session when slug is omitted
- add test covering slugless session end

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acee6d6cac8327bd2d0dfcd19377d9