### PR TITLE
Add sitemap generation and robots rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "sitemap": "node tools/generate-sitemap.mjs"
   },
   "devDependencies": {
     "jsdom": "^24.0.0",

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>/</loc></url>
+  <url><loc>/stats.html</loc></url>
+  <url><loc>/cabinet.html</loc></url>
+  <url><loc>/games/box3d/</loc></url>
+  <url><loc>/games/pong/</loc></url>
+  <url><loc>/games/runner/</loc></url>
+  <url><loc>/games/asteroids/</loc></url>
+  <url><loc>/games/shooter/</loc></url>
+  <url><loc>/games/platformer/</loc></url>
+  <url><loc>/games/maze3d/</loc></url>
+</urlset>

--- a/tools/generate-sitemap.mjs
+++ b/tools/generate-sitemap.mjs
@@ -1,0 +1,17 @@
+import {readFile, writeFile} from 'node:fs/promises';
+
+const data = JSON.parse(await readFile(new URL('../games.json', import.meta.url), 'utf8'));
+
+const gamePaths = data.games.map(g => {
+  const p = g.path.replace(/^\.\//, '/');
+  return p.startsWith('/') ? p : `/${p}`;
+});
+
+const urls = ['/', '/stats.html', '/cabinet.html', ...gamePaths];
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  urls.map(u => `  <url><loc>${u}</loc></url>`).join('\n') +
+  `\n</urlset>\n`;
+
+await writeFile(new URL('../sitemap.xml', import.meta.url), xml);


### PR DESCRIPTION
## Summary
- add Node script to build `sitemap.xml` from `games.json`
- add `robots.txt` referencing sitemap and allow all crawlers
- expose npm script `sitemap`

## Testing
- `npm run sitemap`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adde35c77883278bbca6410d6ca264