### PR TITLE
feat: add fallback panel and wrap game init

### DIFF
--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -3,7 +3,9 @@ import { attachPauseOverlay, saveBestScore, shareScore } from '../../shared/ui.j
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
 import * as net from './net.js';
-
+import { renderFallbackPanel } from '../../shared/fallback.js';
+import signature from 'console-signature';
+async function init(){
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 const DPR = Math.min(2, window.devicePixelRatio||1);
@@ -430,3 +432,9 @@ function render(){
 // Session timing
 startSessionTimer('asteroids');
 window.addEventListener('beforeunload', ()=> endSessionTimer('asteroids'));
+}
+
+init().catch(e => {
+  signature(e);
+  renderFallbackPanel(e, 'asteroids');
+});

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -3,7 +3,9 @@ import { attachPauseOverlay, saveBestScore, shareScore } from '../../shared/ui.j
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
 import { getMission, updateMission, formatMission, clearMission } from '../../shared/missions.js';
-
+import { renderFallbackPanel } from '../../shared/fallback.js';
+import signature from 'console-signature';
+async function init(){
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 const DPR = Math.min(2, window.devicePixelRatio||1);
@@ -300,3 +302,9 @@ function pause(){running=false;overlay.show();}
 startSessionTimer('runner');
 emitEvent({ type: 'play', slug: 'runner' });
 window.addEventListener('beforeunload',()=>endSessionTimer('runner'));
+}
+
+init().catch(e => {
+  signature(e);
+  renderFallbackPanel(e, 'runner');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "game",
       "version": "1.0.0",
+      "dependencies": {
+        "console-signature": "^1.5.0"
+      },
       "devDependencies": {
         "jsdom": "^24.0.0",
         "service-worker-mock": "^2.0.5",
@@ -1069,6 +1072,12 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/console-signature": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/console-signature/-/console-signature-1.5.0.tgz",
+      "integrity": "sha512-RsfRT98mjmYPu2XCG6FzoWbA0kQVRv15HcMQiAeOD4qgGffLkjEMz9x9akhVTb+uHnLU+0Pgb4Grb5UR3sj1ag==",
+      "license": "ISC"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "jsdom": "^24.0.0",
     "service-worker-mock": "^2.0.5",
     "vitest": "^1.6.0"
+  },
+  "dependencies": {
+    "console-signature": "^1.5.0"
   }
 }

--- a/shared/fallback.js
+++ b/shared/fallback.js
@@ -1,0 +1,51 @@
+export function renderFallbackPanel(error, gameName) {
+  if (typeof document === 'undefined') return;
+  const existing = document.getElementById('fallback-panel');
+  if (existing) return existing;
+
+  const panel = document.createElement('div');
+  panel.id = 'fallback-panel';
+  panel.style.position = 'fixed';
+  panel.style.inset = '0';
+  panel.style.background = 'rgba(0,0,0,0.85)';
+  panel.style.color = '#fff';
+  panel.style.display = 'flex';
+  panel.style.flexDirection = 'column';
+  panel.style.alignItems = 'center';
+  panel.style.justifyContent = 'center';
+  panel.style.padding = '20px';
+  panel.style.zIndex = '9999';
+  panel.style.fontFamily = 'system-ui, sans-serif';
+
+  const msg = document.createElement('pre');
+  msg.style.whiteSpace = 'pre-wrap';
+  msg.style.maxWidth = '90%';
+  msg.textContent = error && error.stack ? error.stack : String(error);
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Reload';
+  btn.onclick = () => location.reload();
+  btn.style.marginRight = '10px';
+
+  const issue = document.createElement('a');
+  issue.textContent = 'Open issue';
+  issue.href = `https://github.com/<org>/<repo>/issues/new?title=${encodeURIComponent(gameName+' crash')}`;
+  issue.target = '_blank';
+  issue.rel = 'noopener noreferrer';
+
+  const actions = document.createElement('div');
+  actions.style.margin = '20px 0';
+  actions.append(btn, issue);
+
+  const info = document.createElement('pre');
+  info.style.fontSize = '12px';
+  info.style.whiteSpace = 'pre-wrap';
+  const ua = navigator.userAgent;
+  const dpr = window.devicePixelRatio || 1;
+  const vp = `${innerWidth}x${innerHeight}`;
+  info.textContent = `UA: ${ua}\nDPR: ${dpr}\nViewport: ${vp}`;
+
+  panel.append(msg, actions, info);
+  document.body.appendChild(panel);
+  return panel;
+}


### PR DESCRIPTION
## Summary
- add shared `renderFallbackPanel` utility for error handling
- wrap runner and asteroids game bootstraps in try/catch and log with console-signature
- install `console-signature` dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25bf2c9988327b476e96eefeeab30