### PR TITLE
feat(chess3d): add board and coordinate labels

### DIFF
--- a/games/chess3d/board.js
+++ b/games/chess3d/board.js
@@ -1,0 +1,86 @@
+import * as THREE from './lib/three.module.js';
+
+const FILES = 'abcdefgh';
+
+function indexToPosition(file, rank) {
+  return { x: -3.5 + file, z: 3.5 - rank };
+}
+
+export function squareToPosition(square) {
+  const file = FILES.indexOf(square[0].toLowerCase());
+  const rank = parseInt(square[1], 10) - 1;
+  if (file < 0 || rank < 0 || file > 7 || rank > 7) return null;
+  return indexToPosition(file, rank);
+}
+
+export function positionToSquare(x, z) {
+  const file = Math.round(x + 3.5);
+  const rank = Math.round(3.5 - z);
+  if (file < 0 || rank < 0 || file > 7 || rank > 7) return null;
+  return FILES[file] + (rank + 1);
+}
+
+export function createBoard(scene) {
+  const lightMat = new THREE.MeshStandardMaterial({ color: 0xf0d9b5 });
+  const darkMat = new THREE.MeshStandardMaterial({ color: 0xb58863 });
+  const squareGeo = new THREE.BoxGeometry(1, 0.1, 1);
+  squareGeo.translate(0, -0.05, 0);
+
+  const lightMesh = new THREE.InstancedMesh(squareGeo, lightMat, 32);
+  const darkMesh = new THREE.InstancedMesh(squareGeo, darkMat, 32);
+  lightMesh.receiveShadow = true;
+  darkMesh.receiveShadow = true;
+
+  const mat = new THREE.Matrix4();
+  let li = 0;
+  let di = 0;
+  for (let file = 0; file < 8; file++) {
+    for (let rank = 0; rank < 8; rank++) {
+      const { x, z } = indexToPosition(file, rank);
+      mat.makeTranslation(x, 0, z);
+      if ((file + rank) % 2 === 0) {
+        lightMesh.setMatrixAt(li++, mat);
+      } else {
+        darkMesh.setMatrixAt(di++, mat);
+      }
+    }
+  }
+  lightMesh.instanceMatrix.needsUpdate = true;
+  darkMesh.instanceMatrix.needsUpdate = true;
+
+  const group = new THREE.Group();
+  group.add(lightMesh);
+  group.add(darkMesh);
+
+  // Frame
+  const frameShape = new THREE.Shape();
+  frameShape.moveTo(-4.5, -4.5);
+  frameShape.lineTo(4.5, -4.5);
+  frameShape.lineTo(4.5, 4.5);
+  frameShape.lineTo(-4.5, 4.5);
+  frameShape.lineTo(-4.5, -4.5);
+  const hole = new THREE.Path();
+  hole.moveTo(-4, -4);
+  hole.lineTo(4, -4);
+  hole.lineTo(4, 4);
+  hole.lineTo(-4, 4);
+  hole.lineTo(-4, -4);
+  frameShape.holes.push(hole);
+  const extrude = {
+    depth: 0.2,
+    bevelEnabled: true,
+    bevelSegments: 1,
+    bevelSize: 0.05,
+    bevelThickness: 0.05,
+  };
+  const frameGeo = new THREE.ExtrudeGeometry(frameShape, extrude);
+  frameGeo.rotateX(-Math.PI / 2);
+  frameGeo.translate(0, -0.1, 0);
+  const frameMat = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
+  const frameMesh = new THREE.Mesh(frameGeo, frameMat);
+  frameMesh.receiveShadow = true;
+  group.add(frameMesh);
+
+  scene.add(group);
+  return group;
+}

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -1,5 +1,7 @@
 import * as THREE from './lib/three.module.js';
 import { OrbitControls } from './lib/OrbitControls.js';
+import { createBoard } from './board.js';
+import { initCoords, setCoordsVisible } from './ui/coords.js';
 
 console.log('[chess3d] boot');
 
@@ -33,6 +35,15 @@ const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
 dirLight.position.set(5, 10, 7.5);
 dirLight.castShadow = true;
 scene.add(dirLight);
+
+// board
+createBoard(scene);
+
+// coordinate labels
+initCoords(stage);
+setCoordsVisible(true);
+// expose toggle placeholder for future HUD
+window.setCoordsVisible = setCoordsVisible;
 
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;

--- a/games/chess3d/ui/coords.js
+++ b/games/chess3d/ui/coords.js
@@ -1,0 +1,57 @@
+const coords = [];
+let visible = true;
+
+function createLabel(text, styles) {
+  const el = document.createElement('div');
+  el.textContent = text;
+  el.style.position = 'absolute';
+  el.style.fontSize = '12px';
+  el.style.color = '#fff';
+  el.style.pointerEvents = 'none';
+  for (const key in styles) el.style[key] = styles[key];
+  return el;
+}
+
+export function initCoords(container) {
+  const letters = 'ABCDEFGH';
+  for (let i = 0; i < 8; i++) {
+    const left = `${((i + 0.5) / 8) * 100}%`;
+    const bottomLabel = createLabel(letters[i], {
+      bottom: '2px',
+      left,
+      transform: 'translateX(-50%)',
+    });
+    const topLabel = createLabel(letters[i], {
+      top: '2px',
+      left,
+      transform: 'translateX(-50%)',
+    });
+    container.appendChild(bottomLabel);
+    container.appendChild(topLabel);
+    coords.push(bottomLabel, topLabel);
+  }
+  for (let i = 0; i < 8; i++) {
+    const bottom = `${(i / 8) * 100}%`;
+    const leftLabel = createLabel(String(i + 1), {
+      left: '2px',
+      bottom,
+      transform: 'translateY(50%)',
+    });
+    const rightLabel = createLabel(String(i + 1), {
+      right: '2px',
+      bottom,
+      transform: 'translateY(50%)',
+    });
+    container.appendChild(leftLabel);
+    container.appendChild(rightLabel);
+    coords.push(leftLabel, rightLabel);
+  }
+  setCoordsVisible(visible);
+}
+
+export function setCoordsVisible(v) {
+  visible = v;
+  coords.forEach(el => {
+    el.style.display = v ? 'block' : 'none';
+  });
+}


### PR DESCRIPTION
## Summary
- add instanced 3D chess board with square-to-position helpers
- overlay coordinate labels with toggleable visibility
- initialize board and coords in main scene

## Testing
- `npm test` *(fails: ReferenceError: GG is not defined; service worker cache assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6d79b448832799994f5343b9efd1