### PR TITLE
Use local Three.js module for Chess 3D controls

### DIFF
--- a/games/chess3d/lib/OrbitControls.js
+++ b/games/chess3d/lib/OrbitControls.js
@@ -9,7 +9,7 @@ import {
 	Plane,
 	Ray,
 	MathUtils
-} from 'three';
+} from './three.module.js';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).


### PR DESCRIPTION
## Summary
- Ensure OrbitControls uses local Three.js module instead of external import

## Testing
- `npm test` *(fails: GG is not defined, expected [] to deeply equal ['precache-fresh-v1', …(1)])*

------
https://chatgpt.com/codex/tasks/task_e_68bb0fedbb4483279fce14b67a7f8c90