### PR TITLE
Add score sharing and metadata

### DIFF
--- a/game.html
+++ b/game.html
@@ -6,6 +6,11 @@
   <title>Game</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="stylesheet" href="./styles.themes.css" />
+  <meta name="description" content="" />
+  <meta property="og:title" content="Game" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="" />
+  <meta name="twitter:card" content="summary_large_image" />
   <style>
     #hero { display:flex; flex-wrap:wrap; gap:20px; align-items:flex-start; }
     #hero img { width:300px; max-width:100%; border-radius:12px; border:1px solid var(--border); }
@@ -76,6 +81,17 @@
       }
     }
 
+    function updateMeta(name, content, prop = false){
+      const sel = prop ? `meta[property="${name}"]` : `meta[name="${name}"]`;
+      let el = document.head.querySelector(sel);
+      if (!el){
+        el = document.createElement('meta');
+        if (prop) el.setAttribute('property', name); else el.setAttribute('name', name);
+        document.head.appendChild(el);
+      }
+      el.setAttribute('content', content);
+    }
+
     function card(g){
       const best = getBestScore(g.slug);
       const bestBadge = Number.isFinite(best) ? `<span class="badge best">Best: ${best}</span>` : '';
@@ -94,6 +110,10 @@
     async function renderGame(game, allGames){
       document.title = game.title;
       pageTitle.textContent = game.title;
+      updateMeta('description', game.blurb || '');
+      updateMeta('og:title', game.title, true);
+      updateMeta('og:description', game.blurb || '', true);
+      if (game.thumb) updateMeta('og:image', new URL(game.thumb, location.href).href, true);
       const best = getBestScore(slug);
       const playHref = (game.path || `./games/${game.slug}/`).replace(/\?.*$/, '');
       heroEl.innerHTML = `

--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -21,6 +21,7 @@
     <span class="stat">Wave: <span id="wave">1</span></span>
     <button id="pauseBtn">⏸️</button>
     <button id="restartBtn">⟲</button>
+    <button id="shareBtn" hidden>🔗</button>
     <label>Fire:
       <select id="fireSel">
         <option value="single" selected>Single</option>

--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -1,5 +1,5 @@
 import { keyState } from '../../shared/controls.js';
-import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
+import { attachPauseOverlay, saveBestScore, shareScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
 
@@ -52,6 +52,7 @@ const HUD = {
   wave: document.getElementById('wave'),
   fireSel: document.getElementById('fireSel')
 };
+const shareBtn = document.getElementById('shareBtn');
 
 document.getElementById('pauseBtn').onclick = ()=> pause();
 document.getElementById('restartBtn').onclick = ()=> restart();
@@ -127,6 +128,7 @@ function restart(){
   spawnWave(4);
   updateHUD();
   emitEvent({ type: 'play', slug: 'asteroids' });
+  shareBtn.hidden = true;
 }
 
 function updateHUD(){
@@ -215,6 +217,8 @@ function update(dt){
         saveBestScore('asteroids', score);
         endSessionTimer('asteroids');
         emitEvent({ type: 'game_over', slug: 'asteroids', value: score });
+        shareBtn.hidden = false;
+        shareBtn.onclick = () => shareScore('asteroids', score);
       }
     }
   }

--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -41,7 +41,7 @@
   <div id="info">
     <div><strong>3D Box Playground</strong></div>
     <div>Click to lock pointer. Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Jump: <kbd>Space</kbd> • Reset: <kbd>R</kbd></div>
-    <div>Score: <span id="score">0</span></div>
+    <div>Score: <span id="score">0</span> <button id="shareBtn" style="display:none">Share</button></div>
   </div>
   <input id="tod" type="range" min="0" max="1" step="0.001" value="0.5" />
   <div id="touch">

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -7,7 +7,7 @@ import { ShaderPass } from 'https://unpkg.com/three@0.160.0/examples/jsm/postpro
 import { FXAAShader } from 'https://unpkg.com/three@0.160.0/examples/jsm/shaders/FXAAShader.js';
 import { Sky } from 'https://unpkg.com/three@0.160.0/examples/jsm/objects/Sky.js';
 import { registerSW } from '../../shared/sw.js';
-import { injectBackButton, recordLastPlayed } from '../../shared/ui.js';
+import { injectBackButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 
 registerSW();
@@ -115,6 +115,7 @@ scene.add(pickup);
 
 const scoreEl = document.getElementById('score');
 let score = 0;
+const shareBtn = document.getElementById('shareBtn');
 
 const GRAVITY = -20;
 const ACCEL = 28;
@@ -199,6 +200,8 @@ function update(dt){
     if (pickup && player.position.distanceTo(pickup.position) < 1){
       score++;
       scoreEl.textContent = score;
+      shareBtn.style.display = 'inline-block';
+      shareBtn.onclick = () => shareScore('box3d', score);
       scene.remove(pickup);
       pickup = null;
     }

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -24,6 +24,7 @@
       <div style="margin-top:10px">
         <button id="startBtn" class="btn">Start</button>
         <button id="restartBtn" class="btn" style="display:none">Restart</button>
+        <button id="shareBtn" class="btn" style="display:none">Share</button>
       </div>
     </div>
   </div>

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -1,4 +1,4 @@
-import { recordLastPlayed } from '../../shared/ui.js';
+import { recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 
 recordLastPlayed('maze3d');
@@ -23,6 +23,7 @@ const overlay = document.getElementById('overlay');
 const message = document.getElementById('message');
 const startBtn = document.getElementById('startBtn');
 const restartBtn = document.getElementById('restartBtn');
+const shareBtn = document.getElementById('shareBtn');
 const timeEl = document.getElementById('time');
 const bestEl = document.getElementById('best');
 
@@ -138,6 +139,7 @@ function restart() {
   message.textContent = 'Click Start to play.';
   startBtn.textContent = 'Start';
   restartBtn.style.display = 'none';
+  shareBtn.style.display = 'none';
   overlay.classList.remove('hidden');
 }
 
@@ -168,6 +170,8 @@ function finish(time) {
   message.textContent = `Finished in ${time.toFixed(2)}s`;
   startBtn.textContent = 'Start';
   restartBtn.style.display = 'inline-block';
+  shareBtn.style.display = 'inline-block';
+  shareBtn.onclick = () => shareScore('maze3d', time.toFixed(2));
   overlay.classList.remove('hidden');
   startTime = 0;
   emitEvent({ type: 'game_over', slug: 'maze3d', value: time });

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -28,6 +28,7 @@
     <h2 id="over-title">Game Over</h2>
     <div id="over-info" style="margin-bottom:10px"></div>
     <div class="btn" id="restartBtn">Restart</div>
+    <div class="btn" id="shareBtn" style="margin-top:8px">Share</div>
   </div></div>
   <script type="module" src="./main.js"></script>
 </body>

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1,4 +1,4 @@
-import { recordLastPlayed } from '../../shared/ui.js';
+import { recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 
 recordLastPlayed('platformer');
@@ -46,6 +46,7 @@ addEventListener('keydown', e => {
 addEventListener('keyup', e => keys.set(e.code, false));
 addEventListener('pointerdown', () => { if (state.running) jump(); else restart(); });
 document.getElementById('restartBtn').addEventListener('click', () => restart());
+const shareBtn = document.getElementById('shareBtn');
 
 function jump(){
   if (player.onGround){
@@ -167,6 +168,7 @@ function gameOver(win){
   over.querySelector('#over-title').textContent = win ? 'You Win!' : 'Game Over';
   over.querySelector('#over-info').textContent = `Score: ${state.score} • Best: ${state.hiscore}`;
   over.classList.add('show');
+  shareBtn.onclick = () => shareScore('platformer', state.score);
   emitEvent({ type: 'game_over', slug: 'platformer', value: state.score });
 }
 

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -27,6 +27,7 @@
       <span class="spacer"></span>
       <button id="pauseBtn" class="btn">⏸️ Pause</button>
       <button id="restartBtn" class="btn">⟲ Restart</button>
+      <button id="shareBtn" class="btn" hidden>Share</button>
       <label style="margin-left:8px">Mode:
         <select id="modeSel">
           <option value="ai" selected>Single (vs AI)</option>

--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -1,5 +1,5 @@
 import { createGamepad, keyState } from '../../shared/controls.js';
-import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
+import { attachPauseOverlay, saveBestScore, shareScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
 
@@ -32,6 +32,7 @@ let serveLock = true; // require key to serve
 let statusEl = document.getElementById('status');
 let lScoreEl = document.getElementById('lScore');
 let rScoreEl = document.getElementById('rScore');
+const shareBtn = document.getElementById('shareBtn');
 
 // Inputs
 const keys = keyState();
@@ -109,6 +110,7 @@ function restart(){
   ball = resetBall(1);
   serveLock = true; running = true; status('Press Space/Enter to serve');
   emitEvent({ type: 'play', slug: 'pong' });
+  shareBtn.hidden = true;
 }
 
 // AI behavior
@@ -216,6 +218,8 @@ function score(side){
     saveBestScore('pong', right.score);
     endSessionTimer('pong');
     emitEvent({ type: 'game_over', slug: 'pong', value: { left: left.score, right: right.score } });
+    shareBtn.hidden = false;
+    shareBtn.onclick = () => shareScore('pong', right.score);
   }
 }
 

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -23,6 +23,7 @@
     <span id="score">0</span> m
     <button id="pauseBtn">⏸️</button>
     <button id="restartBtn">⟲</button>
+    <button id="shareBtn" hidden>🔗</button>
     <label>Difficulty:
       <select id="diffSel">
         <option value="easy">Easy</option>

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -1,5 +1,5 @@
 import { keyState } from '../../shared/controls.js';
-import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
+import { attachPauseOverlay, saveBestScore, shareScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
 
@@ -35,6 +35,7 @@ const diffSel=document.getElementById('diffSel');
 diffSel.onchange=()=>{diff=diffSel.value;};
 document.getElementById('pauseBtn').onclick=()=>pause();
 document.getElementById('restartBtn').onclick=()=>restart();
+const shareBtn=document.getElementById('shareBtn');
 const overlay=attachPauseOverlay({onResume:()=>running=true,onRestart:()=>restart()});
 
 // Touch controls
@@ -60,6 +61,7 @@ function restart(){
   score=0;obstacles=[];coins=[];tick=0;running=true;
   speed=diff==='easy'?4:diff==='med'?5:6.5;
   emitEvent({ type: 'play', slug: 'runner' });
+  shareBtn.hidden=true;
 }
 
 // Game loop
@@ -96,6 +98,8 @@ function update(dt){
       saveBestScore('runner',Math.floor(score));
       endSessionTimer('runner');
       emitEvent({ type: 'game_over', slug: 'runner', value: Math.floor(score) });
+      shareBtn.hidden=false;
+      shareBtn.onclick=()=>shareScore('runner',Math.floor(score));
     }
   }
   for(const c of coins){

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -26,6 +26,7 @@
     <h2 id="over-title">Game Over</h2>
     <div id="over-info" style="margin-bottom:10px"></div>
     <div class="btn" id="restartBtn">Restart</div>
+    <div class="btn" id="shareBtn" style="margin-top:8px">Share</div>
   </div></div>
   <script type="module" src="./main.js"></script>
 </body>

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1,4 +1,4 @@
-import { injectBackButton, recordLastPlayed } from '../../shared/ui.js';
+import { injectBackButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 
 const cvs = document.getElementById('game');
@@ -7,6 +7,7 @@ const W = cvs.width, H = cvs.height;
 
 const scoreEl = document.getElementById('score');
 const bestEl  = document.getElementById('best');
+const shareBtn = document.getElementById('shareBtn');
 
 injectBackButton();
 recordLastPlayed('shooter');
@@ -177,6 +178,7 @@ function gameOver(){
   const over = document.getElementById('overlay');
   over.querySelector('#over-info').textContent = `Score: ${state.score} • Best: ${state.hiscore}`;
   over.classList.add('show');
+  shareBtn.onclick = () => shareScore('shooter', state.score);
   emitEvent({ type: 'game_over', slug: 'shooter', value: state.score });
 }
 

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -134,6 +134,27 @@ export function toggleFullscreen(el = document.documentElement) {
   return document.exitFullscreen?.();
 }
 
+export async function shareScore(slug, score) {
+  const url = `${location.origin}/game.html?slug=${encodeURIComponent(slug)}`;
+  let text = `I scored ${score} in ${slug}!`;
+  try {
+    // Attempt to grab a nicer title from games.json
+    const res = await fetch(new URL('../games.json', import.meta.url));
+    const data = await res.json();
+    const game = (data.games || data).find?.(g => g.slug === slug);
+    if (game?.title) text = `I scored ${score} in ${game.title}!`;
+  } catch {}
+  const shareData = { title: 'My High Score', text, url };
+  try {
+    if (navigator.share) {
+      await navigator.share(shareData);
+    } else {
+      await navigator.clipboard?.writeText(`${text} ${url}`);
+      alert('Share link copied to clipboard');
+    }
+  } catch {}
+}
+
 export function filterGames(games, query = '', tags = []) {
   const q = query.trim().toLowerCase();
   const tagSet = tags.map(t => t.toLowerCase());


### PR DESCRIPTION
## Summary
- implement `shareScore` using Web Share API with clipboard fallback
- add Share buttons to game overlays and HUDs for easy sharing
- enhance game detail page with Open Graph metadata for rich link previews

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfb2a21ac83278051d2caee21a6e5