### PR TITLE
Add diagnostics admin page

### DIFF
--- a/admin/diagnostics.html
+++ b/admin/diagnostics.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Diagnostics — Gurjot's Games</title>
+<link rel="stylesheet" href="../css/styles.css"/>
+<style>
+body{padding:18px}
+table{width:100%;border-collapse:collapse;margin-top:16px}
+th,td{border:1px solid var(--card-border);padding:8px;text-align:left}
+.actions{display:flex;gap:8px;flex-wrap:wrap}
+.chip.ok{background:rgba(16,185,129,.15);border-color:rgba(16,185,129,.4);color:#34d399}
+.chip.fail{background:rgba(239,68,68,.15);border-color:rgba(239,68,68,.4);color:#fca5a5}
+.chip.unknown{background:rgba(156,163,175,.15);border-color:rgba(156,163,175,.4);color:#e5e7eb}
+</style>
+</head>
+<body>
+<h2>Diagnostics</h2>
+<table>
+<thead><tr><th>Game</th><th>Status</th><th>Actions</th></tr></thead>
+<tbody id="rows"></tbody>
+</table>
+<script>
+(async function(){
+  const [gamesRes, hcRes] = await Promise.all([
+    fetch('../games.json',{cache:'no-store'}),
+    fetch('../healthcheck.json',{cache:'no-store'}).catch(()=>null)
+  ]);
+  const gamesData = await gamesRes.json();
+  const games = Array.isArray(gamesData.games)?gamesData.games:(Array.isArray(gamesData)?gamesData:[]);
+  const statuses = hcRes? await hcRes.json():{};
+  const tbody = document.getElementById('rows');
+  games.forEach(g=>{
+    const id=g.slug||g.id;
+    const status=getStatus(statuses,id);
+    const tr=document.createElement('tr');
+    tr.innerHTML=`
+      <td>${g.title||id}</td>
+      <td><span class="chip ${status}">${status}</span></td>
+      <td class="actions">
+        <a class="btn" href="../${g.path}" target="_blank">Launch</a>
+        <a class="btn" href="../${g.path}${g.path.includes('?')?'&':'?'}fx" target="_blank">FX</a>
+        <button class="btn" data-reset="${id}">Reset LS</button>
+      </td>`;
+    tbody.appendChild(tr);
+  });
+  document.addEventListener('click',e=>{
+    const btn=e.target.closest('button[data-reset]');
+    if(btn){
+       const k=btn.getAttribute('data-reset');
+       localStorage.removeItem(k);
+       alert('Cleared localStorage for '+k);
+    }
+  });
+  function getStatus(map,id){
+    if(Array.isArray(map)){
+      const it=map.find(x=>x.id===id);
+      return normalize(it && (it.status||it.state));
+    }else if(map && typeof map==='object'){
+      const v=map[id];
+      if(typeof v==='object') return normalize(v.status||v.state);
+      return normalize(v);
+    }
+    return 'unknown';
+  }
+  function normalize(v){
+    if(v===200||v==='ok'||v==='pass'||v===true) return 'ok';
+    if(!v||v===404||v==='fail'||v==='error'||v===false) return 'fail';
+    return String(v||'unknown');
+  }
+})();
+</script>
+</body></html>


### PR DESCRIPTION
## Summary
- add diagnostics admin page listing game healthcheck statuses
- include quick links to launch games, enable `?fx`, and reset localStorage

## Testing
- `npm test` *(fails: Cannot assign to read only property 'now' of object '#<Performance>')*

------
https://chatgpt.com/codex/tasks/task_e_68c25c0013cc8327bb21c73b1444618d