### PR TITLE
feat: add maze3d mini-map toggle and persistent path

### DIFF
--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -15,6 +15,8 @@ const mapRenderer = new THREE.WebGLRenderer({ antialias: false });
 mapRenderer.setSize(200, 200);
 mapRenderer.domElement.style.position='fixed'; mapRenderer.domElement.style.right='12px'; mapRenderer.domElement.style.bottom='12px'; mapRenderer.domElement.style.border='1px solid rgba(255,255,255,0.2)'; mapRenderer.domElement.style.borderRadius='6px';
 document.body.appendChild(mapRenderer.domElement);
+let mapVisible = true;
+mapRenderer.domElement.style.display = 'block';
 
 const hemi = new THREE.HemisphereLight(0xffffff, 0x444444, 0.6);
 scene.add(hemi);
@@ -45,6 +47,7 @@ document.addEventListener('keydown', (e) => {
   keys[e.code] = true;
   if (e.code === 'KeyP') togglePause();
   if (e.code === 'KeyR') restart();
+  if (e.code === 'KeyM' && !e.repeat) toggleMap();
 });
 document.addEventListener('keyup', (e) => { keys[e.code] = false; });
 
@@ -168,6 +171,11 @@ function togglePause() {
   if (paused) start(); else pause();
 }
 
+function toggleMap() {
+  mapVisible = !mapVisible;
+  mapRenderer.domElement.style.display = mapVisible ? 'block' : 'none';
+}
+
 function finish(time) {
   running = false;
   paused = true;
@@ -198,7 +206,10 @@ function update(dt) {
   const pos = controls.getObject().position;
   pos.y = 1.5;
   // breadcrumbs
-  if (!lastTrailPos || pos.distanceTo(lastTrailPos) > 1.5){ trail.push(pos.clone()); lastTrailPos = pos.clone(); if (trail.length>200) trail.shift(); }
+  if (!lastTrailPos || pos.distanceTo(lastTrailPos) > 1.5) {
+    trail.push(pos.clone());
+    lastTrailPos = pos.clone();
+  }
   for (const box of wallBoxes) {
     if (box.containsPoint(pos)) {
       pos.copy(prev);
@@ -221,16 +232,34 @@ function loop() {
     update(dt);
   }
   renderer.render(scene, camera);
-  // render minimap (orthographic top-down)
-  const miniCam = new THREE.OrthographicCamera(-cellSize*MAZE_CELLS*1.2, cellSize*MAZE_CELLS*1.2, cellSize*MAZE_CELLS*1.2, -cellSize*MAZE_CELLS*1.2, 0.1, 1000);
-  miniCam.position.set(0, 80, 0); miniCam.lookAt(new THREE.Vector3(0,0,0));
-  // simple overlay: draw player/trail using 2D context on top of mapRenderer after render
-  mapRenderer.render(scene, miniCam);
-  const ctx2 = mapRenderer.domElement.getContext('2d');
-  ctx2.save(); ctx2.globalAlpha=0.9; ctx2.fillStyle='rgba(255,255,255,0.15)'; ctx2.fillRect(0,0,200,200); ctx2.restore();
-  // trail dots
-  if (trail.length){ ctx2.fillStyle='#38bdf8'; for (const p of trail){ const u=(p.x/(cellSize*MAZE_CELLS*1.2))*100+100; const v=(p.z/(cellSize*MAZE_CELLS*1.2))*100+100; ctx2.fillRect(u-1,v-1,2,2); } }
-  const p = controls.getObject().position; const u=(p.x/(cellSize*MAZE_CELLS*1.2))*100+100; const v=(p.z/(cellSize*MAZE_CELLS*1.2))*100+100; ctx2.fillStyle='#eab308'; ctx2.fillRect(u-2,v-2,4,4);
+  if (mapVisible) {
+    // render minimap (orthographic top-down)
+    const miniCam = new THREE.OrthographicCamera(-cellSize*MAZE_CELLS*1.2, cellSize*MAZE_CELLS*1.2, cellSize*MAZE_CELLS*1.2, -cellSize*MAZE_CELLS*1.2, 0.1, 1000);
+    miniCam.position.set(0, 80, 0);
+    miniCam.lookAt(new THREE.Vector3(0,0,0));
+    // simple overlay: draw player/trail using 2D context on top of mapRenderer after render
+    mapRenderer.render(scene, miniCam);
+    const ctx2 = mapRenderer.domElement.getContext('2d');
+    ctx2.save();
+    ctx2.globalAlpha = 0.9;
+    ctx2.fillStyle = 'rgba(255,255,255,0.15)';
+    ctx2.fillRect(0,0,200,200);
+    ctx2.restore();
+    // trail dots
+    if (trail.length) {
+      ctx2.fillStyle = '#38bdf8';
+      for (const p of trail) {
+        const u = (p.x/(cellSize*MAZE_CELLS*1.2))*100+100;
+        const v = (p.z/(cellSize*MAZE_CELLS*1.2))*100+100;
+        ctx2.fillRect(u-1, v-1, 2, 2);
+      }
+    }
+    const p = controls.getObject().position;
+    const u = (p.x/(cellSize*MAZE_CELLS*1.2))*100+100;
+    const v = (p.z/(cellSize*MAZE_CELLS*1.2))*100+100;
+    ctx2.fillStyle = '#eab308';
+    ctx2.fillRect(u-2, v-2, 4, 4);
+  }
 }
 
 window.addEventListener('resize', () => {


### PR DESCRIPTION
## Summary
- add mini-map overlay toggle via `M` key
- keep full breadcrumb trail to reveal explored paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c485009083279ac570e71aa9b365