### PR TITLE
Add basic i18n support with language selector

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Achievements</title>
+  <title data-i18n="achievementsTitle">Achievements</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>
@@ -16,13 +16,15 @@
 </head>
 <body>
   <main>
-    <h1>Achievements</h1>
+    <h1 data-i18n="achievementsTitle">Achievements</h1>
     <div id="achList" class="ach-list"></div>
   </main>
   <script type="module">
     import { getAchievements } from './shared/achievements.js';
     import { applyTheme, injectBackButton } from './shared/ui.js';
+    import { initI18n } from './shared/i18n.js';
     applyTheme();
+    initI18n();
     injectBackButton('./');
     const list = document.getElementById('achList');
     const achs = getAchievements();

--- a/cabinet.html
+++ b/cabinet.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Gurjot's Games Cabinet Mode</title>
+  <title data-i18n="cabinetTitle">Gurjot's Games Cabinet Mode</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>
@@ -16,18 +16,21 @@
 <body>
   <div class="wrap">
     <header class="site-header">
-      <strong>Cabinet Mode</strong>
+      <strong data-i18n="cabinetMode">Cabinet Mode</strong>
       <span id="label" class="muted" style="margin-left:auto"></span>
-      <button id="fsBtn" class="btn">⛶ Fullscreen</button>
-      <button id="startBtn" class="btn">▶️ Start</button>
-      <button id="stopBtn" class="btn">⏸️ Stop</button>
+      <select id="langSelect" style="margin-left:8px"><option value="en">EN</option><option value="es">ES</option></select>
+      <button id="fsBtn" class="btn" data-i18n="fullscreen">⛶ Fullscreen</button>
+      <button id="startBtn" class="btn" data-i18n="start">▶️ Start</button>
+      <button id="stopBtn" class="btn" data-i18n="stop">⏸️ Stop</button>
     </header>
     <iframe id="view" title="Game view"></iframe>
   </div>
 
   <script type="module">
     import { applyTheme, currentTheme } from './shared/themes.js';
+    import { initI18n } from './shared/i18n.js';
     applyTheme(currentTheme());
+    initI18n();
 
     const ROTATE_MS = 60000; // 60 seconds
     const frame = document.getElementById('view');

--- a/game.html
+++ b/game.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Game</title>
+  <title data-i18n="genericGame">Game</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>
@@ -16,43 +16,48 @@
   </style>
 </head>
 <body>
-  <header class="site-header" style="display:flex;align-items:center;gap:12px">
-    <a class="btn" href="./index.html">← Back</a>
-    <h1 id="pageTitle" style="margin:0;font-size:1.5rem">Game</h1>
+  <header class="site-header" style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+    <div style="display:flex;align-items:center;gap:12px">
+      <a class="btn" href="./index.html" data-i18n="back">← Back</a>
+      <h1 id="pageTitle" style="margin:0;font-size:1.5rem" data-i18n="genericGame">Game</h1>
+    </div>
+    <select id="langSelect"><option value="en">EN</option><option value="es">ES</option></select>
   </header>
 
   <main style="max-width:1100px;margin:0 auto;padding:16px">
     <section id="hero"></section>
     <section id="details" class="row">
-      <h2>Description</h2>
+      <h2 data-i18n="description">Description</h2>
       <p id="blurb"></p>
-      <h3>Instructions</h3>
+      <h3 data-i18n="instructions">Instructions</h3>
       <pre id="instructions" class="muted" style="white-space:pre-wrap"></pre>
-      <h3>Controls</h3>
+      <h3 data-i18n="controls">Controls</h3>
       <p id="controls" class="muted"></p>
     </section>
     <section id="leaderboardSection" class="row">
-      <h2>Local Leaderboard</h2>
+      <h2 data-i18n="localLeaderboard">Local Leaderboard</h2>
       <div id="leaderboard"></div>
     </section>
     <section id="relatedSection" class="row">
-      <h2>Related Games</h2>
+      <h2 data-i18n="relatedGames">Related Games</h2>
       <div class="cards" id="relatedCards"></div>
     </section>
   </main>
 
-  <footer class="site-footer"><small>Game details • Data from games.json</small></footer>
+  <footer class="site-footer"><small data-i18n="footerGame">Game details • Data from games.json</small></footer>
 
   <script type="module">
     import { applyTheme, getBestScore, getLocalLeaderboard } from './shared/ui.js';
+    import { initI18n, t } from './shared/i18n.js';
     applyTheme();
+    initI18n();
 
     const params = new URLSearchParams(location.search);
     const slug = params.get('slug');
     const heroEl = document.getElementById('hero');
     const pageTitle = document.getElementById('pageTitle');
     if (!slug) {
-      heroEl.innerHTML = '<p class="muted">Missing slug.</p>';
+      heroEl.innerHTML = `<p class="muted">${t('missingSlug')}</p>`;
       document.getElementById('details').hidden = true;
       document.getElementById('leaderboardSection').hidden = true;
       document.getElementById('relatedSection').hidden = true;
@@ -69,7 +74,7 @@
         if (!game) throw new Error('not found');
         renderGame(game, games);
       } catch (e) {
-        heroEl.innerHTML = '<p class="muted">Game not found.</p>';
+        heroEl.innerHTML = `<p class="muted">${t('gameNotFound')}</p>`;
         document.getElementById('details').hidden = true;
         document.getElementById('leaderboardSection').hidden = true;
         document.getElementById('relatedSection').hidden = true;
@@ -78,10 +83,10 @@
 
     function card(g){
       const best = getBestScore(g.slug);
-      const bestBadge = Number.isFinite(best) ? `<span class="badge best">Best: ${best}</span>` : '';
+      const bestBadge = Number.isFinite(best) ? `<span class="badge best">${t('best')} ${best}</span>` : '';
       return `
         <a class="card" href="./game.html?slug=${g.slug}">
-          ${g.isNew ? '<span class="ribbon">NEW</span>' : ''}
+          ${g.isNew ? `<span class="ribbon">${t('new')}</span>` : ''}
           ${g.thumb ? `<img src="${g.thumb}" alt="${g.title||g.slug} thumbnail" loading="lazy" onerror="this.remove()">` : ''}
           <div class="meta">
             <div class="title">${g.title||g.slug} ${g.badge?`<span class="badge">${g.badge}</span>`:''} ${bestBadge}</div>
@@ -101,17 +106,17 @@
         <div class="info">
           <h2>${game.title} ${game.badge?`<span class=\"badge\">${game.badge}</span>`:''}</h2>
           <div class="tags">${(game.tags||[]).map(t=>`<span>${t}</span>`).join('')}</div>
-          <div id="heroBest" class="muted" style="margin-top:8px">${Number.isFinite(best)?`Best score: ${best}`:''}</div>
-          <div class="actions"><a class="btn" id="playBtn" href="${playHref}">▶️ Play</a></div>
+          <div id="heroBest" class="muted" style="margin-top:8px">${Number.isFinite(best)?`${t('bestScore')} ${best}`:''}</div>
+          <div class="actions"><a class="btn" id="playBtn" href="${playHref}">${t('play')}</a></div>
         </div>`;
       document.getElementById('blurb').textContent = game.blurb || '';
 
       // Load instructions if available
       try {
         const r = await fetch(`${playHref}README.txt`);
-        document.getElementById('instructions').textContent = r.ok ? await r.text() : 'No detailed instructions.';
+        document.getElementById('instructions').textContent = r.ok ? await r.text() : t('noDetailedInstructions');
       } catch {
-        document.getElementById('instructions').textContent = 'No detailed instructions.';
+        document.getElementById('instructions').textContent = t('noDetailedInstructions');
       }
 
       // Detect controls heuristically
@@ -126,12 +131,12 @@
           if (/Enter/.test(txt)) controls.push('Enter');
         }
       } catch {}
-      document.getElementById('controls').textContent = controls.length ? controls.join(', ') : 'Unknown';
+      document.getElementById('controls').textContent = controls.length ? controls.join(', ') : t('unknown');
 
       // Leaderboard
       const board = getLocalLeaderboard(slug);
       const lbEl = document.getElementById('leaderboard');
-      lbEl.innerHTML = board.length ? `<ol>${board.map(e=>`<li>${e.name}: ${e.score}</li>`).join('')}</ol>` : '<p class="muted">No scores yet.</p>';
+      lbEl.innerHTML = board.length ? `<ol>${board.map(e=>`<li>${e.name}: ${e.score}</li>`).join('')}</ol>` : `<p class="muted">${t('noScoresYet')}</p>`;
 
       // Related games
       const related = allGames.filter(g => g.slug !== game.slug && g.tags && game.tags && g.tags.some(t => game.tags.includes(t)));

--- a/index.html
+++ b/index.html
@@ -3,52 +3,55 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Arcade Hub</title>
+  <title data-i18n="siteTitle">Arcade Hub</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
 </head>
 <body>
   <header class="site-header" style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px">
-    <h1 style="margin:0">Arcade Hub</h1>
+    <h1 style="margin:0" data-i18n="siteTitle">Arcade Hub</h1>
       <nav style="display:flex;gap:8px;align-items:center">
-        <a class="btn" href="./stats.html">📈 Stats</a>
-        <a class="btn" href="./quests.html">🗺️ Quests</a>
-        <a class="btn" href="./cabinet.html">🕹️ Cabinet</a>
+        <a class="btn" href="./stats.html" data-i18n="navStats">📈 Stats</a>
+        <a class="btn" href="./quests.html" data-i18n="navQuests">🗺️ Quests</a>
+        <a class="btn" href="./cabinet.html" data-i18n="navCabinet">🕹️ Cabinet</a>
+        <select id="langSelect" style="margin-left:8px"><option value="en">EN</option><option value="es">ES</option></select>
         <div id="themeChips" style="display:flex;gap:8px"></div>
       </nav>
     </header>
 
   <main style="max-width:1100px;margin:0 auto;padding:16px">
     <section id="recently" class="row" hidden>
-      <h2>Recently Played</h2>
+      <h2 data-i18n="recentlyPlayed">Recently Played</h2>
       <div class="cards" id="recently-cards"></div>
     </section>
 
     <div id="filterBar" style="display:flex;flex-direction:column;gap:8px;margin:24px 0">
-      <input type="search" id="searchInput" placeholder="Search games..." />
+      <input type="search" id="searchInput" data-i18n="searchPlaceholder" data-i18n-attr="placeholder" />
       <div id="tagFilters" style="display:flex;gap:4px;flex-wrap:wrap"></div>
     </div>
 
     <section id="all" class="row">
-      <h2>All Games</h2>
+      <h2 data-i18n="allGames">All Games</h2>
       <div class="cards" id="all-cards"></div>
-      <p id="emptyState" class="muted" hidden>Couldn't load <code>games.json</code> or it's empty.</p>
+      <p id="emptyState" class="muted" hidden data-i18n="emptyState">Couldn't load games.json or it's empty.</p>
     </section>
   </main>
 
-  <footer class="site-footer"><small>Hub • Data from games.json • Offline via sw.js</small></footer>
+  <footer class="site-footer"><small data-i18n="footerIndex">Hub • Data from games.json • Offline via sw.js</small></footer>
 
   <script type="module">
     import { getLastPlayed, getBestScore, filterGames } from './shared/ui.js';
     import { getUnlocks, currentTheme, applyTheme } from './shared/themes.js';
+    import { initI18n, t } from './shared/i18n.js';
 
     applyTheme(currentTheme());
+    initI18n();
 
     function themeChip(name, unlocked, active) {
-      const label = name === 'neon' ? 'Neon' : name === 'retro' ? 'Retro' : 'Minimal';
+      const label = name === 'neon' ? t('themeNeon') : name === 'retro' ? t('themeRetro') : t('themeMinimal');
       const cls = `theme-chip ${active ? 'active' : ''} ${unlocked ? '' : 'locked'}`;
       const lock = unlocked ? '' : '🔒';
-      return `<button class="${cls}" data-skin="${name}" title="${unlocked ? '' : 'Unlock by playing more'}">${lock} ${label}</button>`;
+      return `<button class="${cls}" data-skin="${name}" title="${unlocked ? '' : t('unlockByPlayingMore')}">${lock} ${label}</button>`;
     }
 
     const chipsEl = document.getElementById('themeChips');
@@ -61,7 +64,7 @@
       chipsEl.querySelectorAll('button').forEach(b => {
         b.onclick = () => {
           const skin = b.dataset.skin;
-          if (!getUnlocks()[skin]) return alert('Locked. Play more games to unlock!');
+          if (!getUnlocks()[skin]) return alert(t('lockedPlayMore'));
           applyTheme(skin);
           renderThemeChips();
         };
@@ -78,10 +81,10 @@
 
     function card(g) {
       const best = getBestScore(g.slug);
-      const bestBadge = Number.isFinite(best) ? `<span class="badge best">Best: ${best}</span>` : '';
+      const bestBadge = Number.isFinite(best) ? `<span class="badge best">${t('best')} ${best}</span>` : '';
       return `
       <a class="card" href="${(g.path || `./games/${g.slug}/`).replace(/\\?.*$/, '')}">
-        ${g.isNew ? '<span class="ribbon">NEW</span>' : ''}
+        ${g.isNew ? `<span class="ribbon">${t('new')}</span>` : ''}
         ${g.thumb ? `<img src="${g.thumb}" alt="${g.title || g.slug} thumbnail" loading="lazy" onerror="this.remove()">` : ''}
         <div class="meta">
           <div class="title">${g.title || g.slug} ${g.badge ? `<span class="badge">${g.badge}</span>` : ''} ${bestBadge}</div>

--- a/quests.html
+++ b/quests.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Quests</title>
+  <title data-i18n="questsTitle">Quests</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>
@@ -12,35 +12,38 @@
 </head>
 <body>
   <header class="site-header" style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px">
-    <h1 style="margin:0">🗺️ Quests</h1>
+    <h1 style="margin:0">🗺️ <span data-i18n="questsTitle">Quests</span></h1>
     <nav style="display:flex;gap:8px;align-items:center">
-      <a class="btn" href="./index.html">← Back</a>
+      <a class="btn" href="./index.html" data-i18n="back">← Back</a>
+      <select id="langSelect"><option value="en">EN</option><option value="es">ES</option></select>
     </nav>
   </header>
 
   <main style="max-width:1100px;margin:0 auto;padding:16px">
     <section>
-      <h2>Daily Quests</h2>
+      <h2 data-i18n="dailyQuests">Daily Quests</h2>
       <ul id="daily"></ul>
     </section>
     <section>
-      <h2>Weekly Quests</h2>
+      <h2 data-i18n="weeklyQuests">Weekly Quests</h2>
       <ul id="weekly"></ul>
     </section>
-    <p>Total XP: <span id="xp">0</span></p>
+    <p><span data-i18n="totalXP">Total XP:</span> <span id="xp">0</span></p>
   </main>
 
   <script type="module">
     import { getActiveQuests, getXP } from './shared/quests.js';
     import { applyTheme, currentTheme } from './shared/themes.js';
+    import { initI18n, t } from './shared/i18n.js';
     applyTheme(currentTheme());
+    initI18n();
 
     function render(){
       const { daily, weekly } = getActiveQuests();
       const dailyEl = document.getElementById('daily');
       const weeklyEl = document.getElementById('weekly');
-      dailyEl.innerHTML = daily.map(q => `<li>${q.description} — ${q.progress}/${q.goal} XP:${q.xp} ${q.completed ? '✔' : ''}</li>`).join('');
-      weeklyEl.innerHTML = weekly.map(q => `<li>${q.description} — ${q.progress}/${q.goal} XP:${q.xp} ${q.completed ? '✔' : ''}</li>`).join('');
+      dailyEl.innerHTML = daily.map(q => `<li>${q.description} — ${q.progress}/${q.goal} ${t('xp')}:${q.xp} ${q.completed ? '✔' : ''}</li>`).join('');
+      weeklyEl.innerHTML = weekly.map(q => `<li>${q.description} — ${q.progress}/${q.goal} ${t('xp')}:${q.xp} ${q.completed ? '✔' : ''}</li>`).join('');
       document.getElementById('xp').textContent = getXP();
     }
 

--- a/shared/i18n.js
+++ b/shared/i18n.js
@@ -1,0 +1,158 @@
+const dictionaries = {
+  en: {
+    siteTitle: 'Arcade Hub',
+    navStats: '📈 Stats',
+    navQuests: '🗺️ Quests',
+    navCabinet: '🕹️ Cabinet',
+    recentlyPlayed: 'Recently Played',
+    allGames: 'All Games',
+    searchPlaceholder: 'Search games...',
+    emptyState: "Couldn't load games.json or it's empty.",
+    footerIndex: 'Hub • Data from games.json • Offline via sw.js',
+    back: '← Back',
+    description: 'Description',
+    instructions: 'Instructions',
+    controls: 'Controls',
+    localLeaderboard: 'Local Leaderboard',
+    relatedGames: 'Related Games',
+    footerGame: 'Game details • Data from games.json',
+    missingSlug: 'Missing slug.',
+    gameNotFound: 'Game not found.',
+    noDetailedInstructions: 'No detailed instructions.',
+    unknown: 'Unknown',
+    noScoresYet: 'No scores yet.',
+    best: 'Best:',
+    bestScore: 'Best score:',
+    play: '▶️ Play',
+    new: 'NEW',
+    unlockByPlayingMore: 'Unlock by playing more',
+    lockedPlayMore: 'Locked. Play more games to unlock!',
+    paused: 'Paused',
+    resume: 'Resume',
+    restart: 'Restart',
+    backToHub: '← Back to Hub',
+    achievementsTitle: 'Achievements',
+    questsTitle: 'Quests',
+    cabinetTitle: "Cabinet Mode",
+    statsTitle: '📈 Stats Dashboard',
+    dailyQuests: 'Daily Quests',
+    weeklyQuests: 'Weekly Quests',
+    totalXP: 'Total XP:',
+    cabinetMode: 'Cabinet Mode',
+    fullscreen: '⛶ Fullscreen',
+    start: '▶️ Start',
+    stop: '⏸️ Stop',
+    timeByGame: 'Time Played by Game',
+    playsByDay: 'Plays per Day (last 14)',
+    totalPlays: 'Total Plays',
+    minutes: 'Minutes',
+    plays: 'Plays',
+    themeNeon: 'Neon',
+    themeRetro: 'Retro',
+    themeMinimal: 'Minimal',
+    genericGame: 'Game',
+    xp: 'XP'
+  },
+  es: {
+    siteTitle: 'Centro Arcade',
+    navStats: '📈 Estadísticas',
+    navQuests: '🗺️ Misiones',
+    navCabinet: '🕹️ Gabinete',
+    recentlyPlayed: 'Jugado Recientemente',
+    allGames: 'Todos los Juegos',
+    searchPlaceholder: 'Buscar juegos...',
+    emptyState: 'No se pudo cargar games.json o está vacío.',
+    footerIndex: 'Centro • Datos de games.json • Offline via sw.js',
+    back: '← Volver',
+    description: 'Descripción',
+    instructions: 'Instrucciones',
+    controls: 'Controles',
+    localLeaderboard: 'Tabla Local',
+    relatedGames: 'Juegos Relacionados',
+    footerGame: 'Detalles del juego • Datos de games.json',
+    missingSlug: 'Falta slug.',
+    gameNotFound: 'Juego no encontrado.',
+    noDetailedInstructions: 'No hay instrucciones detalladas.',
+    unknown: 'Desconocido',
+    noScoresYet: 'Sin puntuaciones.',
+    best: 'Mejor:',
+    bestScore: 'Mejor puntuación:',
+    play: '▶️ Jugar',
+    new: 'NUEVO',
+    unlockByPlayingMore: 'Desbloquea jugando más',
+    lockedPlayMore: 'Bloqueado. ¡Juega más para desbloquear!',
+    paused: 'Pausado',
+    resume: 'Continuar',
+    restart: 'Reiniciar',
+    backToHub: '← Volver al Hub',
+    achievementsTitle: 'Logros',
+    questsTitle: 'Misiones',
+    cabinetTitle: 'Modo Gabinete',
+    statsTitle: '📈 Panel de Estadísticas',
+    dailyQuests: 'Misiones Diarias',
+    weeklyQuests: 'Misiones Semanales',
+    totalXP: 'XP Total:',
+    cabinetMode: 'Modo Gabinete',
+    fullscreen: '⛶ Pantalla completa',
+    start: '▶️ Iniciar',
+    stop: '⏸️ Detener',
+    timeByGame: 'Tiempo Jugado por Juego',
+    playsByDay: 'Partidas por Día (últimos 14)',
+    totalPlays: 'Partidas Totales',
+    minutes: 'Minutos',
+    plays: 'Partidas',
+    themeNeon: 'Neón',
+    themeRetro: 'Retro',
+    themeMinimal: 'Minimal',
+    genericGame: 'Juego',
+    xp: 'XP'
+  }
+};
+
+const defaultLang = 'en';
+
+export function getLang() {
+  try {
+    return localStorage.getItem('lang') || defaultLang;
+  } catch {
+    return defaultLang;
+  }
+}
+
+export function t(key) {
+  const lang = getLang();
+  return dictionaries[lang]?.[key] ?? dictionaries[defaultLang]?.[key] ?? key;
+}
+
+export function translatePage(root = document) {
+  root.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    const attr = el.getAttribute('data-i18n-attr');
+    const val = t(key);
+    if (attr) el.setAttribute(attr, val);
+    else el.textContent = val;
+  });
+}
+
+export function initI18n() {
+  translatePage();
+  document.documentElement.lang = getLang();
+  let sel = document.getElementById('langSelect');
+  if (!sel) {
+    sel = document.createElement('select');
+    sel.id = 'langSelect';
+    sel.innerHTML = `<option value="en">EN</option><option value="es">ES</option>`;
+    sel.style.position = 'fixed';
+    sel.style.top = '10px';
+    sel.style.right = '10px';
+    document.body.appendChild(sel);
+  }
+  sel.value = getLang();
+  sel.addEventListener('change', () => {
+    try { localStorage.setItem('lang', sel.value); } catch {}
+    document.documentElement.lang = getLang();
+    translatePage();
+  });
+}
+
+export { dictionaries };

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -1,4 +1,5 @@
 // Shared UI helpers — fresh build
+import { t } from './i18n.js';
 
 export function applyTheme(theme) {
   let t = theme;
@@ -47,7 +48,7 @@ export function injectBackButton(href = '../../') {
   if (!a) {
     a = document.createElement('a');
     a.className = 'back-to-hub';
-    a.textContent = '← Back to Hub';
+    a.textContent = t('backToHub');
     document.body.appendChild(a);
   }
   a.href = href;
@@ -117,9 +118,9 @@ export function attachPauseOverlay({ onResume, onRestart }) {
   overlay.className = 'pause-overlay hidden';
   overlay.innerHTML = `
     <div class="panel">
-      <h3>Paused</h3>
-      <button id="resumeBtn">Resume</button>
-      <button id="restartBtn">Restart</button>
+      <h3>${t('paused')}</h3>
+      <button id="resumeBtn">${t('resume')}</button>
+      <button id="restartBtn">${t('restart')}</button>
     </div>`;
   document.body.appendChild(overlay);
   const show = () => overlay.classList.remove('hidden');

--- a/stats.html
+++ b/stats.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Gurjot's Games Stats</title>
+  <title data-i18n="statsTitle">Gurjot's Games Stats</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>
@@ -14,17 +14,18 @@
 </head>
 <body>
   <header class="site-header" style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px">
-    <h1 style="margin:0">📈 Stats Dashboard</h1>
+    <h1 style="margin:0" data-i18n="statsTitle">📈 Stats Dashboard</h1>
     <nav style="display:flex;gap:8px;align-items:center">
-      <a class="btn" href="./index.html">← Back</a>
+      <a class="btn" href="./index.html" data-i18n="back">← Back</a>
+      <select id="langSelect"><option value="en">EN</option><option value="es">ES</option></select>
     </nav>
   </header>
 
   <main style="max-width:1100px;margin:0 auto;padding:16px">
     <div class="grid">
-      <div class="card pad"><h3>Time Played by Game</h3><canvas id="timeByGame"></canvas></div>
-      <div class="card pad"><h3>Plays per Day (last 14)</h3><canvas id="playsByDay"></canvas></div>
-      <div class="card pad"><h3>Total Plays</h3><div id="totalPlays" style="font-size:36px;font-weight:700"></div></div>
+      <div class="card pad"><h3 data-i18n="timeByGame">Time Played by Game</h3><canvas id="timeByGame"></canvas></div>
+      <div class="card pad"><h3 data-i18n="playsByDay">Plays per Day (last 14)</h3><canvas id="playsByDay"></canvas></div>
+      <div class="card pad"><h3 data-i18n="totalPlays">Total Plays</h3><div id="totalPlays" style="font-size:36px;font-weight:700"></div></div>
     </div>
   </main>
 
@@ -32,6 +33,8 @@
   <script type="module">
     import { getTimeByGame, getPlaysByDay } from './shared/metrics.js';
     import { totalPlays } from './shared/themes.js';
+    import { initI18n, t } from './shared/i18n.js';
+    initI18n();
 
     // Friendly formatter
     const msToMin = ms => (ms/60000).toFixed(1);
@@ -43,7 +46,7 @@
       type: 'bar',
       data: {
         labels: timeRows.map(r => r.slug),
-        datasets: [{ label: 'Minutes', data: timeRows.map(r => Number(msToMin(r.ms))) }]
+        datasets: [{ label: t('minutes'), data: timeRows.map(r => Number(msToMin(r.ms))) }]
       },
       options: { responsive: true, plugins: { legend: { display: false } } }
     });
@@ -55,7 +58,7 @@
       type: 'line',
       data: {
         labels: dayRows.map(r => r.day),
-        datasets: [{ label: 'Plays', data: dayRows.map(r => r.count) }]
+        datasets: [{ label: t('plays'), data: dayRows.map(r => r.count) }]
       },
       options: { responsive: true }
     });


### PR DESCRIPTION
## Summary
- implement shared i18n module with English and Spanish dictionaries
- translate static text in pages and UI helpers using `t()` and `data-i18n`
- add language selector that stores preference and updates page content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfb23654c8327b51f4466602a2ed6