### PR TITLE
Add analysis mode with engine evaluation bar

### DIFF
--- a/games/chess3d/ai/stockfish.worker.js
+++ b/games/chess3d/ai/stockfish.worker.js
@@ -7,6 +7,22 @@ engine.onmessage = (e) => {
     if (line.startsWith('bestmove')) {
       const uci = line.split(' ')[1] ?? null;
       postMessage({ type: 'bestmove', uci: (uci && uci !== '(none)' && uci !== '0000') ? uci : null });
+    } else if (line.startsWith('info')) {
+      const parts = line.split(' ');
+      const depthIdx = parts.indexOf('depth');
+      const scoreIdx = parts.indexOf('score');
+      const pvIdx = parts.indexOf('pv');
+      let cp = null;
+      let mate = null;
+      if (scoreIdx !== -1) {
+        const type = parts[scoreIdx + 1];
+        const val = parseInt(parts[scoreIdx + 2], 10);
+        if (type === 'cp') cp = val;
+        else if (type === 'mate') mate = val;
+      }
+      const depth = depthIdx !== -1 ? parseInt(parts[depthIdx + 1], 10) : undefined;
+      const pv = pvIdx !== -1 ? parts.slice(pvIdx + 1).join(' ') : undefined;
+      postMessage({ type: 'info', depth, cp, mate, pv });
     } else if (line === 'readyok') {
       postMessage({ type: 'ready' });
     }

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -318,6 +318,9 @@ import('./ui/clocks.js').then(({ mountClocks }) => {
       endGame(`${winner} wins on time`);
     },
   });
+  import('./modes/analysis.js').then(({ mountAnalysis }) => {
+    mountAnalysis(document.getElementById('hud'), { clocks });
+  });
 });
 
 import('./ui/movelist.js').then(({ mountMoveList }) => {

--- a/games/chess3d/modes/analysis.js
+++ b/games/chess3d/modes/analysis.js
@@ -1,0 +1,73 @@
+import { evaluate, cancel } from "../ai/ai.js";
+import * as rules from "../engine/rules.js";
+import Chess from "../engine/chess.min.js";
+
+export function mountAnalysis(container,{clocks}={}){
+  const btn=document.createElement('button');
+  btn.textContent='Analysis';
+  btn.style.opacity='0.8';
+  container.appendChild(btn);
+
+  let active=false;
+  let polling=false;
+  let evalUI=null;
+  let paused=false;
+
+  async function ensureUI(){
+    if(evalUI) return evalUI;
+    const { mountEvalBar } = await import('../ui/evalBar.js');
+    evalUI = mountEvalBar(container);
+    evalUI.el.style.display='none';
+    return evalUI;
+  }
+
+  async function start(){
+    await ensureUI();
+    evalUI.el.style.display='';
+    if(clocks && !paused){ clocks.pause(); paused=true; }
+    polling=true;
+    loop();
+  }
+
+  function stop(){
+    polling=false;
+    cancel();
+    if(clocks && paused){ clocks.resume(); paused=false; }
+    if(evalUI) evalUI.el.style.display='none';
+  }
+
+  async function loop(){
+    if(!polling) return;
+    const fen=rules.fen();
+    const info=await evaluate(fen,{depth:12});
+    if(!polling) return;
+    const cp = info.mate!=null ? (info.mate>0?100000:-100000) : info.cp;
+    const san=pvToSan(fen,info.pv);
+    evalUI.update(cp,san);
+    setTimeout(loop,1000);
+  }
+
+  function pvToSan(fen,pv){
+    if(!pv) return '';
+    const moves=pv.trim().split(/\s+/);
+    const chess=new Chess(fen);
+    const sans=[];
+    for(const mv of moves){
+      const from=mv.slice(0,2);
+      const to=mv.slice(2,4);
+      const promotion=mv.length>4?mv.slice(4,5):undefined;
+      const res=chess.move({from,to,promotion});
+      if(!res) break;
+      sans.push(res.san);
+    }
+    return sans.join(' ');
+  }
+
+  btn.onclick=()=>{
+    active=!active;
+    btn.style.opacity=active?'1':'0.8';
+    active?start():stop();
+  };
+
+  return { toggle: ()=>btn.onclick() };
+}

--- a/games/chess3d/ui/evalBar.js
+++ b/games/chess3d/ui/evalBar.js
@@ -1,0 +1,40 @@
+export function mountEvalBar(container){
+  const wrap=document.createElement('div');
+  wrap.style.display='flex';
+  wrap.style.flexDirection='column';
+  wrap.style.alignItems='stretch';
+  wrap.style.gap='4px';
+  wrap.style.width='180px';
+
+  const barOuter=document.createElement('div');
+  barOuter.style.height='12px';
+  barOuter.style.background='#333';
+  barOuter.style.border='1px solid #555';
+  const barInner=document.createElement('div');
+  barInner.style.height='100%';
+  barInner.style.width='50%';
+  barInner.style.background='#fff';
+  barOuter.appendChild(barInner);
+  wrap.appendChild(barOuter);
+
+  const lineEl=document.createElement('div');
+  lineEl.style.fontSize='12px';
+  lineEl.style.minHeight='1.2em';
+  wrap.appendChild(lineEl);
+
+  container.appendChild(wrap);
+
+  function update(scoreCp,lineSan){
+    if(typeof scoreCp==='number'){
+      const max=1000; // centipawns
+      const val=Math.max(-max,Math.min(max,scoreCp));
+      const pct=(val+max)/(2*max)*100;
+      barInner.style.width=pct+'%';
+    }else{
+      barInner.style.width='50%';
+    }
+    lineEl.textContent=lineSan||'';
+  }
+
+  return { update, el: wrap };
+}


### PR DESCRIPTION
## Summary
- Add UI evaluation bar to display engine score and principal variation in Chess3D
- Introduce analysis mode that pauses clocks and polls engine evaluations
- Extend Stockfish worker and AI helper to expose evaluation info
- Hook analysis mode into Chess3D main HUD

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6ec75f088327b9ed9a7a69285ebf