### PR TITLE
Add 3D chess theme and camera selectors

### DIFF
--- a/games/chess3d/board.js
+++ b/games/chess3d/board.js
@@ -2,7 +2,13 @@
 /**
  * Creates an 8x8 board at y=0. Provides helpers to map algebraic squares to positions.
  */
+let tiles = [];
+let rim;
+let THREERef;
+
 export async function createBoard(scene, THREE){
+  THREERef = THREE;
+  tiles = [];
   const group = new THREE.Group();
   const tileSize = 1;
   const half = 4 * tileSize;
@@ -18,6 +24,8 @@ export async function createBoard(scene, THREE){
       mesh.receiveShadow = true;
       mesh.position.set(-half + f*tileSize + tileSize/2, 0, -half + r*tileSize + tileSize/2);
       mesh.userData.square = fileRankToSquare(f, r);
+      mesh.userData.isLight = isLight;
+      tiles.push(mesh);
       group.add(mesh);
     }
   }
@@ -25,7 +33,7 @@ export async function createBoard(scene, THREE){
   // simple rim
   const rimGeom = new THREE.BoxGeometry(8*tileSize+0.4, 0.08, 8*tileSize+0.4);
   const rimMat = new THREE.MeshStandardMaterial({ color: 0x2b3140 });
-  const rim = new THREE.Mesh(rimGeom, rimMat);
+  rim = new THREE.Mesh(rimGeom, rimMat);
   rim.position.y = -0.07;
   rim.receiveShadow = true;
   group.add(rim);
@@ -48,6 +56,42 @@ export async function createBoard(scene, THREE){
     }
   };
   return helpers;
+}
+
+export function setBoardTheme(theme){
+  if (!THREERef) return;
+  const T = THREERef;
+  const themes = {
+    wood: {
+      light: 0xdab893,
+      dark: 0x8b5a2b,
+      rim: 0x5a3a22,
+      metalness: 0.2,
+      roughness: 0.8,
+    },
+    marble: {
+      light: 0xffffff,
+      dark: 0xaaaaaa,
+      rim: 0x666666,
+      metalness: 0.1,
+      roughness: 0.5,
+    },
+    neon: {
+      light: 0x00ffcc,
+      dark: 0x003366,
+      rim: 0x000000,
+      metalness: 0.6,
+      roughness: 0.3,
+    }
+  };
+  const cfg = themes[theme] || themes.wood;
+  const lightMat = new T.MeshStandardMaterial({ color: cfg.light, metalness: cfg.metalness, roughness: cfg.roughness });
+  const darkMat = new T.MeshStandardMaterial({ color: cfg.dark, metalness: cfg.metalness, roughness: cfg.roughness });
+  const rimMat = new T.MeshStandardMaterial({ color: cfg.rim, metalness: cfg.metalness, roughness: cfg.roughness });
+  tiles.forEach((tile)=>{
+    tile.material = tile.userData.isLight ? lightMat : darkMat;
+  });
+  if (rim) rim.material = rimMat;
 }
 
 function squareToFileRank(square){

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -5,6 +5,8 @@ import { createPieces, placeInitialPosition, movePieceByUci } from "./pieces.js"
 import { mountHUD } from "./ui/hud.js";
 import { initEngine, requestBestMove, cancel } from "./ai/ai.js";
 import { mountModeBar, getMode, getDifficulty } from "./ui/modeBar.js";
+import { mountThemePicker } from "./ui/themePicker.js";
+import { mountCameraPresets } from "./ui/cameraPresets.js";
 
 console.log('[Chess3D] booting');
 
@@ -196,6 +198,8 @@ async function boot(){
   controls.dampingFactor = 0.08;
   controls.maxPolarAngle = Math.PI * 0.49;
 
+  mountCameraPresets(document.getElementById('hud'), camera, controls);
+
   const amb = new THREE.AmbientLight(0xffffff, 0.5);
   scene.add(amb);
   const dir = new THREE.DirectionalLight(0xffffff, 0.8);
@@ -215,6 +219,7 @@ async function boot(){
   await rules.init();
   await createPieces(scene, THREE, helpers);
   await placeInitialPosition();
+  mountThemePicker(document.getElementById('hud'));
   mountInput({
     THREE,
     scene,

--- a/games/chess3d/pieces.js
+++ b/games/chess3d/pieces.js
@@ -4,6 +4,7 @@
  */
 let THREERef, sceneRef, helpersRef;
 const pieces = new Map(); // id -> {mesh, square, type, color}
+let currentPieceStyle = 'classic';
 
 export async function createPieces(scene, THREE, helpers){
   THREERef = THREE; sceneRef = scene; helpersRef = helpers;
@@ -22,6 +23,7 @@ export async function placeInitialPosition(){
     spawn(back[f],'w', fileRankToSquare(f,0));
     spawn(back[f],'b', fileRankToSquare(f,7));
   }
+  setPieceStyle(currentPieceStyle);
 }
 
 export function listPieces(){
@@ -126,3 +128,22 @@ async function animateTo(mesh, target){
 }
 
 function fileRankToSquare(f,r){ return String.fromCharCode(97+f) + (r+1); }
+
+export function setPieceStyle(style){
+  if (!THREERef) return;
+  currentPieceStyle = style;
+  const T = THREERef;
+  const styles = {
+    classic: (c)=> new T.MeshStandardMaterial({ color: c==='w'?0xeeeeee:0x222222, metalness:0.2, roughness:0.6 }),
+    metal: (c)=> new T.MeshStandardMaterial({ color: c==='w'?0xdddddd:0x333333, metalness:1, roughness:0.2 }),
+    glass: (c)=> new T.MeshPhysicalMaterial({ color: c==='w'?0xffffff:0x444444, metalness:0, roughness:0, transparent:true, opacity:0.4, transmission:1 })
+  };
+  for (const p of pieces.values()){
+    const mat = (styles[style]||styles.classic)(p.color);
+    p.mesh.traverse(ch=>{ if (ch.isMesh) ch.material = mat; });
+  }
+}
+
+export function getPieceStyle(){
+  return currentPieceStyle;
+}

--- a/games/chess3d/ui/cameraPresets.js
+++ b/games/chess3d/ui/cameraPresets.js
@@ -1,0 +1,60 @@
+const CAM_KEY = 'chess3d.cameraPreset';
+
+const presets = {
+  overhead: { pos: [0, 12, 0.01] },
+  angled: { pos: [6, 10, 6] },
+  side: { pos: [10, 6, 0] }
+};
+
+function tweenCamera(camera, controls, pos, instant=false){
+  const [x,y,z] = pos;
+  if (instant){
+    camera.position.set(x,y,z);
+    camera.lookAt(0,0,0);
+    controls?.update();
+    return;
+  }
+  const start = { x: camera.position.x, y: camera.position.y, z: camera.position.z };
+  const end = { x, y, z };
+  const dur = 500;
+  const t0 = performance.now();
+  function step(t){
+    const k = Math.min(1, (t - t0) / dur);
+    camera.position.x = start.x + (end.x - start.x) * k;
+    camera.position.y = start.y + (end.y - start.y) * k;
+    camera.position.z = start.z + (end.z - start.z) * k;
+    camera.lookAt(0,0,0);
+    controls?.update();
+    if (k < 1) requestAnimationFrame(step);
+  }
+  requestAnimationFrame(step);
+}
+
+export function mountCameraPresets(container, camera, controls){
+  const wrap = document.createElement('div');
+  wrap.style.display = 'flex';
+  wrap.style.alignItems = 'center';
+  wrap.style.gap = '8px';
+
+  const lbl = document.createElement('label');
+  lbl.textContent = 'Camera';
+  const select = document.createElement('select');
+  Object.keys(presets).forEach((key)=>{
+    const opt = document.createElement('option');
+    opt.value = key;
+    opt.textContent = key[0].toUpperCase() + key.slice(1);
+    select.appendChild(opt);
+  });
+  select.onchange = ()=>{
+    const val = select.value;
+    localStorage.setItem(CAM_KEY, val);
+    tweenCamera(camera, controls, presets[val].pos);
+  };
+  lbl.appendChild(select);
+  wrap.appendChild(lbl);
+  container.appendChild(wrap);
+
+  const saved = localStorage.getItem(CAM_KEY) || 'angled';
+  select.value = saved;
+  tweenCamera(camera, controls, presets[saved].pos, true);
+}

--- a/games/chess3d/ui/themePicker.js
+++ b/games/chess3d/ui/themePicker.js
@@ -1,0 +1,53 @@
+import { setBoardTheme } from "../board.js";
+import { setPieceStyle, getPieceStyle } from "../pieces.js";
+
+const BOARD_KEY = 'chess3d.boardTheme';
+const PIECE_KEY = 'chess3d.pieceStyle';
+
+export function mountThemePicker(container){
+  const wrap = document.createElement('div');
+  wrap.style.display = 'flex';
+  wrap.style.alignItems = 'center';
+  wrap.style.gap = '8px';
+
+  const boardLabel = document.createElement('label');
+  boardLabel.textContent = 'Board';
+  const boardSelect = document.createElement('select');
+  ['wood','marble','neon'].forEach((t)=>{
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t[0].toUpperCase() + t.slice(1);
+    boardSelect.appendChild(opt);
+  });
+  boardSelect.onchange = ()=>{
+    localStorage.setItem(BOARD_KEY, boardSelect.value);
+    setBoardTheme(boardSelect.value);
+  };
+  boardLabel.appendChild(boardSelect);
+  wrap.appendChild(boardLabel);
+
+  const pieceLabel = document.createElement('label');
+  pieceLabel.textContent = 'Pieces';
+  const pieceSelect = document.createElement('select');
+  ['classic','metal','glass'].forEach((t)=>{
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t[0].toUpperCase() + t.slice(1);
+    pieceSelect.appendChild(opt);
+  });
+  pieceSelect.onchange = ()=>{
+    localStorage.setItem(PIECE_KEY, pieceSelect.value);
+    setPieceStyle(pieceSelect.value);
+  };
+  pieceLabel.appendChild(pieceSelect);
+  wrap.appendChild(pieceLabel);
+
+  container.appendChild(wrap);
+
+  const savedBoard = localStorage.getItem(BOARD_KEY) || 'wood';
+  const savedPieces = localStorage.getItem(PIECE_KEY) || getPieceStyle();
+  boardSelect.value = savedBoard;
+  pieceSelect.value = savedPieces;
+  setBoardTheme(savedBoard);
+  setPieceStyle(savedPieces);
+}


### PR DESCRIPTION
## Summary
- Add board themes (wood, marble, neon) and piece styles (classic, metal, glass)
- Add camera preset selector with tweened transitions and persistence
- Update main loop to mount new UI components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb69b3b14c8327960c2c28c1f417cc