### PR TITLE
Enhance 3D chess visuals with animations and last-move highlight

### DIFF
--- a/games/chess3d/engine/rules.js
+++ b/games/chess3d/engine/rules.js
@@ -51,3 +51,7 @@ export function inStalemate() {
 export function historySAN() {
   return game?.history() ?? [];
 }
+
+export function history() {
+  return game?.history({ verbose: true }) ?? [];
+}

--- a/games/chess3d/input.js
+++ b/games/chess3d/input.js
@@ -1,7 +1,8 @@
 import * as THREE from './lib/three.module.js';
 import { squareToPosition, positionToSquare } from './board.js';
-import { listPieces, getPieceBySquare, movePiece } from './pieces.js';
+import { listPieces, getPieceBySquare, movePiece, capturePiece } from './pieces.js';
 import { initHighlight } from './ui/highlight.js';
+import { initLastMove } from './ui/lastMove.js';
 import {
   init as initRules,
   getLegalMoves,
@@ -14,6 +15,7 @@ import {
 
 export function initInput({ scene, camera, renderer, controls }) {
   const highlighter = initHighlight(scene);
+  const lastMove = initLastMove(scene);
   const raycaster = new THREE.Raycaster();
   const pointer = new THREE.Vector2();
   const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
@@ -63,10 +65,9 @@ export function initInput({ scene, camera, renderer, controls }) {
       }
       const victim = getPieceBySquare(captureSquare);
       if (victim && victim.color !== selected.color) {
-        victim.mesh.parent.remove(victim.mesh);
-        victim.square = null;
+        capturePiece(victim.id);
       }
-      movePiece(selected.id, result.to, false);
+      movePiece(selected.id, result.to);
       if (result.flags && (result.flags.includes('k') || result.flags.includes('q'))) {
         const rookFrom = result.flags.includes('k')
           ? (selected.color === 'w' ? 'h1' : 'h8')
@@ -75,11 +76,12 @@ export function initInput({ scene, camera, renderer, controls }) {
           ? (selected.color === 'w' ? 'f1' : 'f8')
           : (selected.color === 'w' ? 'd1' : 'd8');
         const rook = getPieceBySquare(rookFrom);
-        if (rook) movePiece(rook.id, rookTo, false);
+        if (rook) movePiece(rook.id, rookTo);
       }
       if (result.promotion) {
         selected.type = result.promotion.toUpperCase();
       }
+      lastMove.fromHistory();
       updateStatus();
     } else {
       movePiece(selected.id, startSquare, false);

--- a/games/chess3d/ui/lastMove.js
+++ b/games/chess3d/ui/lastMove.js
@@ -1,0 +1,46 @@
+import * as THREE from '../lib/three.module.js';
+import { squareToPosition } from '../board.js';
+import { history } from '../engine/rules.js';
+
+export function initLastMove(scene) {
+  const group = new THREE.Group();
+  scene.add(group);
+  let arrow = null;
+
+  function clear() {
+    if (arrow) {
+      group.remove(arrow);
+      arrow = null;
+    }
+  }
+
+  function show(from, to) {
+    clear();
+    if (!from || !to) return;
+    const fromPos = squareToPosition(from);
+    const toPos = squareToPosition(to);
+    if (!fromPos || !toPos) return;
+    const start = new THREE.Vector3(fromPos.x, 0.05, fromPos.z);
+    const end = new THREE.Vector3(toPos.x, 0.05, toPos.z);
+    const dir = end.clone().sub(start);
+    const len = dir.length();
+    arrow = new THREE.ArrowHelper(dir.clone().normalize(), start, len, 0xffff00);
+    arrow.line.material.transparent = true;
+    arrow.line.material.opacity = 0.5;
+    arrow.cone.material.transparent = true;
+    arrow.cone.material.opacity = 0.5;
+    group.add(arrow);
+  }
+
+  function fromHistory() {
+    const moves = history();
+    if (!moves.length) {
+      clear();
+      return;
+    }
+    const last = moves[moves.length - 1];
+    show(last.from, last.to);
+  }
+
+  return { show, fromHistory, clear };
+}


### PR DESCRIPTION
## Summary
- Smoothly animate piece movement with vertical lift-and-drop
- Fade and scale captured pieces before removing them
- Highlight the last move with an arrow using game history

## Testing
- `npm test` *(fails: GG is not defined; expected [] to deeply equal [ 'precache-fresh-v1', … ])*

------
https://chatgpt.com/codex/tasks/task_e_68ba70fd02148327bd005c624f978ac3