### PR TITLE
feat: add persistent high score to snake

### DIFF
--- a/games/snake/snake.js
+++ b/games/snake/snake.js
@@ -8,6 +8,7 @@ let snake = [{x:5,y:16},{x:4,y:16},{x:3,y:16}];
 let food = spawnFood();
 let speedMs = 120;
 let score = 0;
+let highScore = parseInt(localStorage.getItem('snakeHighScore')) || 0;
 let dead = false;
 
 function spawnFood() {
@@ -38,6 +39,10 @@ function tick() {
     score++;
     if (speedMs > 60) speedMs -= 3;
     food = spawnFood();
+    if (score > highScore) {
+      highScore = score;
+      localStorage.setItem('snakeHighScore', highScore);
+    }
   } else {
     snake.pop();
   }
@@ -70,7 +75,11 @@ function draw() {
   // HUD
   ctx.fillStyle = '#e6e7ea';
   ctx.font = 'bold 20px Inter, system-ui, sans-serif';
+  ctx.textAlign = 'left';
   ctx.fillText(`Score: ${score}`, 16, 28);
+  ctx.textAlign = 'right';
+  ctx.fillText(`High Score: ${highScore}`, c.width - 16, 28);
+  ctx.textAlign = 'left';
 
   if (dead) {
     ctx.fillStyle = 'rgba(0,0,0,0.6)';


### PR DESCRIPTION
## Summary
- track Snake high score using localStorage
- display high score alongside current score in HUD

## Testing
- `npm test` *(fails: expected [] to deeply equal [ 'precache-fresh-v1', … ])*

------
https://chatgpt.com/codex/tasks/task_e_68ae3f49857c8327a893389f992c21a7