### PR TITLE
Show empty state when filters match no games

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,14 @@
     function applyFilter() {
       const query = searchInput.value;
       const selected = [...tagsRoot.querySelectorAll('button.active')].map(b => b.dataset.tag);
-      renderGames(filterGames(games, query, selected));
+      const list = filterGames(games, query, selected);
+      renderGames(list);
+      if (list.length === 0) {
+        empty.textContent = 'No games match your search/filter';
+        empty.hidden = false;
+      } else {
+        empty.hidden = true;
+      }
     }
 
     function setupFilters() {


### PR DESCRIPTION
## Summary
- Display a friendly message when filters/search yield no games
- Hide the empty state when results are present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae002bf9c88327b8537ceb0c204eb1