### PR TITLE
Add board size selector to 2048 game

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -12,6 +12,13 @@
   </div>
   <div style="text-align:center;margin-bottom:60px;">
     <button id="hintBtn" style="border:1px solid #243047;background:#111827;color:#e6e7ea;padding:8px 16px;border-radius:8px;cursor:pointer;">Hint</button>
+    <select id="sizeSel" style="border:1px solid #243047;background:#111827;color:#e6e7ea;padding:8px 16px;border-radius:8px;margin-left:8px;cursor:pointer;">
+      <option value="4">4×4</option>
+      <option value="5">5×5</option>
+      <option value="6">6×6</option>
+      <option value="7">7×7</option>
+      <option value="8">8×8</option>
+    </select>
     <button id="themeToggle" style="border:1px solid #243047;background:#111827;color:#e6e7ea;padding:8px 16px;border-radius:8px;margin-left:8px;cursor:pointer;">Theme</button>
   </div>
   <script src="../../js/hud.js?v=5.3"></script>


### PR DESCRIPTION
## Summary
- Add board size selector to 2048 UI
- Resize grid based on chosen size and persist selection
- Style selector with theme alongside existing controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e40cf4d4832797d3f5d8edbaabfb