### PR TITLE
Show prominent error when games.json fails to load

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,8 +132,11 @@
       renderGames(games);
       renderRows(games);
       setupFilters();
-    } catch {
+    } catch (err) {
+      console.error('Failed to load games.json', err);
       empty.hidden = false;
+      empty.classList.remove('muted');
+      empty.textContent = 'Game list failed to load. Are you running a local server?';
     }
   </script>
 


### PR DESCRIPTION
## Summary
- Reveal a clear message if `games.json` cannot be fetched, hinting at missing local server.
- Log fetch failures to `console.error` for easier debugging.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae00282cb88327bbfb65982b43efc4