### PR TITLE
Sanitize best score comparison

### DIFF
--- a/shared/ui.js
+++ b/shared/ui.js
@@ -77,7 +77,8 @@ export function getLastPlayed(limit = 10) {
 export function saveBestScore(slug, score) {
   try {
     const key = `bestScore:${slug}`;
-    const prev = Number(localStorage.getItem(key) || '-Infinity');
+    let prev = Number(localStorage.getItem(key));
+    if (!Number.isFinite(prev)) prev = -Infinity;
     if (Number(score) > prev) localStorage.setItem(key, String(score));
   } catch {}
 }

--- a/tests/ui.bestscore.test.js
+++ b/tests/ui.bestscore.test.js
@@ -16,4 +16,9 @@ describe('best score', () => {
     saveBestScore('pong', 12);
     expect(getBestScore('pong')).toBe(12);
   });
+  it('handles non-finite stored values', () => {
+    localStorage.setItem('bestScore:pong', 'not-a-number');
+    saveBestScore('pong', 7);
+    expect(getBestScore('pong')).toBe(7);
+  });
 });


### PR DESCRIPTION
## Summary
- Sanitize stored best score with `Number` and treat non-finite values as `-Infinity`
- Add test to ensure invalid stored values are replaced by new scores

## Testing
- ❌ `npm test` *(fails: TypeError: Cannot set property navigator of #<Object> which has only a getter)*
- ✅ `npx vitest run tests/ui.bestscore.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68adf84d31ac8327b0ef582efd53a39f