### PR TITLE
feat(snake): add skin system

### DIFF
--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -1,1 +1,52 @@
-<!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Snake</title><style>html,body{height:100%;margin:0;background:#0b0d12;color:#e6e7ea;font-family:Inter,system-ui,sans-serif}.wrap{display:grid;place-items:center;height:100%}canvas{background:#0f1320;border:1px solid rgba(255,255,255,.08);border-radius:16px;box-shadow:0 20px 40px rgba(0,0,0,.4)}.hud{position:fixed;top:16px;right:16px;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);padding:10px 12px;border-radius:12px}</style></head><body><div class="hud">Arrows/WASD or swipe • R restart • P pause<label style="display:block;margin-top:4px"><input type="checkbox" id="dailyToggle"/> Daily</label><ol id="dailyScores" style="margin:4px 0 0 0;padding-left:20px;font-size:14px"></ol></div><div class="wrap"><canvas id="c" width="640" height="640" data-basew="640" data-baseh="640"></canvas></div><script src="../../js/injectBackButton.js"></script><script src="../../js/resizeCanvas.global.js"></script><script src="../../js/gameUtil.js"></script><script src="../../js/sfx.js"></script><script src="../../shared/leaderboard.js"></script><script>const seed=new Date().toISOString().slice(0,10);const params=new URLSearchParams(location.search);const daily=params.get('daily')==='1';const toggle=document.getElementById('dailyToggle');toggle.checked=daily;window.DAILY_MODE=daily;window.DAILY_SEED=seed;function renderScores(){const box=document.getElementById('dailyScores');if(!daily){box.style.display='none';return;}const scores=LB.getTopScores('snake',seed,5);box.innerHTML=scores.map((s,i)=>`<li>${s.score}</li>`).join('');}window.renderScores=renderScores;renderScores();toggle.onchange=()=>{params.set('daily',toggle.checked?'1':'0');location.search=params.toString();};</script><script src="./snake.js"></script></body></html>
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Snake</title>
+  <style>
+    html,body{height:100%;margin:0;background:#0b0d12;color:#e6e7ea;font-family:Inter,system-ui,sans-serif}
+    .wrap{display:grid;place-items:center;height:100%}
+    canvas{background:#0f1320;border:1px solid rgba(255,255,255,.08);border-radius:16px;box-shadow:0 20px 40px rgba(0,0,0,.4)}
+    .hud{position:fixed;top:16px;right:16px;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);padding:10px 12px;border-radius:12px}
+    .hud label{display:block;margin-top:4px;font-size:14px}
+    .hud select{background:#111827;color:#e6e7ea;border:1px solid #243047;border-radius:6px;margin-left:4px}
+  </style>
+</head>
+<body>
+  <div class="hud">
+    Arrows/WASD or swipe • R restart • P pause
+    <label><input type="checkbox" id="dailyToggle"/> Daily</label>
+    <ol id="dailyScores" style="margin:4px 0 0 0;padding-left:20px;font-size:14px"></ol>
+    <label>Snake <select id="snakeSkin"></select></label>
+    <label>Fruit <select id="fruitSkin"></select></label>
+    <label>Board <select id="boardSkin"></select></label>
+  </div>
+  <div class="wrap"><canvas id="c" width="640" height="640" data-basew="640" data-baseh="640"></canvas></div>
+  <script src="../../js/injectBackButton.js"></script>
+  <script src="../../js/resizeCanvas.global.js"></script>
+  <script src="../../js/gameUtil.js"></script>
+  <script src="../../js/sfx.js"></script>
+  <script src="../../shared/leaderboard.js"></script>
+  <script>
+    const seed = new Date().toISOString().slice(0,10);
+    const params = new URLSearchParams(location.search);
+    const daily = params.get('daily')==='1';
+    const toggle = document.getElementById('dailyToggle');
+    toggle.checked = daily;
+    window.DAILY_MODE = daily;
+    window.DAILY_SEED = seed;
+    function renderScores(){
+      const box=document.getElementById('dailyScores');
+      if(!daily){box.style.display='none';return;}
+      const scores=LB.getTopScores('snake',seed,5);
+      box.innerHTML=scores.map(s=>`<li>${s.score}</li>`).join('');
+    }
+    window.renderScores = renderScores;
+    renderScores();
+    toggle.onchange=()=>{params.set('daily',toggle.checked?'1':'0');location.search=params.toString();};
+  </script>
+  <script src="./skins.js"></script>
+  <script src="./snake.js"></script>
+</body>
+</html>

--- a/games/snake/skins.js
+++ b/games/snake/skins.js
@@ -1,0 +1,15 @@
+const SNAKE_SKINS = [
+  { id: 'default', name: 'Purple', color: '#8b5cf6', unlock: p => true },
+  { id: 'gold', name: 'Gold', color: '#fcd34d', unlock: p => p.best >= 10 },
+  { id: 'emerald', name: 'Emerald', color: '#10b981', unlock: p => p.plays >= 5 }
+];
+
+const FRUIT_SKINS = [
+  { id: 'classic', name: 'Classic', icons: ['🍎','🍌','🍇','🍒','🍊','🍉'], color: '#22d3ee', unlock: p => true },
+  { id: 'gems', name: 'Gems', icons: ['💎','🔶','🔷'], color: '#eab308', unlock: p => p.best >= 15 }
+];
+
+const BOARD_THEMES = [
+  { id: 'dark', name: 'Dark', colors: ['#111623', '#0f1320'], unlock: p => true },
+  { id: 'light', name: 'Light', colors: ['#f3f4f6', '#e5e7eb'], unlock: p => p.plays >= 3 }
+];


### PR DESCRIPTION
## Summary
- add themed snake, fruit, and board skins with unlock requirements
- allow snake to apply selected cosmetics and track unlock progress
- expose cosmetic selectors on the snake game page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c25085268c8327994f5e524cd4a8c3