### PR TITLE
feat: precache game assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "sitemap": "node tools/generate-sitemap.mjs"
+    "sitemap": "node tools/generate-sitemap.mjs",
+    "sw-manifest": "node tools/generate-sw-manifest.mjs"
   },
   "devDependencies": {
     "jsdom": "^24.0.0",

--- a/precache-manifest.js
+++ b/precache-manifest.js
@@ -1,0 +1,23 @@
+self.__PRECACHE_MANIFEST = [
+  "/games/asteroids/index.html",
+  "/games/asteroids/main.js",
+  "/games/asteroids/thumb.png",
+  "/games/box3d/index.html",
+  "/games/box3d/main.js",
+  "/games/box3d/thumb.png",
+  "/games/maze3d/index.html",
+  "/games/maze3d/main.js",
+  "/games/maze3d/thumb.png",
+  "/games/platformer/index.html",
+  "/games/platformer/main.js",
+  "/games/platformer/thumb.png",
+  "/games/pong/index.html",
+  "/games/pong/main.js",
+  "/games/pong/thumb.png",
+  "/games/runner/index.html",
+  "/games/runner/main.js",
+  "/games/runner/thumb.png",
+  "/games/shooter/index.html",
+  "/games/shooter/main.js",
+  "/games/shooter/thumb.png"
+];

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,16 @@ const CACHE_VERSION = 'fresh-v1';
 const PRECACHE = `precache-${CACHE_VERSION}`;
 const RUNTIME = `runtime-${CACHE_VERSION}`;
 
-const PRECACHE_URLS = ['/', '/index.html', '/styles.css', '/games.json'];
+importScripts('/precache-manifest.js');
+
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/games.json',
+  '/precache-manifest.js',
+  ...(self.__PRECACHE_MANIFEST || []),
+];
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {
@@ -46,9 +55,9 @@ self.addEventListener('fetch', event => {
 });
 
 async function cacheFirst(request) {
-  const cache = await caches.open(RUNTIME);
-  const cached = await cache.match(request);
+  const cached = await caches.match(request);
   if (cached) return cached;
+  const cache = await caches.open(RUNTIME);
   const resp = await fetch(request);
   cache.put(request, resp.clone());
   return resp;
@@ -61,9 +70,8 @@ async function networkFirst(request) {
     cache.put(request, resp.clone());
     return resp;
   } catch {
-    const cached = await cache.match(request);
+    const cached = await caches.match(request);
     if (cached) return cached;
-    if (typeof request === 'string') return caches.match(request);
     return Response.error();
   }
 }

--- a/tests/sw.test.js
+++ b/tests/sw.test.js
@@ -11,6 +11,9 @@ describe('service worker cache management', () => {
     self.clients = {
       claim: () => Promise.resolve(),
     };
+    self.__PRECACHE_MANIFEST = ['/games/asteroids/index.html'];
+    self.importScripts = () => {};
+    self.fetch = global.fetch = () => Promise.resolve(new Response(''));
   });
 
   it('removes outdated caches on activate', async () => {
@@ -30,5 +33,12 @@ describe('service worker cache management', () => {
 
     const keys = await caches.keys();
     expect(keys.sort()).toEqual([PRECACHE, RUNTIME].sort());
+  });
+
+  it('pre-caches manifest assets on install', async () => {
+    await import('../sw.js?cache-bust=' + Date.now());
+    await self.trigger('install');
+    const cached = await caches.match('/games/asteroids/index.html');
+    expect(cached).toBeDefined();
   });
 });

--- a/tools/generate-sw-manifest.mjs
+++ b/tools/generate-sw-manifest.mjs
@@ -1,0 +1,31 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const gamesDir = path.join(root, 'games');
+const exts = new Set(['.js', '.css', '.png', '.jpg', '.jpeg', '.gif', '.svg']);
+
+async function main() {
+  const games = await fs.readdir(gamesDir);
+  const files = [];
+  for (const game of games) {
+    const dirPath = path.join(gamesDir, game);
+    const stat = await fs.stat(dirPath);
+    if (!stat.isDirectory()) continue;
+    const entries = await fs.readdir(dirPath);
+    for (const entry of entries) {
+      const ext = path.extname(entry);
+      if (entry === 'index.html' || exts.has(ext)) {
+        files.push('/' + path.posix.join('games', game, entry));
+      }
+    }
+  }
+  files.sort();
+  const out = `self.__PRECACHE_MANIFEST = ${JSON.stringify(files, null, 2)};\n`;
+  await fs.writeFile(path.join(root, 'precache-manifest.js'), out);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- precache each game's HTML, scripts, and images via build-generated manifest
- serve cached assets when offline
- add build script and tests to keep manifest in sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfb1616fc832792b03e8ff541a748