### PR TITLE
Add animations and theme toggle to 2048

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -4,7 +4,29 @@ const N=4, S=80, PAD=12;
 const hud=HUD.create({title:'2048', onPauseToggle:()=>{}, onRestart:()=>reset()});
 
 const MAX_UNDO=3;
-const LS_UNDO='g2048.undo', LS_BEST='g2048.best';
+const LS_UNDO='g2048.undo', LS_BEST='g2048.best', LS_THEME='g2048.theme';
+const ANIM_TIME=120;
+
+const themes={
+  light:{
+    boardBg:'#fafafa',
+    empty:'#d1d5db',
+    text:'#111827',
+    tileTextDark:'#111827',
+    tileTextLight:'#f9fafb',
+    tileColors:{2:'#fef9c3',4:'#fde68a',8:'#fbbf24',16:'#f59e0b',32:'#f97316',64:'#ea580c',128:'#d946ef',256:'#a855f7',512:'#8b5cf6',1024:'#6366f1',2048:'#4f46e5',default:'#4338ca'}
+  },
+  dark:{
+    boardBg:'#0f172a',
+    empty:'#111827',
+    text:'#e6e7ea',
+    tileTextDark:'#0b1220',
+    tileTextLight:'#e6e7ea',
+    tileColors:{2:'#eef2ff',4:'#c7d2fe',8:'#a5b4fc',16:'#93c5fd',32:'#60a5fa',64:'#3b82f6',128:'#22d3ee',256:'#14b8a6',512:'#10b981',1024:'#f59e0b',2048:'#ef4444',default:'#7c3aed'}
+  }
+};
+
+let currentTheme=localStorage.getItem(LS_THEME) || 'dark';
 
 let grid, score=0, over=false, won=false, hintDir=null;
 let history=[];
@@ -13,7 +35,20 @@ let best=parseInt(localStorage.getItem(LS_BEST) ?? 0);
 if(isNaN(undoLeft)) undoLeft=MAX_UNDO;
 if(isNaN(best)) best=0;
 
+let animating=false;
+
 function copyGrid(g){ return g.map(r=>r.slice()); }
+
+function applyTheme(){
+  const t=themes[currentTheme];
+  document.body.style.background=currentTheme==='dark'?'#0b1220':'#fafafa';
+  document.body.style.color=t.text;
+  c.style.borderColor=currentTheme==='dark'?'#243047':'#9ca3af';
+  const hintBtn=document.getElementById('hintBtn');
+  const themeBtn=document.getElementById('themeToggle');
+  if(hintBtn){ hintBtn.style.background=t.empty; hintBtn.style.color=t.text; hintBtn.style.borderColor=c.style.borderColor; }
+  if(themeBtn){ themeBtn.style.background=t.empty; themeBtn.style.color=t.text; themeBtn.style.borderColor=c.style.borderColor; themeBtn.textContent=currentTheme==='dark'?'Light':'Dark'; }
+}
 
 function reset(keepUndo=false){
   grid=Array.from({length:N},()=>Array(N).fill(0));
@@ -32,15 +67,6 @@ function addTile(){
   grid[y][x]=Math.random()<0.9?2:4;
 }
 
-function slide(row){
-  const a=row.filter(v=>v);
-  for(let i=0;i<a.length-1;i++){
-    if(a[i]===a[i+1]){ a[i]*=2; score+=a[i]; a.splice(i+1,1); }
-  }
-  while(a.length<N) a.push(0);
-  return a;
-}
-
 function slideSim(row){
   const a=row.filter(v=>v); let gained=0;
   for(let i=0;i<a.length-1;i++){
@@ -56,6 +82,7 @@ function saveState(){
 }
 
 function undoMove(){
+  if(animating) return;
   if(undoLeft>0 && history.length>1){
     history.pop();
     const prev=history[history.length-1];
@@ -66,17 +93,127 @@ function undoMove(){
   }
 }
 
-function move(dir){ //0=left,1=up,2=right,3=down
-  if(over||won) return;
+function computeMove(dir){
+  const after=Array.from({length:N},()=>Array(N).fill(0));
+  const animations=[];
+  let moved=false; let gained=0;
+  if(dir===0){
+    for(let y=0;y<N;y++){
+      let target=0, lastMerge=-1;
+      for(let x=0;x<N;x++){
+        const v=grid[y][x]; if(!v) continue;
+        if(after[y][target]===0){
+          after[y][target]=v;
+          if(target!==x) moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:target,toY:y});
+        }else if(after[y][target]===v && lastMerge!==target){
+          after[y][target]+=v; gained+=after[y][target];
+          lastMerge=target; moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:target,toY:y});
+        }else{
+          target++; after[y][target]=v;
+          if(target!==x) moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:target,toY:y});
+        }
+      }
+    }
+  }else if(dir===2){
+    for(let y=0;y<N;y++){
+      let target=0, lastMerge=-1;
+      for(let x=0;x<N;x++){
+        const v=grid[y][N-1-x]; if(!v) continue;
+        const fromX=N-1-x, toX=N-1-target;
+        if(after[y][toX]===0){
+          after[y][toX]=v;
+          if(fromX!==toX) moved=true;
+          animations.push({value:v,fromX,fromY:y,toX,toY:y});
+        }else if(after[y][toX]===v && lastMerge!==target){
+          after[y][toX]+=v; gained+=after[y][toX];
+          lastMerge=target; moved=true;
+          animations.push({value:v,fromX,fromY:y,toX,toY:y});
+        }else{
+          target++; const nx=N-1-target;
+          after[y][nx]=v;
+          if(fromX!==nx) moved=true;
+          animations.push({value:v,fromX,fromY:y,toX:nx,toY:y});
+        }
+      }
+    }
+  }else if(dir===1){
+    for(let x=0;x<N;x++){
+      let target=0, lastMerge=-1;
+      for(let y=0;y<N;y++){
+        const v=grid[y][x]; if(!v) continue;
+        if(after[target][x]===0){
+          after[target][x]=v;
+          if(target!==y) moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:x,toY:target});
+        }else if(after[target][x]===v && lastMerge!==target){
+          after[target][x]+=v; gained+=after[target][x];
+          lastMerge=target; moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:x,toY:target});
+        }else{
+          target++; after[target][x]=v;
+          if(target!==y) moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:x,toY:target});
+        }
+      }
+    }
+  }else if(dir===3){
+    for(let x=0;x<N;x++){
+      let target=0, lastMerge=-1;
+      for(let y=0;y<N;y++){
+        const v=grid[N-1-y][x]; if(!v) continue;
+        const fromY=N-1-y, toY=N-1-target;
+        if(after[toY][x]===0){
+          after[toY][x]=v;
+          if(fromY!==toY) moved=true;
+          animations.push({value:v,fromX:x,fromY,toX:x,toY});
+        }else if(after[toY][x]===v && lastMerge!==target){
+          after[toY][x]+=v; gained+=after[toY][x];
+          lastMerge=target; moved=true;
+          animations.push({value:v,fromX:x,fromY,toX:x,toY});
+        }else{
+          target++; const ny=N-1-target;
+          after[ny][x]=v;
+          if(fromY!==ny) moved=true;
+          animations.push({value:v,fromX:x,fromY,toX:x,toY:ny});
+        }
+      }
+    }
+  }
+  return {after, animations, moved, gained};
+}
+
+function animateMove(anims, after){
+  animating=true;
+  const base=copyGrid(grid);
+  anims.forEach(a=>{ base[a.fromY][a.fromX]=0; });
+  let start=null;
+  function step(ts){
+    if(start==null) start=ts;
+    const p=Math.min((ts-start)/ANIM_TIME,1);
+    draw({base, tiles:anims, p});
+    if(p<1) requestAnimationFrame(step);
+    else{
+      grid=after;
+      addTile();
+      check();
+      draw();
+      animating=false;
+    }
+  }
+  requestAnimationFrame(step);
+}
+
+function move(dir){
+  if(over||won||animating) return;
   saveState();
-  const before=JSON.stringify(grid);
-  if(dir===0){ for(let y=0;y<N;y++) grid[y]=slide(grid[y]); }
-  if(dir===2){ for(let y=0;y<N;y++) grid[y]=slide(grid[y].reverse()).reverse(); }
-  if(dir===1){ for(let x=0;x<N;x++){ const col=slide([grid[0][x],grid[1][x],grid[2][x],grid[3][x]]); for(let y=0;y<N;y++) grid[y][x]=col[y]; } }
-  if(dir===3){ for(let x=0;x<N;x++){ const col=slide([grid[3][x],grid[2][x],grid[1][x],grid[0][x]]).reverse(); for(let y=0;y<N;y++) grid[y][x]=col[y]; } }
-  if(JSON.stringify(grid)!==before) addTile(); else history.pop();
+  const {after, animations, moved, gained}=computeMove(dir);
+  if(!moved){ history.pop(); return; }
+  score+=gained;
   if(score>best){ best=score; localStorage.setItem(LS_BEST,best); }
-  check(); draw();
+  animateMove(animations, after);
 }
 
 function check(){ won = won || grid.flat().some(v=>v>=2048); over = !won && !canMove(); }
@@ -108,27 +245,66 @@ c.addEventListener('touchend',e=>{
   touchStart=null;
 });
 
-function draw(){
-  ctx.clearRect(0,0,c.width,c.height);
-  ctx.fillStyle='#e6e7ea';
+function draw(anim){
+  const theme=themes[currentTheme];
+  ctx.fillStyle=theme.boardBg;
+  ctx.fillRect(0,0,c.width,c.height);
+  ctx.fillStyle=theme.text;
   ctx.font='16px Inter,system-ui';
   ctx.fillText(`Score: ${score} Best: ${best} Undo:${undoLeft}`,12,20);
+  const base=anim?anim.base:grid;
   for(let y=0;y<N;y++) for(let x=0;x<N;x++){
-    const v=grid[y][x]; const px=PAD + x*(S+10); const py=40 + y*(S+10);
-    ctx.fillStyle=v?tileColor(v):'#111827'; ctx.strokeStyle='#243047'; ctx.lineWidth=1;
+    const v=base[y][x]; const px=PAD + x*(S+10); const py=40 + y*(S+10);
+    ctx.fillStyle=v?tileColor(v):theme.empty; ctx.strokeStyle=c.style.borderColor; ctx.lineWidth=1;
     roundRect(ctx,px,py,S,S,10,true,true);
-    if(v){ ctx.fillStyle=(v<=4)?'#0b1220':'#e6e7ea'; ctx.font=(v<100)?'28px Inter':'24px Inter'; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText(v,px+S/2,py+S/2+2); }
+    if(v){ ctx.fillStyle=(v<=4)?theme.tileTextDark:theme.tileTextLight; ctx.font=(v<100)?'28px Inter':'24px Inter'; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText(v,px+S/2,py+S/2+2); }
+  }
+  if(anim){
+    for(const t of anim.tiles){
+      const px=PAD + (t.fromX + (t.toX - t.fromX)*anim.p)*(S+10);
+      const py=40 + (t.fromY + (t.toY - t.fromY)*anim.p)*(S+10);
+      const v=t.value;
+      ctx.fillStyle=tileColor(v); ctx.strokeStyle=c.style.borderColor; ctx.lineWidth=1;
+      roundRect(ctx,px,py,S,S,10,true,true);
+      ctx.fillStyle=(v<=4)?theme.tileTextDark:theme.tileTextLight;
+      ctx.font=(v<100)?'28px Inter':'24px Inter'; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillText(v,px+S/2,py+S/2+2);
+    }
   }
   if(hintDir!=null){ ctx.fillText('Hint: '+['Left','Up','Right','Down'][hintDir],12,c.height-12); }
   if(won){ overlay('You made 2048! Press R to restart'); }
   else if(over){ overlay('No moves left — Press R'); }
 }
 
-function overlay(msg){ ctx.fillStyle='rgba(0,0,0,0.55)'; ctx.fillRect(0,0,c.width,c.height); ctx.fillStyle='#e6e7ea'; ctx.font='18px Inter'; ctx.textAlign='center'; ctx.fillText(msg,c.width/2,c.height/2); }
+function overlay(msg){
+  ctx.fillStyle='rgba(0,0,0,0.55)';
+  ctx.fillRect(0,0,c.width,c.height);
+  ctx.fillStyle=themes[currentTheme].tileTextLight;
+  ctx.font='18px Inter';
+  ctx.textAlign='center';
+  ctx.fillText(msg,c.width/2,c.height/2);
+}
 
-function tileColor(v){ const m={2:'#eef2ff',4:'#c7d2fe',8:'#a5b4fc',16:'#93c5fd',32:'#60a5fa',64:'#3b82f6',128:'#22d3ee',256:'#14b8a6',512:'#10b981',1024:'#f59e0b',2048:'#ef4444'}; return m[v]||'#7c3aed'; }
+function tileColor(v){
+  const m=themes[currentTheme].tileColors;
+  return m[v]||m.default;
+}
 
-function roundRect(ctx,x,y,w,h,r,fill,stroke){ if(typeof r==='number'){ r={tl:r,tr:r,br:r,bl:r}; } ctx.beginPath(); ctx.moveTo(x+r.tl,y); ctx.lineTo(x+w-r.tr,y); ctx.quadraticCurveTo(x+w,y,x+w,y+r.tr); ctx.lineTo(x+w,y+h-r.br); ctx.quadraticCurveTo(x+w,y+h,x+w-r.br,y+h); ctx.lineTo(x+r.bl,y+h); ctx.quadraticCurveTo(x,y+h,x,y+h-r.bl); ctx.lineTo(x,y+r.tl); ctx.quadraticCurveTo(x,y,x+r.tl,y); ctx.closePath(); if(fill) ctx.fill(); if(stroke) ctx.stroke(); }
+function roundRect(ctx,x,y,w,h,r,fill,stroke){
+  if(typeof r==='number'){ r={tl:r,tr:r,br:r,bl:r}; }
+  ctx.beginPath();
+  ctx.moveTo(x+r.tl,y);
+  ctx.lineTo(x+w-r.tr,y);
+  ctx.quadraticCurveTo(x+w,y,x+w,y+r.tr);
+  ctx.lineTo(x+w,y+h-r.br);
+  ctx.quadraticCurveTo(x+w,y+h,x+w-r.br,y+h);
+  ctx.lineTo(x+r.bl,y+h);
+  ctx.quadraticCurveTo(x,y+h,x,y+h-r.bl);
+  ctx.lineTo(x,y+r.tl);
+  ctx.quadraticCurveTo(x,y,x+r.tl,y);
+  ctx.closePath();
+  if(fill) ctx.fill();
+  if(stroke) ctx.stroke();
+}
 
 function simulate(dir){
   let g=copyGrid(grid); let s=score; let moved=false;
@@ -149,7 +325,13 @@ function getHint(){
 }
 
 document.getElementById('hintBtn')?.addEventListener('click',getHint);
+document.getElementById('themeToggle')?.addEventListener('click',()=>{
+  currentTheme=currentTheme==='dark'?'light':'dark';
+  localStorage.setItem(LS_THEME,currentTheme);
+  applyTheme();
+  draw();
+});
 
+applyTheme();
 reset(true);
 })();
-

--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -6,12 +6,13 @@
   <title>2048</title>
   <link rel="stylesheet" href="../../css/styles.css?v=5.3">
 </head>
-<body style="margin:0;background:#0b1220;color:#e6e7ea;">
+<body style="margin:0;">
   <div style="display:flex;justify-content:center;padding:16px 16px 20px;">
-    <canvas id="board" width="360" height="420" style="border:1px solid #243047;border-radius:12px;background:#0f172a;"></canvas>
+    <canvas id="board" width="360" height="420" style="border:1px solid #243047;border-radius:12px;"></canvas>
   </div>
   <div style="text-align:center;margin-bottom:60px;">
     <button id="hintBtn" style="border:1px solid #243047;background:#111827;color:#e6e7ea;padding:8px 16px;border-radius:8px;cursor:pointer;">Hint</button>
+    <button id="themeToggle" style="border:1px solid #243047;background:#111827;color:#e6e7ea;padding:8px 16px;border-radius:8px;margin-left:8px;cursor:pointer;">Theme</button>
   </div>
   <script src="../../js/hud.js?v=5.3"></script>
   <script src="g2048.js?v=5.3"></script>


### PR DESCRIPTION
## Summary
- Animate tile movements and merges using `requestAnimationFrame`
- Introduce light and dark color themes with localStorage persistence
- Add theme toggle button and apply theme colors in drawing routine

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c91857808327a977d0b0e5577b3d