### PR TITLE
Add video previews and actions to game cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,16 +67,54 @@
     function card(g) {
       const best = getBestScore(g.slug);
       const bestBadge = Number.isFinite(best) ? `<span class="badge best">Best: ${best}</span>` : '';
+      const preview = g.preview ? `data-preview="${g.preview}"` : '';
       return `
-      <a class="card" href="${(g.path||`./games/${g.slug}/`).replace(/\?.*$/,'')}">
+      <div class="card" ${preview}>
         ${g.isNew ? '<span class="ribbon">NEW</span>' : ''}
-        ${g.thumb ? `<img src="${g.thumb}" alt="${g.title||g.slug} thumbnail" loading="lazy" onerror="this.remove()">` : ''}
-        <div class="meta">
-          <div class="title">${g.title||g.slug} ${g.badge?`<span class="badge">${g.badge}</span>`:''} ${bestBadge}</div>
-          <div class="tags">${(g.tags||[]).map(t=>`<span>${t}</span>`).join('')}</div>
-          <p>${g.blurb||''}</p>
+        <div class="media">
+          ${g.preview ? '<video muted loop playsinline hidden aria-hidden="true"></video>' : ''}
+          ${g.thumb ? `<img src="${g.thumb}" alt="${g.title||g.slug} thumbnail" loading="lazy" onerror="this.remove()">` : ''}
         </div>
-      </a>`;
+        <div class="meta">
+          <div class="title">${g.title||g.slug}</div>
+          <div class="badges">${g.badge?`<span class="badge">${g.badge}</span>`:''} ${bestBadge} ${(g.tags||[]).map(t=>`<span class="badge tag">${t}</span>`).join('')}</div>
+          <p>${g.blurb||''}</p>
+          <div class="card-actions">
+            <a class="btn primary" href="${(g.path||`./games/${g.slug}/`).replace(/\?.*$/,'')}" aria-label="Play ${g.title||g.slug}">Play</a>
+            <a class="details-link" href="/game.html?slug=${g.slug}" aria-label="Details for ${g.title||g.slug}">Details</a>
+          </div>
+        </div>
+      </div>`;
+    }
+
+    function setupPreviews(root){
+      root.querySelectorAll('.card[data-preview]').forEach(card => {
+        const video = card.querySelector('video');
+        const img = card.querySelector('img');
+        const src = card.dataset.preview;
+        let loaded = false;
+        function play(){
+          if(!loaded){
+            video.src = src;
+            loaded = true;
+          }
+          video.hidden = false;
+          video.play();
+          if(img) img.hidden = true;
+        }
+        function stop(){
+          video.pause();
+          video.removeAttribute('src');
+          video.load();
+          loaded = false;
+          video.hidden = true;
+          if(img) img.hidden = false;
+        }
+        card.addEventListener('mouseenter', play);
+        card.addEventListener('mouseleave', stop);
+        card.addEventListener('touchstart', play);
+        card.addEventListener('touchend', stop);
+      });
     }
 
     function renderRows(games){
@@ -85,6 +123,7 @@
       const sec = document.getElementById('recently');
       sec.hidden = recent.length === 0;
       recRoot.innerHTML = recent.map(card).join('');
+      setupPreviews(recRoot);
     }
 
     try {
@@ -93,6 +132,7 @@
       const games = Array.isArray(data.games) ? data.games : (Array.isArray(data) ? data : []);
       if (!games.length) empty.hidden = true === false; // reveal
       allRoot.innerHTML = games.map(card).join('');
+      setupPreviews(allRoot);
       renderRows(games);
     } catch (e) {
       empty.hidden = false;

--- a/styles.css
+++ b/styles.css
@@ -78,13 +78,12 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
 .card img { width:100%; height:140px; object-fit:cover; }
 .meta { padding:12px; }
 .title { display:flex; align-items:center; gap:6px; font-weight:600; }
-.tags { opacity:.8; margin-top:6px; }
-.tags span {
-  border:1px solid var(--tag-border);
-  border-radius:999px;
-  font-size:12px;
-  padding:2px 6px;
-  margin-right:6px;
+.badges {
+  opacity:.8;
+  margin-top:6px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
 }
 .muted { opacity:.7; }
 .ribbon {
@@ -106,7 +105,23 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
   font-size:12px;
   opacity:.8;
 }
-.badge.best { margin-left:6px; }
+.badge.best { margin-left:0; }
+.card video { width:100%; height:140px; object-fit:cover; }
+.card-actions {
+  margin-top:12px;
+  display:flex;
+  gap:8px;
+}
+.card-actions .btn { flex:1; text-align:center; }
+.card-actions .details-link { align-self:center; font-size:14px; text-decoration:underline; }
+.btn.primary {
+  background:#0069d9;
+  border-color:#0069d9;
+  color:#fff;
+}
+.btn.primary:hover {
+  background:#0053ba;
+}
 
 /* Pause overlay */
 .pause-overlay {


### PR DESCRIPTION
## Summary
- Swap thumbnails for video previews on hover
- Show badges row with best score and tags
- Add Play button and Details link for each game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adde2196548327b57e2cbbcbab9a25