### PR TITLE
feat(chess3d): hook up stockfish AI

### DIFF
--- a/games/chess3d/ai/ai.js
+++ b/games/chess3d/ai/ai.js
@@ -1,32 +1,56 @@
 
 let worker = null;
+let readyPromise = null;
+let currentResolve = null;
+
 export async function initEngine(){
+  if (worker) return readyPromise;
   try{
     const url = new URL('./stockfish.worker.js', import.meta.url);
     worker = new Worker(url, { type: 'module' });
+    readyPromise = new Promise((resolve)=>{
+      const onMsg = (ev)=>{
+        const data = ev.data || {};
+        if (data.type === 'ready'){
+          worker.removeEventListener('message', onMsg);
+          resolve();
+        }
+      };
+      worker.addEventListener('message', onMsg);
+    });
   }catch(e){
     console.warn('[Chess3D] Stockfish worker not found. AI disabled.', e);
     worker = null;
+    readyPromise = Promise.resolve();
   }
+  return readyPromise;
 }
+
 export async function requestBestMove(fen, {depth=10, skill=4}={}){
   if (!worker) return { uci: null };
+  await initEngine();
   return new Promise((resolve) => {
     const onMsg = (ev)=>{
       const data = ev.data || {};
       if (data.type === 'bestmove'){
         worker.removeEventListener('message', onMsg);
+        currentResolve = null;
         resolve({ uci: data.uci });
       }
+    };
+    currentResolve = () => {
+      worker.removeEventListener('message', onMsg);
+      resolve({ uci: null });
     };
     worker.addEventListener('message', onMsg);
     worker.postMessage({ type:'position', fen });
     worker.postMessage({ type:'go', depth, skill });
   });
 }
+
 export function cancel(){
-  if (worker){
-    worker.terminate();
-    worker = null;
-  }
+  if (!worker) return;
+  worker.postMessage({ type:'stop' });
+  if (currentResolve) currentResolve();
+  currentResolve = null;
 }

--- a/games/chess3d/ai/stockfish.worker.js
+++ b/games/chess3d/ai/stockfish.worker.js
@@ -25,5 +25,7 @@ onmessage = (e) => {
     }
     const depth = typeof data.depth === 'number' ? data.depth : '';
     engine.postMessage(`go${depth ? ' depth ' + depth : ''}`);
+  } else if (data.type === 'stop') {
+    engine.postMessage('stop');
   }
 };


### PR DESCRIPTION
## Summary
- integrate real Stockfish worker and wait for ready event
- drive Stockfish for best moves and allow cancelling searches
- wire chess3d main loop to request/cancel AI moves and expose helpers

## Testing
- `npm test` *(fails: GG is not defined; expected [] to deeply equal [ 'precache-fresh-v1', 'runtime-fresh-v1' ])*

------
https://chatgpt.com/codex/tasks/task_e_68bb12c68c2083279c40e3120560ccc0