### PR TITLE
feat: add basic multiplayer to 3d maze

### DIFF
--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -16,7 +16,7 @@
   </style>
 </head>
 <body>
-  <div id="hud">Time: <span id="time">0.00</span> • Best: <span id="best">--</span></div>
+  <div id="hud">Time: <span id="time">0.00</span> • Opp: <span id="oppTime">--</span> • Best: <span id="best">--</span></div>
   <a class="back" href="../../">← Back to Hub</a>
   <div id="overlay" class="">
     <div class="panel">
@@ -28,6 +28,12 @@
           <option value="12">12×12</option>
           <option value="16">16×16</option>
         </select>
+      </div>
+      <div style="margin-top:10px">
+        <label for="roomInput">Room:</label>
+        <input id="roomInput" size="6" />
+        <button id="connectBtn" class="btn">Connect</button>
+        <button id="rematchBtn" class="btn" style="display:none">Rematch</button>
       </div>
       <div style="margin-top:10px">
         <button id="startBtn" class="btn">Start</button>

--- a/games/maze3d/net.js
+++ b/games/maze3d/net.js
@@ -1,0 +1,14 @@
+export function connect(room, handlers = {}) {
+  const bc = new BroadcastChannel('maze3d-' + room);
+  bc.onmessage = (e) => {
+    const { type, data } = e.data || {};
+    const fn = handlers[type];
+    if (fn) fn(data);
+  };
+  return {
+    send(type, data) {
+      bc.postMessage({ type, data });
+    },
+    close() { bc.close(); }
+  };
+}


### PR DESCRIPTION
## Summary
- add BroadcastChannel-based networking for maze seed/position/time sharing
- start synchronized matches and track opponent progress and wins
- include simple matchmaking UI with room codes and rematch button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c25078f6488327b097493c4fd517e9