### PR TITLE
Add Chess 3D local scaffold and game listing

### DIFF
--- a/games.json
+++ b/games.json
@@ -9,7 +9,7 @@
       "2D"
     ],
     "new": false,
-    "emoji": "\ud83c\udfd3",
+    "emoji": "🏓",
     "addedAt": "2025-08-20"
   },
   {
@@ -22,7 +22,7 @@
       "2D"
     ],
     "new": true,
-    "emoji": "\ud83d\udc0d",
+    "emoji": "🐍",
     "addedAt": "2025-08-25"
   },
   {
@@ -35,7 +35,7 @@
       "2D"
     ],
     "new": true,
-    "emoji": "\ud83e\udde9",
+    "emoji": "🧩",
     "addedAt": "2025-08-26"
   },
   {
@@ -48,13 +48,23 @@
       "2D"
     ],
     "new": true,
-    "emoji": "\ud83e\uddf1",
+    "emoji": "🧱",
     "addedAt": "2025-08-26"
   },
   {
     "id": "chess",
-    "title": "Chess",
+    "title": "Chess (2D)",
     "path": "games/chess/index.html"
+  },
+  {
+    "id": "chess3d",
+    "title": "Chess 3D (Local)",
+    "path": "games/chess3d/index.html",
+    "new": true,
+    "tags": [
+      "3D",
+      "offline"
+    ]
   },
   {
     "id": "g2048",

--- a/games/chess3d/README.txt
+++ b/games/chess3d/README.txt
@@ -1,0 +1,1 @@
+Chess 3D (Local) is a placeholder for a future three-dimensional chess experience that currently runs only on your machine and does not use online features.

--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Chess 3D (Local)</title>
+  <link rel="stylesheet" href="/css/styles.css" />
+</head>
+<body>
+  <script src="/js/hud.js"></script>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -1,0 +1,4 @@
+console.log('[chess3d] boot');
+const stage=document.createElement('div');
+stage.id='stage';
+document.body.appendChild(stage);


### PR DESCRIPTION
## Summary
- Scaffold new `Chess 3D (Local)` game with basic HTML, boot script and README
- Update `games.json` to rename `Chess` to `Chess (2D)` and add `chess3d` entry

## Testing
- `npm test` *(fails: GG is not defined in pong test; service worker cache mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_68ba6bbd2d408327ae57bbee681d03d7