### PR TITLE
Stack controls vertically on small screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -23,3 +23,4 @@ body.theme-minimal{--bg:#fcfcfe;--bg-soft:#f3f4f7;--text:#0f172a;--muted:#475569
 .skeleton{position:relative;overflow:hidden;background:linear-gradient(90deg,rgba(255,255,255,.05),rgba(255,255,255,.08),rgba(255,255,255,.05));background-size:300% 100%;animation:shimmer 1.5s infinite}@keyframes shimmer{0%{background-position:0% 0}100%{background-position:100% 0}}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
 @media (max-width:640px){.input,.select{padding:14px;border-radius:14px;font-size:1rem}.chip{padding:10px 16px;font-size:.98rem}.btn{padding:12px 14px;font-size:1rem;border-radius:14px}.card{border-radius:20px}.thumb{border-radius:16px}.titles h1{font-size:1.2rem}.titles .tagline{font-size:.95rem}.hero-copy h2{font-size:1.6rem}}
+@media (max-width:500px){.controls{flex-direction:column;align-items:stretch}.controls>*{width:100%}}


### PR DESCRIPTION
## Summary
- add 500px breakpoint to stack control inputs vertically
- make controls full-width to space out search, sort, and theme selectors

## Testing
- `npm test` *(fails: GG is not defined; expected [] to deeply equal [ 'precache-fresh-v1', …(1) ])*

------
https://chatgpt.com/codex/tasks/task_e_68bb4ce88fb48327ac7716b5b93a00b2