### PR TITLE
feat(chess3d): add pawn promotion modal and AI promotion parsing

### DIFF
--- a/games/chess3d/ui/promotionModal.js
+++ b/games/chess3d/ui/promotionModal.js
@@ -1,4 +1,6 @@
-export function showPromotionModal(color = 'w') {
+// Simple modal for pawn promotion selection.
+// Returns a Promise resolving to one of 'q', 'r', 'b' or 'n'.
+export function openPromotion(color = 'w') {
   return new Promise((resolve) => {
     const overlay = document.createElement('div');
     Object.assign(overlay.style, {


### PR DESCRIPTION
## Summary
- add `openPromotion` modal for selecting promotion pieces
- hook promotion into 3D chess input handling
- parse AI engine UCI promotion output, defaulting to queen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb680ae6388327a26732af684d3705