### PR TITLE
feat(chess3d): add safe chess rules wrapper

### DIFF
--- a/games/chess3d/engine/rules.js
+++ b/games/chess3d/engine/rules.js
@@ -1,19 +1,24 @@
-import Chess from './chess.min.js';
+import Chess from "./chess.min.js";
 
-export let ready = true;
-const game = new Chess();
+export let ready = false;
+let game;
 
 export async function init() {
-  // already initialized; retained for compatibility
+  game = new Chess();
+  ready = true;
 }
 
-export function loadFEN(fen) {
-  if (!fen) game.reset();
-  else game.load(fen);
+export function loadFEN(fenOrNullToReset) {
+  if (fenOrNullToReset == null) game.reset();
+  else game.load(fenOrNullToReset);
 }
 
 export function getLegalMoves(square) {
-  return game.moves({ square, verbose: true }).map(m => ({ from: m.from, to: m.to, promotion: m.promotion }));
+  return game.moves({ square, verbose: true }).map(m => {
+    const move = { from: m.from, to: m.to };
+    if (m.promotion) move.promotion = m.promotion;
+    return move;
+  });
 }
 
 export function move({ from, to, promotion }) {
@@ -21,11 +26,30 @@ export function move({ from, to, promotion }) {
   return res ? { ok: true, san: res.san, flags: res.flags } : { ok: false };
 }
 
-export function undo() { game.undo(); }
-export function fen() { return game.fen(); }
-export function turn() { return game.turn(); }
-export function inCheck() { return game.in_check(); }
-export function inCheckmate() { return game.in_checkmate(); }
-export function inStalemate() { return game.in_stalemate(); }
-export function historySAN() { return game.history(); }
-export function history() { return game.history({ verbose: true }); }
+export function undo() {
+  game.undo();
+}
+
+export function fen() {
+  return game.fen();
+}
+
+export function turn() {
+  return game.turn();
+}
+
+export function inCheck() {
+  return game.in_check();
+}
+
+export function inCheckmate() {
+  return game.in_checkmate();
+}
+
+export function inStalemate() {
+  return game.in_stalemate();
+}
+
+export function historySAN() {
+  return game.history();
+}


### PR DESCRIPTION
## Summary
- add initialization guard and ready flag for chess engine
- expose wrapper functions for FEN loading, move generation, play, and game state queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb5a904c9c8327ac8b481f77466d6c