### PR TITLE
Add touch controls for Snake game

### DIFF
--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -6,15 +6,28 @@
   <title>Snake</title>
   <style>
     html,body { height:100%; margin:0; background:#0b0d12; color:#e6e7ea; font-family: Inter, system-ui, sans-serif; }
-    .wrap { display:grid; place-items:center; height:100%; }
+    .wrap { display:grid; place-items:center; height:calc(100% - 200px); }
     canvas { background:#0f1320; border:1px solid rgba(255,255,255,.08); border-radius:16px; box-shadow: 0 20px 40px rgba(0,0,0,.4); }
     .hud { position: fixed; top:16px; right:16px; background: rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.12); padding:10px 12px; border-radius:12px; }
+    .controls { position:fixed; bottom:16px; left:50%; transform:translateX(-50%); display:grid; grid-template-columns:repeat(3,60px); grid-template-rows:repeat(3,60px); gap:12px; }
+    .controls button { width:60px; height:60px; background:rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.12); color:#e6e7ea; font-size:24px; border-radius:12px; }
+    .controls button:active { background:rgba(255,255,255,0.12); }
+    .controls .up { grid-row:1; grid-column:2; }
+    .controls .left { grid-row:2; grid-column:1; }
+    .controls .down { grid-row:3; grid-column:2; }
+    .controls .right { grid-row:2; grid-column:3; }
   </style>
 </head>
 <body>
   <div class="hud">Arrows / WASD to move • Don’t hit walls or yourself</div>
   <div class="wrap">
     <canvas id="c" width="640" height="640" data-basew="900" data-baseh="600"></canvas>
+  </div>
+  <div class="controls">
+    <button class="up" data-key="arrowup">▲</button>
+    <button class="left" data-key="arrowleft">◀</button>
+    <button class="down" data-key="arrowdown">▼</button>
+    <button class="right" data-key="arrowright">▶</button>
   </div>
   <script src="../../js/injectBackButton.js"></script>
   <script src="../../js/resizeCanvas.global.js"></script>

--- a/games/snake/snake.js
+++ b/games/snake/snake.js
@@ -9,6 +9,17 @@ let food = spawnFood();
 let speedMs = 120;
 let score = 0;
 let dead = false;
+const map = { 'arrowup':{x:0,y:-1}, 'w':{x:0,y:-1},
+              'arrowdown':{x:0,y:1}, 's':{x:0,y:1},
+              'arrowleft':{x:-1,y:0}, 'a':{x:-1,y:0},
+              'arrowright':{x:1,y:0}, 'd':{x:1,y:0} };
+
+function changeDirection(k) {
+  const nd = map[k];
+  if (nd && (nd.x !== -lastDir.x || nd.y !== -lastDir.y)) {
+    dir = nd;
+  }
+}
 
 function spawnFood() {
   while (true) {
@@ -92,17 +103,11 @@ document.addEventListener('keydown', e => {
     food = spawnFood(); speedMs = 120; score = 0; dead = false;
     draw(); setTimeout(tick, speedMs); return;
   }
-  const map = { 'arrowup':{x:0,y:-1}, 'w':{x:0,y:-1},
-                'arrowdown':{x:0,y:1}, 's':{x:0,y:1},
-                'arrowleft':{x:-1,y:0}, 'a':{x:-1,y:0},
-                'arrowright':{x:1,y:0}, 'd':{x:1,y:0} };
-  if (map[k]) {
-    const nd = map[k];
-    // prevent 180 turns in one tick
-    if (nd.x !== -lastDir.x || nd.y !== -lastDir.y) {
-      dir = nd;
-    }
-  }
+  changeDirection(k);
+});
+
+document.querySelectorAll('.controls button').forEach(btn => {
+  btn.addEventListener('click', () => changeDirection(btn.dataset.key));
 });
 
 draw();


### PR DESCRIPTION
## Summary
- Add fixed bottom control pad for Snake with large touch-friendly directional buttons
- Hook control pad buttons into existing movement logic

## Testing
- `npm test` *(fails: service worker cache management > removes outdated caches on activate)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3f4708348327b4b7684b64dad1f8