### PR TITLE
feat: make maze size selectable

### DIFF
--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -22,6 +22,14 @@
     <div class="panel">
       <div id="message">Click Start to play.<br/>WASD to move • Mouse to look<br/>P to pause • R to restart<br/>Esc to release pointer lock.</div>
       <div style="margin-top:10px">
+        <label for="mazeSize">Maze Size:</label>
+        <select id="mazeSize">
+          <option value="8">8×8</option>
+          <option value="12">12×12</option>
+          <option value="16">16×16</option>
+        </select>
+      </div>
+      <div style="margin-top:10px">
         <button id="startBtn" class="btn">Start</button>
         <button id="restartBtn" class="btn" style="display:none">Restart</button>
         <button id="shareBtn" class="btn" style="display:none">Share</button>

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -46,6 +46,7 @@ const restartBtn = document.getElementById('restartBtn');
 const shareBtn = document.getElementById('shareBtn');
 const timeEl = document.getElementById('time');
 const bestEl = document.getElementById('best');
+const sizeSelect = document.getElementById('mazeSize');
 
 let running = false;
 let paused = true;
@@ -66,14 +67,22 @@ document.addEventListener('keyup', (e) => { keys[e.code] = false; });
 
 startBtn.addEventListener('click', () => start());
 restartBtn.addEventListener('click', () => restart());
+sizeSelect.addEventListener('change', () => restart());
 
 let wallBoxes = [];
 let exitBox = null;
 let floor = null;
 let exitMesh = null;
-const cellSize = 4;
 const wallHeight = 4;
-const MAZE_CELLS = 8;
+const BASE_CELLS = 8;
+const BASE_CELL_SIZE = 4;
+let MAZE_CELLS = BASE_CELLS;
+let cellSize = BASE_CELL_SIZE;
+
+function updateMazeParams() {
+  MAZE_CELLS = parseInt(sizeSelect.value, 10);
+  cellSize = (BASE_CELL_SIZE * BASE_CELLS) / MAZE_CELLS;
+}
 
 function generateMaze(width, height) {
   const cols = width * 2 + 1;
@@ -165,6 +174,7 @@ function restart() {
   running = false;
   paused = true;
   startTime = 0;
+  updateMazeParams();
   buildMaze();
   timeEl.textContent = '0.00';
   message.textContent = 'Click Start to play.';


### PR DESCRIPTION
## Summary
- add maze size selector to 3D Maze HUD
- regenerate maze based on selected dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e43b34fc8327b436546c03b0b95a