### PR TITLE
Add muzzle flash, explosions and bullet trails to shooter

### DIFF
--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -48,13 +48,25 @@ class Bullet {
   constructor(x,y){
     this.x = x;
     this.y = y;
+    this.prevX = x;
+    this.prevY = y;
     this.vy = -500;
     this.r = 4;
   }
   update(dt){
+    this.prevX = this.x;
+    this.prevY = this.y;
     this.y += this.vy * dt;
   }
   draw(ctx){
+    // trail
+    ctx.strokeStyle = 'rgba(255,236,153,0.4)';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(this.prevX, this.prevY);
+    ctx.lineTo(this.x, this.y);
+    ctx.stroke();
+
     ctx.fillStyle = '#ffec99';
     ctx.beginPath();
     ctx.arc(this.x, this.y, this.r, 0, Math.PI*2);
@@ -96,10 +108,122 @@ class Enemy {
   }
 }
 
+class MuzzleFlash {
+  constructor(x, y){
+    this.x = x;
+    this.y = y;
+    this.life = 0.1;
+  }
+  update(dt){
+    this.life -= dt;
+  }
+  draw(ctx){
+    if (this.life <= 0) return;
+    ctx.save();
+    ctx.globalAlpha = this.life / 0.1;
+    ctx.fillStyle = '#ffd166';
+    ctx.beginPath();
+    ctx.moveTo(this.x, this.y);
+    ctx.lineTo(this.x - 5, this.y - 20);
+    ctx.lineTo(this.x + 5, this.y - 20);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+  }
+}
+
+class Explosion {
+  constructor(x, y){
+    this.x = x;
+    this.y = y;
+    this.particles = [];
+    for(let i=0;i<20;i++){
+      const ang = Math.random()*Math.PI*2;
+      const spd = 80 + Math.random()*120;
+      this.particles.push({
+        x, y,
+        vx: Math.cos(ang)*spd,
+        vy: Math.sin(ang)*spd,
+        life: 0.6,
+        r: 2 + Math.random()*2
+      });
+    }
+    this.debris = [];
+    for(let i=0;i<6;i++){
+      const ang = Math.random()*Math.PI*2;
+      const spd = 40 + Math.random()*60;
+      this.debris.push({
+        x, y,
+        vx: Math.cos(ang)*spd,
+        vy: Math.sin(ang)*spd,
+        life: 0.8,
+        size: 3 + Math.random()*3,
+        rot: Math.random()*Math.PI*2,
+        vr: (Math.random()-0.5)*6
+      });
+    }
+    this.light = 0.4;
+  }
+  update(dt){
+    this.particles.forEach(p => {
+      p.x += p.vx*dt;
+      p.y += p.vy*dt;
+      p.life -= dt;
+    });
+    this.particles = this.particles.filter(p => p.life > 0);
+
+    this.debris.forEach(d => {
+      d.x += d.vx*dt;
+      d.y += d.vy*dt;
+      d.rot += d.vr*dt;
+      d.life -= dt;
+    });
+    this.debris = this.debris.filter(d => d.life > 0);
+
+    this.light -= dt;
+  }
+  draw(ctx){
+    ctx.save();
+    this.particles.forEach(p => {
+      ctx.globalAlpha = p.life/0.6;
+      ctx.fillStyle = '#ffa94d';
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI*2);
+      ctx.fill();
+    });
+    this.debris.forEach(d => {
+      ctx.save();
+      ctx.translate(d.x, d.y);
+      ctx.rotate(d.rot);
+      ctx.globalAlpha = d.life/0.8;
+      ctx.fillStyle = '#6b7280';
+      ctx.fillRect(-d.size/2, -d.size/2, d.size, d.size);
+      ctx.restore();
+    });
+    if (this.light > 0){
+      ctx.globalAlpha = this.light;
+      const grd = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, 40);
+      grd.addColorStop(0, '#ffffff');
+      grd.addColorStop(1, 'rgba(255,255,255,0)');
+      ctx.fillStyle = grd;
+      ctx.beginPath();
+      ctx.arc(this.x, this.y, 40, 0, Math.PI*2);
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+  isDone(){
+    return this.particles.length===0 && this.debris.length===0 && this.light<=0;
+  }
+}
+
 const player = new Player();
 let bullets = [];
 let enemies = [];
+let flashes = [];
+let explosions = [];
 let spawnTimer = 0;
+let shakeTime = 0;
 
 const keys = new Map();
 addEventListener('keydown', e => {
@@ -114,6 +238,8 @@ document.getElementById('restartBtn').addEventListener('click', () => restart())
 
 function fire(){
   bullets.push(new Bullet(player.x, player.y - player.r));
+  flashes.push(new MuzzleFlash(player.x, player.y - player.r));
+  shakeTime = 0.1;
 }
 
 function restart(){
@@ -123,7 +249,7 @@ function restart(){
   state.lives = 3;
   bestEl.textContent = state.hiscore;
   player.x = W/2; player.y = H/2;
-  bullets = []; enemies = []; spawnTimer = 0;
+  bullets = []; enemies = []; flashes = []; explosions = []; spawnTimer = 0; shakeTime = 0;
   emitEvent({ type: 'play', slug: 'shooter' });
 }
 
@@ -143,12 +269,20 @@ function update(dt){
   bullets.forEach(b => b.update(dt));
   bullets = bullets.filter(b => b.y + b.r > 0);
 
+  flashes.forEach(f => f.update(dt));
+  flashes = flashes.filter(f => f.life > 0);
+
+  explosions.forEach(ex => ex.update(dt));
+  explosions = explosions.filter(ex => !ex.isDone());
+
   spawnTimer -= dt;
   if(spawnTimer <= 0){
     spawnTimer = 1 + Math.random()*1.5;
     enemies.push(new Enemy());
   }
   enemies.forEach(e => e.update(dt, player));
+
+  if(shakeTime > 0) shakeTime -= dt;
 
   // bullet vs enemy collisions
   for(let i=bullets.length-1; i>=0; i--){
@@ -160,6 +294,7 @@ function update(dt){
         bullets.splice(i,1);
         e.hitFlash = 1;
         enemies.splice(j,1);
+        explosions.push(new Explosion(e.x, e.y));
         state.score += e.elite ? 3 : 1; scoreEl.textContent = state.score;
         emitEvent({ type: 'score', slug: 'shooter', value: state.score });
         break;
@@ -194,10 +329,20 @@ function gameOver(){
 }
 
 function draw(){
+  ctx.save();
+  if(shakeTime > 0){
+    const m = 5;
+    ctx.translate((Math.random()-0.5)*m, (Math.random()-0.5)*m);
+  }
+
   ctx.fillStyle = '#0a0d13';
   ctx.fillRect(0,0,W,H);
 
   player.draw(ctx);
   bullets.forEach(b => b.draw(ctx));
   enemies.forEach(e => e.draw(ctx));
+  flashes.forEach(f => f.draw(ctx));
+  explosions.forEach(ex => ex.draw(ctx));
+
+  ctx.restore();
 }


### PR DESCRIPTION
## Summary
- add bullet trail rendering
- implement muzzle flashes, explosions and screen shake
- extend explosion visuals with particles, debris and light flashes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1c9361b408327aab11ad8afcb5831