### PR TITLE
Ignore non-finite values in total plays count

### DIFF
--- a/shared/themes.js
+++ b/shared/themes.js
@@ -8,7 +8,10 @@ const THRESHOLDS = { neon: 5, retro: 10, minimal: 0 };
 export function totalPlays(){
   let sum = 0;
   for (const k of Object.keys(localStorage)) {
-    if (k.startsWith('plays:')) sum += Number(localStorage.getItem(k) || 0);
+    if (k.startsWith('plays:')) {
+      const n = Number(localStorage.getItem(k));
+      sum += Number.isFinite(n) ? n : 0;
+    }
   }
   return sum;
 }


### PR DESCRIPTION
## Summary
- Validate play-count values from `localStorage` with `Number`.
- Only add to play total when values are finite.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf84e56b08327ba360f0c36fa692c