### PR TITLE
Use semantic list markup for achievements

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="./styles.themes.css" />
   <style>
     main{max-width:700px;margin:0 auto;padding:16px;}
-    .ach-list{display:flex;flex-direction:column;gap:12px;margin-top:20px;}
+    .ach-list{list-style:none;padding:0;display:flex;flex-direction:column;gap:12px;margin:20px 0 0;}
     .ach-item{display:flex;gap:12px;align-items:center;padding:10px 14px;border:1px solid var(--button-border);background:var(--button-bg);border-radius:8px;opacity:.5;}
     .ach-item.unlocked{opacity:1;}
     .ach-item .icon{font-size:24px;}
@@ -17,7 +17,7 @@
 <body>
   <main>
     <h1 data-i18n="achievementsTitle">Achievements</h1>
-    <div id="achList" class="ach-list"></div>
+    <ul id="achList" class="ach-list" role="list"></ul>
   </main>
   <script type="module">
     import { getAchievements } from './shared/achievements.js';
@@ -29,13 +29,13 @@
     const list = document.getElementById('achList');
     const achs = getAchievements();
     list.innerHTML = achs.map(a => `
-      <div class="ach-item ${a.unlocked ? 'unlocked' : ''}">
+      <li class="ach-item ${a.unlocked ? 'unlocked' : ''}" role="listitem">
         <span class="icon">${a.icon}</span>
         <div>
           <div><strong>${a.title}</strong></div>
           <div class="muted">${a.desc}</div>
         </div>
-      </div>
+      </li>
     `).join('');
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Replace div-based achievement list with `<ul>`/`<li>` semantics
- Add optional ARIA roles for list and list items
- Update CSS to remove default list styling and support list items

## Testing
- `npm test` *(fails: GG is not defined; expected caches to match)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4ecd3e688327ac17710cc4a726f9