### PR TITLE
Cache navigations individually

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -27,7 +27,10 @@ self.addEventListener('fetch', event => {
   const same = url.origin === self.location.origin;
 
   if (req.mode === 'navigate') {
-    event.respondWith(networkFirst('/index.html'));
+    event.respondWith((async () => {
+      const resp = await networkFirst(req);
+      return resp.type === 'error' ? networkFirst('/index.html') : resp;
+    })());
     return;
   }
 


### PR DESCRIPTION
## Summary
- Cache navigation requests individually by passing the original request to `networkFirst`.
- Fall back to cached `/index.html` when navigation requests fail.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf8522e1883278eedbef2340625a9