### PR TITLE
feat(chess3d): wire chess.js engine

### DIFF
--- a/games/chess3d/engine/rules.js
+++ b/games/chess3d/engine/rules.js
@@ -1,42 +1,31 @@
+import Chess from './chess.min.js';
 
-/**
- * chess.js wrapper (expected at ./chess.min.js). This stub avoids crashes if the vendor file is missing.
- */
-export let ready = false;
-let ChessCtor, game;
+export let ready = true;
+const game = new Chess();
 
-export async function init(){
-  try {
-    const mod = await import('./chess.min.js');
-    ChessCtor = mod.default || mod.Chess || mod;
-    game = new ChessCtor();
-    ready = true;
-  } catch (e){
-    console.warn('[Chess3D] chess.min.js not found; rules will be inert.', e);
-    ready = false;
-  }
+export async function init() {
+  // already initialized; retained for compatibility
 }
 
-export function loadFEN(fen){
-  if (!ready) return;
+export function loadFEN(fen) {
   if (!fen) game.reset();
   else game.load(fen);
 }
 
-export function getLegalMoves(square){
-  if (!ready) return [];
-  return game.moves({ square, verbose:true }).map(m => ({from:m.from,to:m.to,promotion:m.promotion}));
+export function getLegalMoves(square) {
+  return game.moves({ square, verbose: true }).map(m => ({ from: m.from, to: m.to, promotion: m.promotion }));
 }
 
-export function move({from,to,promotion}){
-  if (!ready) return {ok:false};
+export function move({ from, to, promotion }) {
   const res = game.move({ from, to, promotion });
-  return res ? { ok:true, san:res.san, flags:res.flags } : { ok:false };
+  return res ? { ok: true, san: res.san, flags: res.flags } : { ok: false };
 }
 
-export function undo(){ if (ready) game.undo(); }
-export function fen(){ return ready ? game.fen() : 'startpos'; }
-export function turn(){ return ready ? game.turn() : 'w'; }
-export function inCheck(){ return ready ? game.in_check() : false; }
-export function inCheckmate(){ return ready ? game.in_checkmate() : false; }
-export function inStalemate(){ return ready ? game.in_stalemate() : false; }
+export function undo() { game.undo(); }
+export function fen() { return game.fen(); }
+export function turn() { return game.turn(); }
+export function inCheck() { return game.in_check(); }
+export function inCheckmate() { return game.in_checkmate(); }
+export function inStalemate() { return game.in_stalemate(); }
+export function historySAN() { return game.history(); }
+export function history() { return game.history({ verbose: true }); }


### PR DESCRIPTION
## Summary
- Import bundled chess.js engine as an ES module and mark rules as ready
- Provide move generation, history, and check utilities for 3D chess

## Testing
- `npm test` *(fails: GG is not defined; expected [] to deeply equal ['precache-fresh-v1', …(1)])*

------
https://chatgpt.com/codex/tasks/task_e_68bb10c23aac832799b7d2d635d38831