### PR TITLE
feat: add canvas loop util

### DIFF
--- a/docs/game-inventory.md
+++ b/docs/game-inventory.md
@@ -2,7 +2,7 @@
 
 | slug | title | entry file | main files | shared utils | input methods | current known issues | suggested quick wins |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| pong | Pong Classic | games/pong/index.html | pong.js, career.js | injectBackButton.js, resizeCanvas.global.js, gameUtil.js, sfx.js | keyboard, touch | Pause only via **P**, no unified overlay | Pilot global pause overlay with ESC |
+| pong | Pong Classic | games/pong/index.html | pong.js, career.js | injectBackButton.js, canvasLoop.global.js, gameUtil.js, sfx.js | keyboard, touch | Pause only via **P**, no unified overlay | Pilot global pause overlay with ESC |
 | snake | Snake | games/snake/index.html | snake.js, skins.js | injectBackButton.js, resizeCanvas.global.js, gameUtil.js, sfx.js, shared/leaderboard.js | keyboard, touch | `setTimeout` game loop; no game‑over screen | Move loop to `requestAnimationFrame` and add restart overlay |
 | tetris | Tetris | games/tetris/play.html | tetris.js, replay.js | injectBackButton.js, resizeCanvas.global.js, gameUtil.js, sfx.js | keyboard | No touch controls; update loop not delta‑based | Add swipe controls and separate update vs. render |
 | breakout | Breakout | games/breakout/index.html | breakout.js, levels.js | injectBackButton.js, resizeCanvas.global.js, gameUtil.js, sfx.js, shared/leaderboard.js | keyboard, mouse | Lacks touch controls; pause only via **P** | Add touch paddle and ESC pause |
@@ -16,4 +16,4 @@
 | runner | City Runner | games/runner/index.html | main.js, editor.js | shared/controls.js, shared/ui.js, shared/metrics.js, shared/achievements.js, shared/missions.js | keyboard, touch | No baseline smoke test | Add smoke test and minor loop cleanup |
 | shooter | Alien Shooter | games/shooter/index.html | main.js, net.js | shared/ui.js, shared/achievements.js | keyboard | No touch controls | Add tap/virtual joystick and ESC pause |
 
-*Most games also include `sfx.js` for audio and `resizeCanvas.global.js` or `shared/ui.js` for layout helpers.*
+*Most games also include `sfx.js` for audio and `resizeCanvas.global.js`, `canvasLoop.global.js`, or `shared/ui.js` for layout helpers.*

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -28,7 +28,7 @@
   <div id="ladder" class="ladder"></div>
   <div class="wrap"><canvas id="game" width="900" height="600" data-basew="900" data-baseh="600"></canvas></div>
   <script src="../../js/injectBackButton.js"></script>
-  <script src="../../js/resizeCanvas.global.js"></script>
+  <script src="../../js/canvasLoop.global.js"></script>
   <script src="../../js/gameUtil.js"></script>
   <script src="../../js/sfx.js"></script>
   <script src="./career.js"></script>

--- a/games/pong/pong.js
+++ b/games/pong/pong.js
@@ -1,11 +1,18 @@
 const canvas = document.getElementById('game');
-fitCanvasToParent(canvas, 1100, 800, 24);
-addEventListener('resize', () => fitCanvasToParent(canvas, 1100, 800, 24));
 const ctx = canvas.getContext('2d');
 function ctxSave() { if (ctx.save) ctx.save(); }
 function ctxRestore() { if (ctx.restore) ctx.restore(); }
 
-let W = canvas.width, H = canvas.height;
+let W = 0, H = 0;
+const loop = createCanvasLoop(canvas, () => { step(); draw(); }, {
+  onResize: (w, h, dpr) => {
+    W = w;
+    H = h;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+});
+window.pong = loop;
+loop.start();
 const PADDLE_W = 12, PADDLE_H = 110, BALL_R = 8;
 const COS_KEY = 'gg:pong:cosmetics';
 let cosmetics = {};
@@ -273,7 +280,6 @@ function draw() {
   }
 }
 
-(function loop() { step(); draw(); requestAnimationFrame(loop); })();
 
 // Difficulty selector hookup
 const diffSel = document.getElementById('difficulty');

--- a/js/canvasLoop.global.js
+++ b/js/canvasLoop.global.js
@@ -1,0 +1,45 @@
+(function(){
+  function createCanvasLoop(canvas, render, opts){
+    opts = opts || {};
+    var onResize = opts.onResize;
+    var raf = null;
+    var ro = null;
+    function resize(){
+      var style = getComputedStyle(canvas);
+      var cssW = parseFloat(style.width) || canvas.width;
+      var cssH = parseFloat(style.height) || canvas.height;
+      var dpr = window.devicePixelRatio || 1;
+      canvas.style.width = cssW + 'px';
+      canvas.style.height = cssH + 'px';
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+      if(onResize) onResize(canvas.width, canvas.height, dpr);
+    }
+    if(typeof ResizeObserver !== 'undefined'){
+      ro = new ResizeObserver(function(){ resize(); });
+      ro.observe(canvas);
+    } else {
+      window.addEventListener('resize', resize);
+    }
+    resize();
+    function loop(t){
+      raf = requestAnimationFrame(loop);
+      render(t);
+    }
+    function start(){
+      if(raf==null) raf = requestAnimationFrame(loop);
+    }
+    function stop(){
+      if(raf!=null){
+        cancelAnimationFrame(raf);
+        raf = null;
+      }
+    }
+    function dispose(){
+      stop();
+      if(ro) ro.disconnect(); else window.removeEventListener('resize', resize);
+    }
+    return { start:start, stop:stop, dispose:dispose, resize:resize };
+  }
+  window.createCanvasLoop = createCanvasLoop;
+})();

--- a/js/canvasLoop.js
+++ b/js/canvasLoop.js
@@ -1,0 +1,41 @@
+export function createCanvasLoop(canvas, render, opts = {}) {
+  const { onResize } = opts;
+  let raf = null;
+  let ro = null;
+  function resize() {
+    const style = getComputedStyle(canvas);
+    const cssW = parseFloat(style.width) || canvas.width;
+    const cssH = parseFloat(style.height) || canvas.height;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.style.width = cssW + 'px';
+    canvas.style.height = cssH + 'px';
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    if (onResize) onResize(canvas.width, canvas.height, dpr);
+  }
+  if (typeof ResizeObserver !== 'undefined') {
+    ro = new ResizeObserver(() => resize());
+    ro.observe(canvas);
+  } else {
+    window.addEventListener('resize', resize);
+  }
+  resize();
+  function loop(t) {
+    raf = requestAnimationFrame(loop);
+    render(t);
+  }
+  function start() {
+    if (raf == null) raf = requestAnimationFrame(loop);
+  }
+  function stop() {
+    if (raf != null) {
+      cancelAnimationFrame(raf);
+      raf = null;
+    }
+  }
+  function dispose() {
+    stop();
+    if (ro) ro.disconnect(); else window.removeEventListener('resize', resize);
+  }
+  return { start, stop, dispose, resize };
+}

--- a/sw.js
+++ b/sw.js
@@ -6,6 +6,7 @@ const CORE = [
   '/js/app.js',
   '/js/injectBackButton.js',
   '/js/resizeCanvas.global.js',
+  '/js/canvasLoop.global.js',
   '/js/gameUtil.js',
   '/js/sfx.js',
   '/assets/logo.svg',


### PR DESCRIPTION
## Summary
- add high-DPI `createCanvasLoop` utility with resize observation and game loop controls
- refactor Pong to use `createCanvasLoop` and expose start/stop/dispose
- cache new script in the service worker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25bf5c22883279ac3da9ea8afff68