### PR TITLE
feat: add achievements system

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Achievements</title>
+  <link rel="stylesheet" href="./styles.css" />
+  <link rel="stylesheet" href="./styles.themes.css" />
+  <style>
+    main{max-width:700px;margin:0 auto;padding:16px;}
+    .ach-list{display:flex;flex-direction:column;gap:12px;margin-top:20px;}
+    .ach-item{display:flex;gap:12px;align-items:center;padding:10px 14px;border:1px solid var(--button-border);background:var(--button-bg);border-radius:8px;opacity:.5;}
+    .ach-item.unlocked{opacity:1;}
+    .ach-item .icon{font-size:24px;}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Achievements</h1>
+    <div id="achList" class="ach-list"></div>
+  </main>
+  <script type="module">
+    import { getAchievements } from './shared/achievements.js';
+    import { applyTheme, injectBackButton } from './shared/ui.js';
+    applyTheme();
+    injectBackButton('./');
+    const list = document.getElementById('achList');
+    const achs = getAchievements();
+    list.innerHTML = achs.map(a => `
+      <div class="ach-item ${a.unlocked ? 'unlocked' : ''}">
+        <span class="icon">${a.icon}</span>
+        <div>
+          <div><strong>${a.title}</strong></div>
+          <div class="muted">${a.desc}</div>
+        </div>
+      </div>
+    `).join('');
+  </script>
+</body>
+</html>

--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -1,6 +1,7 @@
 import { keyState } from '../../shared/controls.js';
 import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
+import { emitEvent } from '../../shared/achievements.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -125,12 +126,14 @@ function restart(){
   bullets.length=0; rocks.length=0; particles.length=0;
   spawnWave(4);
   updateHUD();
+  emitEvent({ type: 'play', slug: 'asteroids' });
 }
 
 function updateHUD(){
   HUD.score.textContent = score;
   HUD.lives.textContent = lives;
   HUD.wave.textContent = wave;
+  emitEvent({ type: 'score', slug: 'asteroids', value: score });
 }
 
 addEventListener('keydown', (e)=>{
@@ -211,6 +214,7 @@ function update(dt){
         running=false;
         saveBestScore('asteroids', score);
         endSessionTimer('asteroids');
+        emitEvent({ type: 'game_over', slug: 'asteroids', value: score });
       }
     }
   }

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -8,10 +8,12 @@ import { FXAAShader } from 'https://unpkg.com/three@0.160.0/examples/jsm/shaders
 import { Sky } from 'https://unpkg.com/three@0.160.0/examples/jsm/objects/Sky.js';
 import { registerSW } from '../../shared/sw.js';
 import { injectBackButton, recordLastPlayed } from '../../shared/ui.js';
+import { emitEvent } from '../../shared/achievements.js';
 
 registerSW();
 injectBackButton();
 recordLastPlayed('box3d');
+emitEvent({ type: 'play', slug: 'box3d' });
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.75));

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -1,4 +1,5 @@
 import { recordLastPlayed } from '../../shared/ui.js';
+import { emitEvent } from '../../shared/achievements.js';
 
 recordLastPlayed('maze3d');
 
@@ -121,6 +122,7 @@ function start() {
   if (!running) {
     running = true;
     startTime = performance.now();
+    emitEvent({ type: 'play', slug: 'maze3d' });
   }
   paused = false;
   overlay.classList.add('hidden');
@@ -168,6 +170,7 @@ function finish(time) {
   restartBtn.style.display = 'inline-block';
   overlay.classList.remove('hidden');
   startTime = 0;
+  emitEvent({ type: 'game_over', slug: 'maze3d', value: time });
 }
 
 function update(dt) {

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1,6 +1,8 @@
 import { recordLastPlayed } from '../../shared/ui.js';
+import { emitEvent } from '../../shared/achievements.js';
 
 recordLastPlayed('platformer');
+emitEvent({ type: 'play', slug: 'platformer' });
 
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
@@ -59,6 +61,7 @@ function restart(){
   map = levelData.map(r => r.split(''));
   player.x = 100; player.y = 0; player.vx = 0; player.vy = 0; player.onGround = false;
   camX = 0;
+  emitEvent({ type: 'play', slug: 'platformer' });
 }
 
 let last = 0;
@@ -148,6 +151,7 @@ function checkCollectibles(){
       if (t === '2'){
         setTile(x, y, '0');
         state.score += 1;
+        emitEvent({ type: 'score', slug: 'platformer', value: state.score });
       } else if (t === '3'){
         gameOver(true);
       }
@@ -163,6 +167,7 @@ function gameOver(win){
   over.querySelector('#over-title').textContent = win ? 'You Win!' : 'Game Over';
   over.querySelector('#over-info').textContent = `Score: ${state.score} • Best: ${state.hiscore}`;
   over.classList.add('show');
+  emitEvent({ type: 'game_over', slug: 'platformer', value: state.score });
 }
 
 function getTile(x, y){

--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -1,6 +1,7 @@
 import { createGamepad, keyState } from '../../shared/controls.js';
 import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
+import { emitEvent } from '../../shared/achievements.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -107,6 +108,7 @@ function restart(){
   left.y = right.y = (FIELD.h-PADDLE.h)/2;
   ball = resetBall(1);
   serveLock = true; running = true; status('Press Space/Enter to serve');
+  emitEvent({ type: 'play', slug: 'pong' });
 }
 
 // AI behavior
@@ -203,6 +205,7 @@ function score(side){
   serveLock = true;
   ball = resetBall(side==='L' ? 1 : -1);
   status('Press Space/Enter to serve');
+  emitEvent({ type: 'score', slug: 'pong', value: right.score });
 
   // End/win
   if (left.score >= WIN_SCORE || right.score >= WIN_SCORE){
@@ -212,6 +215,7 @@ function score(side){
     // Persist best score (use Right player points as "your" score in single mode)
     saveBestScore('pong', right.score);
     endSessionTimer('pong');
+    emitEvent({ type: 'game_over', slug: 'pong', value: { left: left.score, right: right.score } });
   }
 }
 
@@ -249,4 +253,5 @@ function render(){
 
 // Session timing
 startSessionTimer('pong');
+emitEvent({ type: 'play', slug: 'pong' });
 window.addEventListener('beforeunload', ()=> endSessionTimer('pong'));

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -1,6 +1,7 @@
 import { keyState } from '../../shared/controls.js';
 import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
+import { emitEvent } from '../../shared/achievements.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -58,6 +59,7 @@ function restart(){
   player={x:80,y:0,w:30,h:50,vy:0,sliding:0};
   score=0;obstacles=[];coins=[];tick=0;running=true;
   speed=diff==='easy'?4:diff==='med'?5:6.5;
+  emitEvent({ type: 'play', slug: 'runner' });
 }
 
 // Game loop
@@ -93,6 +95,7 @@ function update(dt){
       running=false;
       saveBestScore('runner',Math.floor(score));
       endSessionTimer('runner');
+      emitEvent({ type: 'game_over', slug: 'runner', value: Math.floor(score) });
     }
   }
   for(const c of coins){
@@ -126,4 +129,5 @@ function pause(){running=false;overlay.show();}
 
 // Session timing
 startSessionTimer('runner');
+emitEvent({ type: 'play', slug: 'runner' });
 window.addEventListener('beforeunload',()=>endSessionTimer('runner'));

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1,4 +1,5 @@
 import { injectBackButton, recordLastPlayed } from '../../shared/ui.js';
+import { emitEvent } from '../../shared/achievements.js';
 
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
@@ -9,6 +10,7 @@ const bestEl  = document.getElementById('best');
 
 injectBackButton();
 recordLastPlayed('shooter');
+emitEvent({ type: 'play', slug: 'shooter' });
 
 const state = {
   running: true,
@@ -112,6 +114,7 @@ function restart(){
   bestEl.textContent = state.hiscore;
   player.x = W/2; player.y = H/2;
   bullets = []; enemies = []; spawnTimer = 0;
+  emitEvent({ type: 'play', slug: 'shooter' });
 }
 
 let last = 0;
@@ -146,6 +149,7 @@ function update(dt){
       if(dx*dx + dy*dy < (b.r + e.r)*(b.r + e.r)){
         bullets.splice(i,1); enemies.splice(j,1);
         state.score++; scoreEl.textContent = state.score;
+        emitEvent({ type: 'score', slug: 'shooter', value: state.score });
         break;
       }
     }
@@ -173,6 +177,7 @@ function gameOver(){
   const over = document.getElementById('overlay');
   over.querySelector('#over-info').textContent = `Score: ${state.score} • Best: ${state.hiscore}`;
   over.classList.add('show');
+  emitEvent({ type: 'game_over', slug: 'shooter', value: state.score });
 }
 
 function draw(){


### PR DESCRIPTION
## Summary
- add shared achievements registry and toast notifications
- track play and score events from games
- expose achievements list page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adde4c61908327b76dcb3ecb9821a7