### PR TITLE
Handle non-finite quest XP

### DIFF
--- a/shared/quests.js
+++ b/shared/quests.js
@@ -114,13 +114,17 @@ function xpKey(){
 }
 
 export function getXP(){
-  return Number(localStorage.getItem(xpKey()) || 0);
+  const parsed = Number(localStorage.getItem(xpKey()));
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function addXP(n){
   const k = xpKey();
   const prev = getXP();
-  localStorage.setItem(k, String(prev + n));
+  const next = prev + n;
+  if (Number.isFinite(next)){
+    localStorage.setItem(k, String(next));
+  }
 }
 
 function select(pool, count, seedStr){


### PR DESCRIPTION
## Summary
- Safely parse quest XP values, defaulting to 0 for non-finite numbers
- Prevent storing non-finite XP totals when adding XP

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf84f595c83279e287685b1b7e02f