### PR TITLE
feat: refine chess ai interactions

### DIFF
--- a/games/chess3d/input.js
+++ b/games/chess3d/input.js
@@ -25,6 +25,7 @@ export function initInput({ scene, camera, renderer, controls, onStatus } = {}) 
   let dragging = false;
   let currentMoves = [];
   const statusCb = onStatus;
+  let enabled = true;
 
   function setPointer(event) {
     const rect = renderer.domElement.getBoundingClientRect();
@@ -103,6 +104,7 @@ export function initInput({ scene, camera, renderer, controls, onStatus } = {}) 
   }
 
   function onPointerDown(event) {
+    if (!enabled) return;
     if (selected && event.pointerType !== 'mouse' && !dragging) {
       setPointer(event);
       const { square } = rayToSquare();
@@ -122,14 +124,14 @@ export function initInput({ scene, camera, renderer, controls, onStatus } = {}) 
   }
 
   function onPointerMove(event) {
-    if (!dragging || !selected) return;
+    if (!enabled || !dragging || !selected) return;
     setPointer(event);
     const { position } = rayToSquare();
     selected.mesh.position.set(position.x, 0, position.z);
   }
 
   function onPointerUp(event) {
-    if (!selected) return;
+    if (!enabled || !selected) return;
     if (dragging) {
       setPointer(event);
       const { square } = rayToSquare();
@@ -168,6 +170,10 @@ export function initInput({ scene, camera, renderer, controls, onStatus } = {}) 
   initRules();
   updateStatus();
 
-  return { reset, updateStatus };
+  function setEnabled(v) {
+    enabled = v;
+  }
+
+  return { reset, updateStatus, setEnabled };
 }
 


### PR DESCRIPTION
## Summary
- disable player input while the engine animates its move and show an "Engine thinking…" banner during search
- auto-queen engine promotions and cancel searches on checkmate/stalemate, mode swap or new game
- persist last selected mode/difficulty across sessions

## Testing
- `npm test` *(fails: GG is not defined; expected [] to deeply equal [ 'precache-fresh-v1', …(1) ])*

------
https://chatgpt.com/codex/tasks/task_e_68bb0bbbaffc832799938ce6d09b0cd6