### PR TITLE
Detect OS color preference for theme

### DIFF
--- a/shared/themes.js
+++ b/shared/themes.js
@@ -38,5 +38,10 @@ export function applyTheme(name){
 }
 
 export function currentTheme(){
-  return localStorage.getItem(THEME_KEY) || 'minimal';
+  const stored = localStorage.getItem(THEME_KEY);
+  if (stored) return stored;
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const skin = prefersDark ? 'neon' : 'minimal';
+  localStorage.setItem(THEME_KEY, skin);
+  return skin;
 }


### PR DESCRIPTION
## Summary
- Respect OS dark-mode preference when selecting initial theme
- Persist auto-detected theme in `localStorage`

## Testing
- `npm test` *(fails: GG is not defined; expected [] to deeply equal ['precache-fresh-v1', …(1)])*

------
https://chatgpt.com/codex/tasks/task_e_68bb50206ccc8327b1464f5c50fd75b5