### PR TITLE
Add chess lobby with WebSocket play and Elo ratings

### DIFF
--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -1,4 +1,11 @@
-<!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Chess</title><link rel="stylesheet" href="../../css/styles.css?v=5.3"></head>
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Chess</title>
+<link rel="stylesheet" href="../../css/styles.css?v=5.3">
+</head>
 <body style="margin:0;background:#0b1220;color:#e6e7ea;">
 <div style="display:flex;gap:16px;justify-content:center;align-items:flex-start;padding:16px 16px 80px;">
   <canvas id="board" width="480" height="480" style="border:1px solid #243047;border-radius:12px;background:#0f172a;"></canvas>
@@ -9,13 +16,41 @@
     <br/>
     <label>Puzzles: <select id="puzzle-select"><option value="-1">Free Play</option></select></label>
     <div id="status"></div>
+    <div id="lobby" style="margin-top:16px;">
+      <button id="find-match">Find Match</button>
+      <div id="lobby-status"></div>
+      <ol id="rankings"></ol>
+    </div>
   </div>
 </div>
 <script src="../../js/hud.js?v=5.3"></script>
 <script src="ai.js?v=5.3"></script>
 <script src="puzzles.js?v=5.3"></script>
+<script src="ratings.js?v=5.3"></script>
+<script src="net.js?v=5.3"></script>
 <script src="chess.js?v=5.3"></script>
+<script>
+(function(){
+  const rating = Ratings.getRating();
+  const btn = document.getElementById('find-match');
+  const status = document.getElementById('lobby-status');
+  const rankings = document.getElementById('rankings');
+  btn.addEventListener('click', () => {
+    ChessNet.onStatus(m => status.textContent = m);
+    ChessNet.onPlayers(list => {
+      rankings.innerHTML = '';
+      list.forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = `${p.name || 'Player'}: ${p.rating}`;
+        rankings.appendChild(li);
+      });
+    });
+    ChessNet.connect('wss://example.com/chess', rating);
+  });
+})();
+</script>
 <script src="../../js/input.js?v=5.3"></script>
 <script src="../../js/remapUI.js?v=5.3"></script>
 <script src="../../js/perfHud.js?v=5.3"></script>
-</body></html>
+</body>
+</html>

--- a/games/chess/net.js
+++ b/games/chess/net.js
@@ -1,0 +1,44 @@
+const ChessNet = (() => {
+  let ws;
+  let moveHandler = () => {};
+  let playersHandler = () => {};
+  let statusHandler = () => {};
+
+  function connect(url, rating) {
+    if (ws) ws.close();
+    ws = new WebSocket(url);
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: 'join', rating }));
+      statusHandler('Waiting for opponent...');
+    };
+    ws.onmessage = e => {
+      try {
+        const msg = JSON.parse(e.data);
+        if (msg.type === 'move' && msg.move) {
+          moveHandler(msg.move);
+        } else if (msg.type === 'players' && Array.isArray(msg.players)) {
+          playersHandler(msg.players);
+        } else if (msg.type === 'status' && msg.message) {
+          statusHandler(msg.message);
+        }
+      } catch(err) {
+        console.error('Bad message', err);
+      }
+    };
+    ws.onclose = () => statusHandler('Disconnected');
+  }
+
+  function sendMove(move) {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'move', move }));
+    }
+  }
+
+  return {
+    connect,
+    sendMove,
+    onMove: cb => { moveHandler = cb; },
+    onPlayers: cb => { playersHandler = cb; },
+    onStatus: cb => { statusHandler = cb; }
+  };
+})();

--- a/games/chess/ratings.js
+++ b/games/chess/ratings.js
@@ -1,0 +1,40 @@
+const Ratings = (() => {
+  const KEY = 'chessRating';
+  const DEFAULT = 1200;
+
+  function getRating() {
+    const r = parseInt(localStorage.getItem(KEY), 10);
+    return isNaN(r) ? DEFAULT : r;
+  }
+
+  function saveRating(r) {
+    localStorage.setItem(KEY, Math.round(r));
+  }
+
+  function expected(ra, rb) {
+    return 1 / (1 + Math.pow(10, (rb - ra) / 400));
+  }
+
+  function updateRating(result, opponentRating, k = 32) {
+    const r = getRating();
+    const e = expected(r, opponentRating);
+    const nr = r + k * (result - e);
+    saveRating(nr);
+    return Math.round(nr);
+  }
+
+  async function sync(url) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rating: getRating() })
+      });
+      return await res.json();
+    } catch (err) {
+      console.warn('Rating sync failed', err);
+    }
+  }
+
+  return { getRating, saveRating, expected, updateRating, sync };
+})();


### PR DESCRIPTION
## Summary
- create `ChessNet` WebSocket helper for exchanging algebraic moves
- add local ELO rating calculations with optional backend sync
- integrate lobby in chess page for matchmaking and ranking display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25073fda483279e9bbd6173d9a7c1