### PR TITLE
Add settings page with customizable controls

### DIFF
--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -1,4 +1,4 @@
-import { keyState } from '../../shared/controls.js';
+import { keyState, getKey } from '../../shared/controls.js';
 import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
@@ -137,8 +137,9 @@ function updateHUD(){
 }
 
 addEventListener('keydown', (e)=>{
-  if (e.key === ' ') fire();
-  if (e.key.toLowerCase() === 'p') pause();
+  const k = e.key.toLowerCase();
+  if (k === getKey('fire')) fire();
+  if (k === getKey('pause')) pause();
 });
 
 // Init
@@ -158,9 +159,9 @@ requestAnimationFrame(loop);
 
 function update(dt){
   // Ship movement
-  if (keys.has('arrowleft')) ship.angle -= 0.07;
-  if (keys.has('arrowright')) ship.angle += 0.07;
-  if (keys.has('arrowup')) {
+  if (keys.has('left')) ship.angle -= 0.07;
+  if (keys.has('right')) ship.angle += 0.07;
+  if (keys.has('up')) {
     ship.vx += Math.cos(ship.angle) * ship.thrust;
     ship.vy += Math.sin(ship.angle) * ship.thrust;
     particles.push({ x: ship.x - Math.cos(ship.angle)*12, y: ship.y - Math.sin(ship.angle)*12, vx: (Math.random()-0.5)*1.5, vy: (Math.random()-0.5)*1.5, life: 18, col: '#6ee7b7' });
@@ -269,7 +270,7 @@ function render(){
   drawShip(ship.x, ship.y, ship.angle, ship.inv>0);
 
   // thrust glow
-  if (keys.has('arrowup')){
+  if (keys.has('up')){
     ctx.globalAlpha = 0.25;
     ctx.beginPath(); ctx.arc(ship.x - Math.cos(ship.angle)*16, ship.y - Math.sin(ship.angle)*16, 10, 0, Math.PI*2); ctx.fill();
     ctx.globalAlpha = 1;

--- a/games/box3d/index.html
+++ b/games/box3d/index.html
@@ -46,12 +46,12 @@
   <input id="tod" type="range" min="0" max="1" step="0.001" value="0.5" />
   <div id="touch">
     <div class="pad">
-      <button class="up" data-k="KeyW">▲</button>
-      <button class="left" data-k="KeyA">◀</button>
-      <button class="down" data-k="KeyS">▼</button>
-      <button class="right" data-k="KeyD">▶</button>
+      <button class="up" data-a="up">▲</button>
+      <button class="left" data-a="left">◀</button>
+      <button class="down" data-a="down">▼</button>
+      <button class="right" data-a="right">▶</button>
     </div>
-    <button class="jump" data-k="Space">⤒</button>
+    <button class="jump" data-a="jump">⤒</button>
   </div>
   <script type="module" src="./main.js"></script>
   <!-- Back to hub button and service worker are injected by main.js -->

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -1,5 +1,6 @@
 import { recordLastPlayed } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
+import { keyState, getKey } from '../../shared/controls.js';
 
 recordLastPlayed('maze3d');
 
@@ -32,13 +33,12 @@ let startTime = 0;
 let best = Number(localStorage.getItem('besttime:maze3d') || 0);
 if (best) bestEl.textContent = best.toFixed(2);
 
-const keys = {};
+const keys = keyState();
 document.addEventListener('keydown', (e) => {
-  keys[e.code] = true;
-  if (e.code === 'KeyP') togglePause();
-  if (e.code === 'KeyR') restart();
+  const k = e.key.toLowerCase();
+  if (k === getKey('pause')) togglePause();
+  if (k === getKey('restart')) restart();
 });
-document.addEventListener('keyup', (e) => { keys[e.code] = false; });
 
 startBtn.addEventListener('click', () => start());
 restartBtn.addEventListener('click', () => restart());
@@ -176,10 +176,10 @@ function finish(time) {
 function update(dt) {
   const speed = 5;
   const prev = controls.getObject().position.clone();
-  if (keys['KeyW']) controls.moveForward(speed * dt);
-  if (keys['KeyS']) controls.moveForward(-speed * dt);
-  if (keys['KeyA']) controls.moveRight(-speed * dt);
-  if (keys['KeyD']) controls.moveRight(speed * dt);
+  if (keys.has('up')) controls.moveForward(speed * dt);
+  if (keys.has('down')) controls.moveForward(-speed * dt);
+  if (keys.has('left')) controls.moveRight(-speed * dt);
+  if (keys.has('right')) controls.moveRight(speed * dt);
 
   const pos = controls.getObject().position;
   pos.y = 1.5;

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1,5 +1,6 @@
 import { recordLastPlayed } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
+import { keyState, getKey } from '../../shared/controls.js';
 
 recordLastPlayed('platformer');
 emitEvent({ type: 'play', slug: 'platformer' });
@@ -36,14 +37,13 @@ const gravity = 2000;
 const jumpV = -900;
 let camX = 0;
 
-const keys = new Map();
+const keys = keyState();
 addEventListener('keydown', e => {
-  keys.set(e.code, true);
-  if (e.code === 'ArrowUp' || e.code === 'Space') jump();
-  if (e.code === 'KeyP') state.running = !state.running;
-  if (e.code === 'KeyR') restart();
+  const k = e.key.toLowerCase();
+  if (k === getKey('jump')) jump();
+  if (k === getKey('pause')) state.running = !state.running;
+  if (k === getKey('restart')) restart();
 });
-addEventListener('keyup', e => keys.set(e.code, false));
 addEventListener('pointerdown', () => { if (state.running) jump(); else restart(); });
 document.getElementById('restartBtn').addEventListener('click', () => restart());
 
@@ -76,8 +76,8 @@ function loop(ts){
 
 function update(dt){
   player.vx = 0;
-  if (keys.get('ArrowLeft'))  player.vx = -moveSpeed;
-  if (keys.get('ArrowRight')) player.vx =  moveSpeed;
+  if (keys.has('left'))  player.vx = -moveSpeed;
+  if (keys.has('right')) player.vx =  moveSpeed;
 
   // horizontal movement
   player.x += player.vx * dt;

--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -1,4 +1,4 @@
-import { createGamepad, keyState } from '../../shared/controls.js';
+import { createGamepad, keyState, getKey } from '../../shared/controls.js';
 import { attachPauseOverlay, saveBestScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
@@ -74,8 +74,8 @@ const overlay = attachPauseOverlay({ onResume: ()=> running=true, onRestart: ()=
 // Keyboard binds
 window.addEventListener('keydown', (e)=>{
   const k = e.key.toLowerCase();
-  if (k === 'p') { pause(); }
-  if (k === ' ' || k === 'enter') { serveLock = false; status(''); }
+  if (k === getKey('pause')) { pause(); }
+  if (k === getKey('serve') || k === 'enter') { serveLock = false; status(''); }
 });
 
 // Audio (synthesized with WebAudio)
@@ -139,13 +139,13 @@ function tick(dt){
   if (!running) return;
   // Move paddles
   if (mode==='p2'){
-    if (keys.has('w')) left.y -= PADDLE.speed;
-    if (keys.has('s')) left.y += PADDLE.speed;
+    if (keys.has('p1up')) left.y -= PADDLE.speed;
+    if (keys.has('p1down')) left.y += PADDLE.speed;
   } else {
     updateAI();
   }
-  if (keys.has('arrowup')) right.y -= PADDLE.speed;
-  if (keys.has('arrowdown')) right.y += PADDLE.speed;
+  if (keys.has('p2up')) right.y -= PADDLE.speed;
+  if (keys.has('p2down')) right.y += PADDLE.speed;
 
   left.y = clamp(left.y, 0, FIELD.h - PADDLE.h);
   right.y = clamp(right.y, 0, FIELD.h - PADDLE.h);

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -83,8 +83,8 @@ function update(dt){
   if(player.y>0){player.y=0;player.vy=0;}
   if(player.sliding>0) player.sliding--;
   // Keys
-  if(keys.has('arrowup')||keys.has(' ')) jump();
-  if(keys.has('arrowdown')) slide();
+  if(keys.has('jump')) jump();
+  if(keys.has('down')) slide();
   // Spawn obstacles/coins
   spawn();
   obstacles.forEach(o=>o.x-=speed); coins.forEach(c=>c.x-=speed);

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1,5 +1,6 @@
 import { injectBackButton, recordLastPlayed } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
+import { keyState, getKey } from '../../shared/controls.js';
 
 const cvs = document.getElementById('game');
 const ctx = cvs.getContext('2d');
@@ -28,8 +29,8 @@ class Player {
     this.speed = 300;
   }
   update(dt, keys){
-    const dirX = (keys.get('KeyD')?1:0) - (keys.get('KeyA')?1:0);
-    const dirY = (keys.get('KeyS')?1:0) - (keys.get('KeyW')?1:0);
+    const dirX = (keys.has('right')?1:0) - (keys.has('left')?1:0);
+    const dirY = (keys.has('down')?1:0) - (keys.has('up')?1:0);
     this.x += dirX * this.speed * dt;
     this.y += dirY * this.speed * dt;
     this.x = Math.max(this.r, Math.min(W - this.r, this.x));
@@ -91,14 +92,13 @@ let bullets = [];
 let enemies = [];
 let spawnTimer = 0;
 
-const keys = new Map();
+const keys = keyState();
 addEventListener('keydown', e => {
-  keys.set(e.code, true);
-  if(e.code === 'Space') fire();
-  if(e.code === 'KeyP') state.running = !state.running;
-  if(e.code === 'KeyR') restart();
+  const k = e.key.toLowerCase();
+  if(k === getKey('fire')) fire();
+  if(k === getKey('pause')) state.running = !state.running;
+  if(k === getKey('restart')) restart();
 });
-addEventListener('keyup', e => keys.set(e.code, false));
 
 document.getElementById('restartBtn').addEventListener('click', () => restart());
 

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Settings</title>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; margin:20px; background:#0e0f12; color:#e6e6e6; }
+    fieldset { margin-bottom:20px; border:1px solid #27314b; border-radius:10px; padding:10px 14px; }
+    legend { padding:0 6px; }
+    label { display:block; margin:8px 0; }
+    input[type=text] { width:120px; }
+    button { padding:6px 12px; border:1px solid #27314b; border-radius:8px; background:#0e1422; color:#cfe6ff; font-weight:600; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <h1>Settings</h1>
+  <form id="settings">
+    <fieldset>
+      <legend>Key Bindings</legend>
+      <label>Move Left <input type="text" name="left" /></label>
+      <label>Move Right <input type="text" name="right" /></label>
+      <label>Move Up <input type="text" name="up" /></label>
+      <label>Move Down <input type="text" name="down" /></label>
+      <label>Jump <input type="text" name="jump" /></label>
+      <label>Fire <input type="text" name="fire" /></label>
+      <label>Pause <input type="text" name="pause" /></label>
+      <label>Restart <input type="text" name="restart" /></label>
+      <label>P1 Up <input type="text" name="p1up" /></label>
+      <label>P1 Down <input type="text" name="p1down" /></label>
+      <label>P2 Up <input type="text" name="p2up" /></label>
+      <label>P2 Down <input type="text" name="p2down" /></label>
+      <label>Serve <input type="text" name="serve" /></label>
+    </fieldset>
+    <fieldset>
+      <legend>Accessibility</legend>
+      <label>Control Sensitivity <input type="range" name="sensitivity" min="1" max="10" value="5" /></label>
+      <label><input type="checkbox" name="reducedMotion" /> Reduced Motion</label>
+    </fieldset>
+    <button type="submit">Save</button>
+  </form>
+  <script type="module">
+    import { loadMappings, saveMappings, reloadMappings } from './shared/controls.js';
+
+    const actions = ['left','right','up','down','jump','fire','pause','restart','p1up','p1down','p2up','p2down','serve'];
+    const form = document.getElementById('settings');
+    const mapping = loadMappings();
+    for (const act of actions) {
+      const input = form.elements[act];
+      input.value = mapping[act] || '';
+      input.addEventListener('keydown', e => {
+        e.preventDefault();
+        input.value = e.key;
+      });
+    }
+    const opts = JSON.parse(localStorage.getItem('accessibility') || '{}');
+    form.sensitivity.value = opts.sensitivity ?? 5;
+    form.reducedMotion.checked = !!opts.reducedMotion;
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const map = {};
+      for (const act of actions) map[act] = form.elements[act].value;
+      saveMappings(map);
+      const acc = { sensitivity: form.sensitivity.value, reducedMotion: form.reducedMotion.checked };
+      localStorage.setItem('accessibility', JSON.stringify(acc));
+      reloadMappings();
+      alert('Settings saved');
+    });
+  </script>
+</body>
+</html>

--- a/shared/controls.js
+++ b/shared/controls.js
@@ -1,4 +1,43 @@
-// Basic controls helpers — fresh build
+// Basic controls helpers — now with user mappings
+
+const DEFAULT_MAPPING = {
+  left: 'arrowleft',
+  right: 'arrowright',
+  up: 'arrowup',
+  down: 'arrowdown',
+  jump: ' ',
+  fire: ' ',
+  pause: 'p',
+  restart: 'r',
+  p1up: 'w',
+  p1down: 's',
+  p2up: 'arrowup',
+  p2down: 'arrowdown',
+  serve: ' '
+};
+
+export function loadMappings() {
+  try {
+    return { ...DEFAULT_MAPPING, ...(JSON.parse(localStorage.getItem('controls')) || {}) };
+  } catch {
+    return { ...DEFAULT_MAPPING };
+  }
+}
+
+let mapping = loadMappings();
+
+export function getKey(action) {
+  return (mapping[action] || action || '').toLowerCase();
+}
+
+export function saveMappings(newMap) {
+  mapping = { ...mapping, ...newMap };
+  localStorage.setItem('controls', JSON.stringify(mapping));
+}
+
+export function reloadMappings() {
+  mapping = loadMappings();
+}
 
 export function keyState() {
   const keys = new Set();
@@ -6,10 +45,15 @@ export function keyState() {
   const up = e => keys.delete(e.key.toLowerCase());
   window.addEventListener('keydown', down);
   window.addEventListener('keyup', up);
-  return { has: k => keys.has(k.toLowerCase()), destroy: () => {
-    window.removeEventListener('keydown', down);
-    window.removeEventListener('keyup', up);
-  }};
+  return {
+    has: a => keys.has(getKey(a)),
+    press: a => keys.add(getKey(a)),
+    release: a => keys.delete(getKey(a)),
+    destroy: () => {
+      window.removeEventListener('keydown', down);
+      window.removeEventListener('keyup', up);
+    }
+  };
 }
 
 export function createGamepad(fn) {

--- a/tests/sw.test.js
+++ b/tests/sw.test.js
@@ -7,7 +7,9 @@ const RUNTIME = `runtime-${CACHE_VERSION}`;
 
 describe('service worker cache management', () => {
   beforeEach(() => {
-    Object.assign(global, makeServiceWorkerEnv());
+    const env = makeServiceWorkerEnv();
+    delete env.navigator;
+    Object.assign(global, env);
     self.clients = {
       claim: () => Promise.resolve(),
     };


### PR DESCRIPTION
## Summary
- add settings page to remap keys and toggle accessibility options
- centralize control mapping in shared/controls.js with localStorage persistence
- update games to use mapped input instead of hardcoded keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adfb2fa7808327a813bb281af19599