### PR TITLE
Add rotating quests system with XP rewards

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,13 @@
 <body>
   <header class="site-header" style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px">
     <h1 style="margin:0">Arcade Hub</h1>
-    <nav style="display:flex;gap:8px;align-items:center">
-      <a class="btn" href="./stats.html">📈 Stats</a>
-      <a class="btn" href="./cabinet.html">🕹️ Cabinet</a>
-      <div id="themeChips" style="display:flex;gap:8px"></div>
-    </nav>
-  </header>
+      <nav style="display:flex;gap:8px;align-items:center">
+        <a class="btn" href="./stats.html">📈 Stats</a>
+        <a class="btn" href="./quests.html">🗺️ Quests</a>
+        <a class="btn" href="./cabinet.html">🕹️ Cabinet</a>
+        <div id="themeChips" style="display:flex;gap:8px"></div>
+      </nav>
+    </header>
 
   <main style="max-width:1100px;margin:0 auto;padding:16px">
     <section id="recently" class="row" hidden>

--- a/quests.html
+++ b/quests.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Quests</title>
+  <link rel="stylesheet" href="./styles.css" />
+  <link rel="stylesheet" href="./styles.themes.css" />
+  <style>
+    ul{list-style:disc;padding-left:20px}
+  </style>
+</head>
+<body>
+  <header class="site-header" style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px">
+    <h1 style="margin:0">🗺️ Quests</h1>
+    <nav style="display:flex;gap:8px;align-items:center">
+      <a class="btn" href="./index.html">← Back</a>
+    </nav>
+  </header>
+
+  <main style="max-width:1100px;margin:0 auto;padding:16px">
+    <section>
+      <h2>Daily Quests</h2>
+      <ul id="daily"></ul>
+    </section>
+    <section>
+      <h2>Weekly Quests</h2>
+      <ul id="weekly"></ul>
+    </section>
+    <p>Total XP: <span id="xp">0</span></p>
+  </main>
+
+  <script type="module">
+    import { getActiveQuests, getXP } from './shared/quests.js';
+    import { applyTheme, currentTheme } from './shared/themes.js';
+    applyTheme(currentTheme());
+
+    function render(){
+      const { daily, weekly } = getActiveQuests();
+      const dailyEl = document.getElementById('daily');
+      const weeklyEl = document.getElementById('weekly');
+      dailyEl.innerHTML = daily.map(q => `<li>${q.description} — ${q.progress}/${q.goal} XP:${q.xp} ${q.completed ? '✔' : ''}</li>`).join('');
+      weeklyEl.innerHTML = weekly.map(q => `<li>${q.description} — ${q.progress}/${q.goal} XP:${q.xp} ${q.completed ? '✔' : ''}</li>`).join('');
+      document.getElementById('xp').textContent = getXP();
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/shared/game-boot.js
+++ b/shared/game-boot.js
@@ -1,9 +1,24 @@
 // shared/game-boot.js
 // Usage in a game page: <script type="module" src="../../shared/game-boot.js" data-slug="runner"></script>
 import { injectBackButton, recordLastPlayed } from './ui.js';
+import { recordPlay } from './quests.js';
 
 const currentScript = document.currentScript;
 const slug = currentScript?.dataset?.slug || (new URL(location.href)).pathname.split('/').filter(Boolean).slice(-1)[0] || 'unknown';
 
 injectBackButton('/');
 recordLastPlayed(slug);
+
+async function track(){
+  let tags = [];
+  try {
+    const res = await fetch('/games.json');
+    const data = await res.json();
+    const games = Array.isArray(data.games) ? data.games : (Array.isArray(data) ? data : []);
+    const g = games.find(g => g.slug === slug);
+    if (g) tags = g.tags || [];
+  } catch {}
+  recordPlay(slug, tags);
+}
+
+track();

--- a/shared/quests.js
+++ b/shared/quests.js
@@ -1,0 +1,191 @@
+// Quest system with daily/weekly rotations and XP rewards
+
+// Pools of possible quests
+const DAILY_POOL = [
+  {
+    id: 'd_play_any',
+    description: 'Play a game',
+    goal: 1,
+    xp: 25,
+    criteria: { action: 'play' }
+  },
+  {
+    id: 'd_play3',
+    description: 'Play 3 games',
+    goal: 3,
+    xp: 50,
+    criteria: { action: 'play' }
+  },
+  {
+    id: 'd_play3d3',
+    description: 'Play 3 different 3D games',
+    goal: 3,
+    xp: 100,
+    criteria: { action: 'play', tag: '3D', unique: true }
+  }
+];
+
+const WEEKLY_POOL = [
+  {
+    id: 'w_play10',
+    description: 'Play 10 games',
+    goal: 10,
+    xp: 150,
+    criteria: { action: 'play' }
+  },
+  {
+    id: 'w_play3d5',
+    description: 'Play 5 different 3D games',
+    goal: 5,
+    xp: 250,
+    criteria: { action: 'play', tag: '3D', unique: true }
+  }
+];
+
+const DAILY_COUNT = 2;
+const WEEKLY_COUNT = 1;
+
+// deterministic PRNG
+function xmur3(str){
+  let h = 1779033703 ^ str.length;
+  for(let i=0;i<str.length;i++){
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = h << 13 | h >>> 19;
+  }
+  return function(){
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    return h >>> 0;
+  };
+}
+
+function mulberry32(a){
+  return function(){
+    let t = a += 0x6D2B79F5;
+    t = Math.imul(t ^ t >>> 15, t | 1);
+    t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+function seededShuffle(arr, seedStr){
+  const seed = xmur3(seedStr)();
+  const rand = mulberry32(seed);
+  const a = arr.slice();
+  for(let i=a.length-1;i>0;i--){
+    const j = Math.floor(rand() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function weekKey(date){
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+  const weekNo = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${weekNo}`;
+}
+
+function profileId(){
+  return localStorage.getItem('profile') || 'default';
+}
+
+function progressKey(type, seed){
+  return `questProgress:${profileId()}:${type}:${seed}`;
+}
+
+function loadProgress(type, seed){
+  try {
+    return JSON.parse(localStorage.getItem(progressKey(type, seed)) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function saveProgress(type, seed, obj){
+  localStorage.setItem(progressKey(type, seed), JSON.stringify(obj));
+}
+
+function xpKey(){
+  return `profile:xp:${profileId()}`;
+}
+
+export function getXP(){
+  return Number(localStorage.getItem(xpKey()) || 0);
+}
+
+function addXP(n){
+  const k = xpKey();
+  const prev = getXP();
+  localStorage.setItem(k, String(prev + n));
+}
+
+function select(pool, count, seedStr){
+  return seededShuffle(pool, seedStr).slice(0, count);
+}
+
+export function getActiveQuests(date = new Date()){
+  const daySeed = date.toISOString().slice(0,10);
+  const weekSeed = weekKey(date);
+  const dailySel = select(DAILY_POOL, DAILY_COUNT, daySeed);
+  const weeklySel = select(WEEKLY_POOL, WEEKLY_COUNT, weekSeed);
+
+  const dailyProg = loadProgress('daily', daySeed);
+  const weeklyProg = loadProgress('weekly', weekSeed);
+
+  const daily = dailySel.map(q => ({
+    ...q,
+    progress: dailyProg[q.id]?.count || 0,
+    completed: !!dailyProg[q.id]?.done
+  }));
+  const weekly = weeklySel.map(q => ({
+    ...q,
+    progress: weeklyProg[q.id]?.count || 0,
+    completed: !!weeklyProg[q.id]?.done
+  }));
+
+  return { daily, weekly };
+}
+
+export function recordPlay(slug, tags = [], date = new Date()){
+  const daySeed = date.toISOString().slice(0,10);
+  const weekSeed = weekKey(date);
+
+  const dailySel = select(DAILY_POOL, DAILY_COUNT, daySeed);
+  const weeklySel = select(WEEKLY_POOL, WEEKLY_COUNT, weekSeed);
+
+  const dailyProg = loadProgress('daily', daySeed);
+  const weeklyProg = loadProgress('weekly', weekSeed);
+
+  const lowerTags = tags.map(t => t.toLowerCase());
+
+  function apply(quests, prog, type, seed){
+    quests.forEach(q => {
+      if (q.criteria.action !== 'play') return;
+      if (q.criteria.tag && !lowerTags.includes(q.criteria.tag.toLowerCase())) return;
+
+      let entry = prog[q.id] || { count: 0, uniques: [], done: false };
+      if (q.criteria.unique){
+        if (entry.uniques.includes(slug)) return; // already counted
+        entry.uniques.push(slug);
+        entry.count = entry.uniques.length;
+      } else {
+        entry.count += 1;
+      }
+      if (!entry.done && entry.count >= q.goal){
+        entry.done = true;
+        addXP(q.xp);
+      }
+      prog[q.id] = entry;
+    });
+    saveProgress(type, seed, prog);
+  }
+
+  apply(dailySel, dailyProg, 'daily', daySeed);
+  apply(weeklySel, weeklyProg, 'weekly', weekSeed);
+}
+
+export default { getActiveQuests, recordPlay, getXP };

--- a/tests/quests.test.js
+++ b/tests/quests.test.js
@@ -1,0 +1,57 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getActiveQuests, recordPlay, getXP } from '../shared/quests.js';
+
+function findDateForDailyQuest(id){
+  const start = new Date('2025-01-01');
+  for(let i=0;i<365;i++){
+    const d = new Date(start.getTime() + i*86400000);
+    const qs = getActiveQuests(d).daily;
+    if (qs.some(q => q.id === id)) return d;
+  }
+  throw new Error('quest not found');
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('quest rotation', () => {
+  it('is stable for the same date', () => {
+    const d = new Date('2024-05-05');
+    const q1 = getActiveQuests(d);
+    const q2 = getActiveQuests(d);
+    expect(q1.daily.map(q=>q.id)).toEqual(q2.daily.map(q=>q.id));
+    expect(q1.weekly.map(q=>q.id)).toEqual(q2.weekly.map(q=>q.id));
+  });
+});
+
+describe('recordPlay progress', () => {
+  it('tracks 3D quest progress and awards XP', () => {
+    const date = findDateForDailyQuest('d_play3d3');
+    recordPlay('box3d', ['3D'], date);
+    recordPlay('maze3d', ['3D'], date);
+    recordPlay('third3d', ['3D'], date);
+
+    const q = getActiveQuests(date).daily.find(q => q.id === 'd_play3d3');
+    expect(q.progress).toBe(3);
+    expect(q.completed).toBe(true);
+    expect(getXP()).toBeGreaterThanOrEqual(q.xp);
+  });
+});
+
+describe('profile isolation', () => {
+  it('separates progress per profile', () => {
+    const date = findDateForDailyQuest('d_play3d3');
+    localStorage.setItem('profile', 'p1');
+    recordPlay('box3d', ['3D'], date);
+    recordPlay('maze3d', ['3D'], date);
+    recordPlay('third3d', ['3D'], date);
+    expect(getXP()).toBeGreaterThan(0);
+
+    localStorage.setItem('profile', 'p2');
+    const q = getActiveQuests(date).daily.find(q => q.id === 'd_play3d3');
+    expect(q.progress).toBe(0);
+    expect(getXP()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce quest module with seed-based daily/weekly rotations, per-profile progress, and XP rewards
- track game plays to update quest progress and expose new quests page from the header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adde5aff188327a4ad288c54784422