### PR TITLE
Improve modal accessibility and focus handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -15,8 +15,67 @@ function skeletonCards(n=6){const grid=$("#gamesGrid");grid.innerHTML="";for(let
 function particleBG(){const cvs=document.createElement('canvas');cvs.id='bgParticles';Object.assign(cvs.style,{position:'fixed',inset:0,zIndex:0,pointerEvents:'none'});document.body.prepend(cvs);const ctx=cvs.getContext('2d');let w,h,dpr,dots=[];function resize(){dpr=window.devicePixelRatio||1;w=cvs.width=innerWidth*dpr;h=cvs.height=innerHeight*dpr;cvs.style.width=innerWidth+'px';cvs.style.height=innerHeight+'px';dots=new Array(80).fill(0).map(()=>({x:Math.random()*w,y:Math.random()*h,vx:(Math.random()-.5)*0.4*dpr,vy:(Math.random()-.5)*0.4*dpr,r:(0.6+Math.random()*1.6)*dpr}));}resize();addEventListener('resize',resize);function draw(){ctx.clearRect(0,0,w,h);ctx.fillStyle='rgba(255,255,255,0.15)';dots.forEach(p=>{p.x+=p.vx;p.y+=p.vy;if(p.x<0||p.x>w)p.vx*=-1;if(p.y<0||p.y>h)p.vy*=-1;ctx.beginPath();ctx.arc(p.x,p.y,p.r,0,Math.PI*2);ctx.fill();});requestAnimationFrame(draw);}draw();}
 function getGameMetaText(id){return localStorage.getItem('gg:meta:'+id)||'';}
 function getGameBadges(id){const v=localStorage.getItem('gg:ach:'+id)||'';return v?v.split(',').filter(Boolean):[];}
-function ensureModal(){if($('#playerModal'))return $('#playerModal');const wrap=document.createElement('div');wrap.id='playerModal';Object.assign(wrap.style,{position:'fixed',inset:0,background:'rgba(0,0,0,0.65)',display:'none',alignItems:'center',justifyContent:'center',zIndex:100});const inner=document.createElement('div');Object.assign(inner.style,{width:'min(1000px,94vw)',height:'min(720px,84vh)',borderRadius:'16px',overflow:'hidden',border:'1px solid rgba(255,255,255,0.12)',background:'var(--bg-soft)',position:'relative',boxShadow:'var(--shadow)'});const close=document.createElement('button');close.textContent='✕';Object.assign(close.style,{position:'absolute',top:'8px',right:'8px',zIndex:2,background:'var(--bg)',color:'var(--text)',border:'1px solid var(--card-border)',borderRadius:'10px',padding:'6px 10px',cursor:'pointer'});const frame=document.createElement('iframe');Object.assign(frame,{id:'playerFrame'});Object.assign(frame.style,{width:'100%',height:'100%',border:'0'});close.onclick=()=>{wrap.style.display='none';frame.src='about:blank';};inner.appendChild(close);inner.appendChild(frame);wrap.appendChild(inner);document.body.appendChild(wrap);return wrap;}
-async function playInModal(url,id){const m=ensureModal();const f=$('#playerFrame',m);try{const res=await fetch(url,{method:'HEAD'});if(!res.ok)throw 0;m.style.display='flex';f.src=url;addXP(5);}catch{alert('Game not found. It may be missing or the path is wrong.');}}
+let lastFocus=null;
+function ensureModal(){
+  if($('#playerModal'))return $('#playerModal');
+  const wrap=document.createElement('div');
+  wrap.id='playerModal';
+  wrap.setAttribute('role','dialog');
+  wrap.setAttribute('aria-modal','true');
+  Object.assign(wrap.style,{position:'fixed',inset:0,background:'rgba(0,0,0,0.65)',display:'none',alignItems:'center',justifyContent:'center',zIndex:100});
+  const inner=document.createElement('div');
+  inner.id='playerModalInner';
+  inner.tabIndex=-1;
+  Object.assign(inner.style,{width:'min(1000px,94vw)',height:'min(720px,84vh)',borderRadius:'16px',overflow:'hidden',border:'1px solid rgba(255,255,255,0.12)',background:'var(--bg-soft)',position:'relative',boxShadow:'var(--shadow)'});
+  const close=document.createElement('button');
+  close.textContent='✕';
+  close.setAttribute('aria-label','Close modal');
+  Object.assign(close.style,{position:'absolute',top:'8px',right:'8px',zIndex:2,background:'var(--bg)',color:'var(--text)',border:'1px solid var(--card-border)',borderRadius:'10px',padding:'6px 10px',cursor:'pointer'});
+  const frame=document.createElement('iframe');
+  Object.assign(frame,{id:'playerFrame'});
+  Object.assign(frame.style,{width:'100%',height:'100%',border:'0'});
+  function closeModal(){
+    wrap.style.display='none';
+    frame.src='about:blank';
+    if(lastFocus)lastFocus.focus();
+  }
+  close.onclick=closeModal;
+  wrap.addEventListener('click',e=>{if(e.target===wrap)closeModal();});
+  wrap.addEventListener('keydown',e=>{
+    if(e.key==='Escape'){e.preventDefault();closeModal();}
+    if(e.key==='Tab'){
+      const fcs=$$('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',inner);
+      if(!fcs.length)return;
+      const first=fcs[0],last=fcs[fcs.length-1];
+      if(e.shiftKey){
+        if(document.activeElement===first||document.activeElement===inner){e.preventDefault();last.focus();}
+      }else{
+        if(document.activeElement===last){e.preventDefault();first.focus();}
+      }
+    }
+  });
+  inner.appendChild(close);
+  inner.appendChild(frame);
+  wrap.appendChild(inner);
+  document.body.appendChild(wrap);
+  return wrap;
+}
+async function playInModal(url,id){
+  const m=ensureModal();
+  const f=$('#playerFrame',m);
+  const inner=$('#playerModalInner',m);
+  try{
+    const res=await fetch(url,{method:'HEAD'});
+    if(!res.ok)throw 0;
+    lastFocus=document.activeElement;
+    m.style.display='flex';
+    f.src=url;
+    inner.focus();
+    addXP(5);
+  }catch{
+    alert('Game not found. It may be missing or the path is wrong.');
+  }
+}
 async function shareGame(game){const url=new URL(location.href);url.hash=game.id;const data={title:game.title,text:`Play ${game.title} on Gurjot's Games`,url:url.toString()};try{if(navigator.share){await navigator.share(data);}else{await navigator.clipboard.writeText(data.url);alert('Link copied!');}}catch{}}
 function readStat(){try{return JSON.parse(localStorage.getItem('gg:xp')||'{"xp":0,"plays":0}');}catch{return {xp:0,plays:0};}}
 function addXP(n){const s=readStat();s.xp+=n|0;localStorage.setItem('gg:xp',JSON.stringify(s));}


### PR DESCRIPTION
## Summary
- Add dialog semantics and aria labels to the game modal
- Implement focus trapping, escape/backdrop closing, and focus restoration

## Testing
- `npm test` *(fails: GG is not defined; expected [] to deeply equal [ 'precache-fresh-v1', …(1) ])*

------
https://chatgpt.com/codex/tasks/task_e_68bb349a7bfc8327b68f2d6bc408764b