### PR TITLE
Add XP tracking and hub progress bar

### DIFF
--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -1,6 +1,6 @@
 import { keyState } from '../../shared/controls.js';
 import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
-import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
+import { endPlaySession } from '../../shared/xp.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -210,7 +210,7 @@ function update(dt){
       if (lives<=0){
         running=false;
         saveBestScore('asteroids', score);
-        endSessionTimer('asteroids');
+        endPlaySession('asteroids');
       }
     }
   }
@@ -283,6 +283,4 @@ function render(){
   ctx.globalAlpha = 1;
 }
 
-// Session timing
-startSessionTimer('asteroids');
-window.addEventListener('beforeunload', ()=> endSessionTimer('asteroids'));
+// Session timing handled globally in game-boot.js

--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -1,6 +1,6 @@
 import { createGamepad, keyState } from '../../shared/controls.js';
 import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
-import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
+import { endPlaySession } from '../../shared/xp.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -211,7 +211,7 @@ function score(side){
     status(`${winner} wins! Press Restart.`);
     // Persist best score (use Right player points as "your" score in single mode)
     saveBestScore('pong', right.score);
-    endSessionTimer('pong');
+    endPlaySession('pong');
   }
 }
 
@@ -247,6 +247,4 @@ function render(){
   }
 }
 
-// Session timing
-startSessionTimer('pong');
-window.addEventListener('beforeunload', ()=> endSessionTimer('pong'));
+// Session timing handled globally in game-boot.js

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -1,6 +1,6 @@
 import { keyState } from '../../shared/controls.js';
 import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
-import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
+import { endPlaySession } from '../../shared/xp.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -92,7 +92,7 @@ function update(dt){
     if(player.x<o.x+o.w&&player.x+player.w>o.x&&player.y+player.h>o.y&&player.y<o.y+o.h){
       running=false;
       saveBestScore('runner',Math.floor(score));
-      endSessionTimer('runner');
+      endPlaySession('runner');
     }
   }
   for(const c of coins){
@@ -124,6 +124,4 @@ function render(){
 
 function pause(){running=false;overlay.show();}
 
-// Session timing
-startSessionTimer('runner');
-window.addEventListener('beforeunload',()=>endSessionTimer('runner'));
+// Session timing handled globally in game-boot.js

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <nav style="display:flex;gap:8px;align-items:center">
       <a class="btn" href="./stats.html">📈 Stats</a>
       <a class="btn" href="./cabinet.html">🕹️ Cabinet</a>
+      <div id="xpWidget" class="xp-widget"></div>
       <div id="themeChips" style="display:flex;gap:8px"></div>
     </nav>
   </header>
@@ -35,6 +36,7 @@
   <script type="module">
     import { getLastPlayed, getBestScore } from './shared/ui.js';
     import { getUnlocks, currentTheme, applyTheme } from './shared/themes.js';
+    import { getXP, levelFromXP, xpForLevel } from './shared/xp.js';
 
     applyTheme(currentTheme());
     function themeChip(name, unlocked, active){
@@ -59,6 +61,18 @@
       });
     }
     renderThemeChips();
+
+    const xpEl = document.getElementById('xpWidget');
+    function renderXP(){
+      const xp = getXP();
+      const lvl = levelFromXP(xp);
+      const prev = xpForLevel(lvl);
+      const next = xpForLevel(lvl + 1);
+      const progress = (xp - prev) / (next - prev || 1);
+      const pct = Math.floor(progress * 100);
+      xpEl.innerHTML = `<span>Lv ${lvl}</span><div class="xp-bar"><div class="xp-bar-fill" style="width:${pct}%"></div></div><span class="muted" style="font-size:12px">${next - xp} XP</span>`;
+    }
+    renderXP();
 
     const allRoot = document.getElementById('all-cards');
     const recRoot = document.getElementById('recently-cards');

--- a/shared/game-boot.js
+++ b/shared/game-boot.js
@@ -1,9 +1,12 @@
 // shared/game-boot.js
 // Usage in a game page: <script type="module" src="../../shared/game-boot.js" data-slug="runner"></script>
 import { injectBackButton, recordLastPlayed } from './ui.js';
+import { beginPlaySession, endPlaySession } from './xp.js';
 
 const currentScript = document.currentScript;
 const slug = currentScript?.dataset?.slug || (new URL(location.href)).pathname.split('/').filter(Boolean).slice(-1)[0] || 'unknown';
 
 injectBackButton('/');
 recordLastPlayed(slug);
+beginPlaySession(slug);
+window.addEventListener('beforeunload', () => endPlaySession(slug));

--- a/shared/themes.js
+++ b/shared/themes.js
@@ -1,5 +1,6 @@
 
 // Theme pack manager (local-only unlocks)
+import { awardAchievementXP } from './xp.js';
 const THEME_KEY = 'skin:current';
 const UNLOCKS_KEY = 'skin:unlocks';
 // thresholds by total plays
@@ -16,12 +17,14 @@ export function totalPlays(){
 export function getUnlocks(){
   let u = {};
   try { u = JSON.parse(localStorage.getItem(UNLOCKS_KEY) || '{}'); } catch {}
+  const before = { ...u };
   // recompute from threshold + total plays
   const t = totalPlays();
   u.minimal = true;
   u.neon = u.neon || t >= THRESHOLDS.neon;
   u.retro = u.retro || t >= THRESHOLDS.retro;
   localStorage.setItem(UNLOCKS_KEY, JSON.stringify(u));
+  if ((!before.neon && u.neon) || (!before.retro && u.retro)) awardAchievementXP();
   return u;
 }
 

--- a/shared/xp.js
+++ b/shared/xp.js
@@ -1,0 +1,76 @@
+import { startSessionTimer, endSessionTimer } from './metrics.js';
+
+const PROFILE_KEY = 'profile:current';
+const XP_PREFIX = 'xp:';
+const DEFAULT_ACHIEVEMENT_BONUS = 50;
+let session = null; // { slug, start }
+
+function currentProfile(){
+  try { return localStorage.getItem(PROFILE_KEY) || 'default'; }
+  catch { return 'default'; }
+}
+
+function xpKey(profile=currentProfile()){
+  return `${XP_PREFIX}${profile}`;
+}
+
+export function getXP(profile=currentProfile()){
+  try { return Number(localStorage.getItem(xpKey(profile)) || 0); }
+  catch { return 0; }
+}
+
+function setXP(xp, profile=currentProfile()){
+  try { localStorage.setItem(xpKey(profile), String(xp)); } catch {}
+}
+
+export function addXP(amount, profile=currentProfile()){
+  const total = getXP(profile) + Number(amount||0);
+  setXP(total, profile);
+  return total;
+}
+
+export function xpForLevel(level){
+  if (level <= 1) return 0;
+  return Math.round(100 * Math.pow(level - 1, 1/0.8));
+}
+
+export function levelFromXP(xp){
+  return Math.floor(Math.pow((xp||0)/100, 0.8)) + 1;
+}
+
+export function currentLevel(profile=currentProfile()){
+  return levelFromXP(getXP(profile));
+}
+
+export function xpToNext(profile=currentProfile()){
+  const xp = getXP(profile);
+  const lvl = levelFromXP(xp);
+  const nextThreshold = xpForLevel(lvl + 1);
+  return nextThreshold - xp;
+}
+
+export function beginPlaySession(slug){
+  try {
+    const key = `plays:${slug}`;
+    const prev = Number(localStorage.getItem(key) || 0);
+    localStorage.setItem(key, String(prev + 1));
+  } catch {}
+  addXP(10);
+  startSessionTimer(slug);
+  session = { slug, start: performance.now() };
+}
+
+export function endPlaySession(slug){
+  if (session && session.slug === slug){
+    const ms = performance.now() - session.start;
+    const minutes = Math.floor(ms / 60000);
+    if (minutes > 0) addXP(minutes);
+    session = null;
+  }
+  endSessionTimer(slug);
+}
+
+export function awardAchievementXP(bonus=DEFAULT_ACHIEVEMENT_BONUS){
+  addXP(bonus);
+}
+

--- a/styles.css
+++ b/styles.css
@@ -128,3 +128,8 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
   text-align:center;
 }
 .pause-overlay button { margin:6px; }
+
+/* XP progress widget */
+.xp-widget{display:flex;align-items:center;gap:6px;font-size:14px;}
+.xp-bar{width:80px;height:8px;background:var(--border);border-radius:4px;overflow:hidden;}
+.xp-bar-fill{height:100%;background:var(--accent);}


### PR DESCRIPTION
## Summary
- Track experience and levels per profile with new `shared/xp.js`
- Start/stop play sessions via `game-boot.js` and award XP for plays, minutes, and theme unlocks
- Display player level and XP progress in hub header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adde540dfc83279275e369ddfa0f54