### PR TITLE
Add HUD controls and camera flip to Chess3D

### DIFF
--- a/games/chess3d/ui/hud.js
+++ b/games/chess3d/ui/hud.js
@@ -1,23 +1,24 @@
 
-export function mountHUD({ onNew, onFlip, onCoords }){
+export function mountHUD({ onNew, onFlip, onCoords }) {
   const hud = document.getElementById('hud');
   hud.innerHTML = '';
 
   const btnNew = document.createElement('button');
   btnNew.textContent = 'New Game';
-  btnNew.onclick = () => onNew && onNew();
+  if (onNew) btnNew.onclick = onNew;
 
   const btnFlip = document.createElement('button');
   btnFlip.textContent = 'Flip Board';
-  btnFlip.onclick = () => onFlip && onFlip();
+  if (onFlip) btnFlip.onclick = onFlip;
 
   const btnCoords = document.createElement('button');
   btnCoords.textContent = 'Coords';
-  let show = false;
+  let show = localStorage.getItem('chess3d.coords') !== '0';
+  btnCoords.style.opacity = show ? '1' : '0.8';
   btnCoords.onclick = () => {
     show = !show;
     btnCoords.style.opacity = show ? '1' : '0.8';
-    onCoords && onCoords(show);
+    if (onCoords) onCoords(show);
   };
 
   hud.appendChild(btnNew);


### PR DESCRIPTION
## Summary
- Add reusable HUD with New Game, Flip Board, and Coords buttons
- Flip camera with smooth tween for board reversal
- Persist coordinate overlay preference in localStorage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5e4abcec83278f0ffd45cfeb87a6