### PR TITLE
Add HUD and controls for Chess3D

### DIFF
--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -7,7 +7,6 @@
   <link rel="stylesheet" href="/css/styles.css" />
 </head>
 <body>
-  <script src="/js/hud.js"></script>
   <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/games/chess3d/pieces.js
+++ b/games/chess3d/pieces.js
@@ -303,5 +303,15 @@ export function capturePiece(id, animate = true) {
   }
 }
 
+export function resetPieces(scene) {
+  pieces.forEach(p => {
+    p.mesh.parent?.remove(p.mesh);
+  });
+  pieces.clear();
+  if (boardHelpers) {
+    placeInitialPosition(scene, boardHelpers);
+  }
+}
+
 export { createPiece };
 

--- a/games/chess3d/ui/hud.js
+++ b/games/chess3d/ui/hud.js
@@ -1,0 +1,69 @@
+export function initHUD({ onNewGame, onFlipBoard, onToggleCoords } = {}) {
+  const bar = document.createElement('div');
+  Object.assign(bar.style, {
+    position: 'fixed',
+    top: '12px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: 9999,
+    display: 'flex',
+    gap: '8px',
+    alignItems: 'center',
+    background: 'rgba(0,0,0,0.5)',
+    border: '1px solid rgba(255,255,255,0.18)',
+    borderRadius: '12px',
+    padding: '8px 10px',
+    backdropFilter: 'saturate(140%) blur(8px)',
+  });
+  document.body.appendChild(bar);
+
+  function mk(label) {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    Object.assign(btn.style, {
+      border: '1px solid rgba(255,255,255,0.25)',
+      background: 'rgba(255,255,255,0.08)',
+      color: '#e6e7ea',
+      padding: '6px 10px',
+      borderRadius: '8px',
+      font: '600 13px Inter,system-ui',
+      cursor: 'pointer',
+      touchAction: 'manipulation',
+    });
+    return btn;
+  }
+
+  const newBtn = mk('New Game');
+  newBtn.onclick = () => onNewGame?.();
+
+  const flipBtn = mk('Flip Board');
+  flipBtn.onclick = () => onFlipBoard?.();
+
+  const coordsBtn = mk('Coords');
+  const key = 'chess3d_coords';
+  let coordsVisible = localStorage.getItem(key) !== '0';
+  function applyCoords() {
+    coordsBtn.style.opacity = coordsVisible ? '1' : '0.5';
+    onToggleCoords?.(coordsVisible);
+  }
+  coordsBtn.onclick = () => {
+    coordsVisible = !coordsVisible;
+    localStorage.setItem(key, coordsVisible ? '1' : '0');
+    applyCoords();
+  };
+  applyCoords();
+
+  const status = document.createElement('div');
+  Object.assign(status.style, {
+    marginLeft: '8px',
+    font: '600 13px/1.2 Inter,system-ui',
+    color: '#e6e7ea',
+  });
+  bar.append(newBtn, flipBtn, coordsBtn, status);
+
+  return {
+    setStatus(text) {
+      status.textContent = text;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add modular HUD for Chess3D with New Game, Flip Board and Coords buttons
- Wire main scene to HUD: reset game state, flip camera, toggle coordinates
- Expose status updates and reset handling in input and piece logic

## Testing
- `npm test` *(fails: ReferenceError: GG is not defined; AssertionError: expected [] to deeply equal ['precache-fresh-v1', 'runtime-fresh-v1'])*

------
https://chatgpt.com/codex/tasks/task_e_68ba71db6a688327abbdd0c834cc163c