### PR TITLE
feat: load games from data json

### DIFF
--- a/data/games.json
+++ b/data/games.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "pong",
+    "title": "Pong Classic",
+    "short": "A snappy canvas remake of the arcade legend.",
+    "tags": ["classic", "2D"],
+    "difficulty": "easy",
+    "released": "2025-08-20",
+    "playUrl": "/games/pong/"
+  },
+  {
+    "id": "snake",
+    "title": "Snake",
+    "short": "Eat, grow, don't bonk into yourself.",
+    "tags": ["classic", "2D"],
+    "difficulty": "easy",
+    "released": "2025-08-25",
+    "playUrl": "/games/snake/"
+  },
+  {
+    "id": "tetris",
+    "title": "Tetris",
+    "short": "Classic falling blocks. Clear lines, level up.",
+    "tags": ["classic", "2D"],
+    "difficulty": "medium",
+    "released": "2025-08-26",
+    "playUrl": "/games/tetris/"
+  },
+  {
+    "id": "breakout",
+    "title": "Breakout",
+    "short": "Smash bricks, power-ups, chase the score.",
+    "tags": ["classic", "2D"],
+    "difficulty": "medium",
+    "released": "2025-08-26",
+    "playUrl": "/games/breakout/"
+  },
+  {
+    "id": "chess",
+    "title": "Chess (2D)",
+    "short": "Traditional chess for two players.",
+    "tags": ["classic", "board"],
+    "difficulty": "hard",
+    "released": "2025-08-20",
+    "playUrl": "/games/chess/"
+  },
+  {
+    "id": "chess3d",
+    "title": "Chess 3D (Local)",
+    "short": "A three-dimensional chess experiment.",
+    "tags": ["3D", "offline"],
+    "difficulty": "hard",
+    "released": "2025-08-27",
+    "playUrl": "/games/chess3d/"
+  },
+  {
+    "id": "g2048",
+    "title": "2048",
+    "short": "Slide numbers to reach 2048.",
+    "tags": ["puzzle", "2D"],
+    "difficulty": "medium",
+    "released": "2025-08-20",
+    "playUrl": "/games/2048/"
+  },
+  {
+    "id": "asteroids",
+    "title": "Asteroids",
+    "short": "Pilot your ship and blast space rocks.",
+    "tags": ["classic", "2D"],
+    "difficulty": "hard",
+    "released": "2025-08-27",
+    "playUrl": "/games/asteroids/"
+  },
+  {
+    "id": "box3d",
+    "title": "3D Box Playground",
+    "short": "A tiny Three.js scene—rotate and vibe.",
+    "tags": ["3D", "demo"],
+    "difficulty": "easy",
+    "released": "2025-08-15",
+    "playUrl": "/games/box3d/"
+  },
+  {
+    "id": "maze3d",
+    "title": "Maze 3D",
+    "short": "Wander a first-person labyrinth to find the exit.",
+    "tags": ["3D"],
+    "difficulty": "medium",
+    "released": "2025-08-27",
+    "playUrl": "/games/maze3d/"
+  },
+  {
+    "id": "platformer",
+    "title": "Pixel Platformer",
+    "short": "Run and jump across platforms to reach the goal.",
+    "tags": ["2D"],
+    "difficulty": "medium",
+    "released": "2025-08-27",
+    "playUrl": "/games/platformer/"
+  },
+  {
+    "id": "runner",
+    "title": "City Runner",
+    "short": "Dash through the city and avoid obstacles.",
+    "tags": ["2D"],
+    "difficulty": "medium",
+    "released": "2025-08-27",
+    "playUrl": "/games/runner/"
+  },
+  {
+    "id": "shooter",
+    "title": "Alien Shooter",
+    "short": "Blast waves of invaders and survive.",
+    "tags": ["2D"],
+    "difficulty": "hard",
+    "released": "2025-08-27",
+    "playUrl": "/games/shooter/"
+  }
+]

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -10,7 +10,7 @@ router.register('/leaderboards', () => import('./pages/leaderboards.js'));
 router.register('/about', () => import('./pages/about.js'));
 router.register('/game/:id', () => import('./pages/game.js'), async ({ id }) => {
   try {
-    const res = await fetch('/games.json');
+    const res = await fetch('/data/games.json');
     const games = await res.json();
     return Array.isArray(games) && games.some(g => g.id === id);
   } catch {

--- a/scripts/components/game-card.js
+++ b/scripts/components/game-card.js
@@ -1,0 +1,32 @@
+import { loadStyle } from '../utils.js';
+
+loadStyle('styles/components/game-card.css');
+
+const template = document.createElement('template');
+template.innerHTML = `
+  <article class="game-card">
+    <h3 class="game-title"></h3>
+    <p class="game-short"></p>
+    <div class="tags"></div>
+    <a class="play" href="#">Play</a>
+  </article>
+`;
+
+export function createGameCard(game) {
+  const fragment = template.content.cloneNode(true);
+  const card = fragment.querySelector('.game-card');
+  card.querySelector('.game-title').textContent = game.title;
+  card.querySelector('.game-short').textContent = game.short || '';
+  const tagsEl = card.querySelector('.tags');
+  (game.tags || []).forEach(tag => {
+    const chip = document.createElement('span');
+    chip.className = 'tag';
+    chip.textContent = tag;
+    tagsEl.appendChild(chip);
+  });
+  const link = card.querySelector('.play');
+  link.href = `/game/${game.id}`;
+  return card;
+}
+
+export default createGameCard;

--- a/scripts/pages/categories.js
+++ b/scripts/pages/categories.js
@@ -2,7 +2,7 @@ import { loadStyle } from '../utils.js';
 
 export default async function(outlet){
   loadStyle('styles/pages/categories.css');
-  const res = await fetch('/games.json');
+  const res = await fetch('/data/games.json');
   const games = await res.json();
   const tags = new Map();
   games.forEach(g => (g.tags||[]).forEach(t => tags.set(t, (tags.get(t)||0)+1)));

--- a/scripts/pages/game.js
+++ b/scripts/pages/game.js
@@ -1,10 +1,17 @@
 import { loadStyle } from '../utils.js';
 
-export default function(outlet, params){
+export default async function(outlet, params){
   loadStyle('styles/pages/game.css');
+  let src = `/games/${params.id}/`;
+  try {
+    const res = await fetch('/data/games.json');
+    const games = await res.json();
+    const game = Array.isArray(games) ? games.find(g => g.id === params.id) : null;
+    if (game && game.playUrl) src = game.playUrl;
+  } catch {}
   const frame = document.createElement('iframe');
   frame.id = 'game-frame';
-  frame.src = `/games/${params.id}/`;
+  frame.src = src;
   frame.loading = 'lazy';
   outlet.appendChild(frame);
 }

--- a/scripts/pages/games.js
+++ b/scripts/pages/games.js
@@ -1,17 +1,19 @@
 import { loadStyle } from '../utils.js';
+import { createGameCard } from '../components/game-card.js';
 
 export default async function(outlet){
   loadStyle('styles/pages/games.css');
-  const res = await fetch('/games.json');
+  loadStyle('styles/components/game-grid.css');
+  const res = await fetch('/data/games.json');
   const games = await res.json();
   const section = document.createElement('section');
   section.innerHTML = '<h2>All Games</h2>';
-  const list = document.createElement('ul');
+  const grid = document.createElement('div');
+  grid.className = 'grid';
   games.forEach(g => {
-    const li = document.createElement('li');
-    li.innerHTML = `<a href="/game/${g.id}">${g.title}</a>`;
-    list.appendChild(li);
+    const card = createGameCard(g);
+    grid.appendChild(card);
   });
-  section.appendChild(list);
+  section.appendChild(grid);
   outlet.appendChild(section);
 }

--- a/scripts/pages/home.js
+++ b/scripts/pages/home.js
@@ -1,21 +1,17 @@
 import { loadStyle } from '../utils.js';
+import { createGameCard } from '../components/game-card.js';
 
 export default async function(outlet){
   loadStyle('styles/pages/home.css');
-  const res = await fetch('/games.json');
+  loadStyle('styles/components/game-grid.css');
+  const res = await fetch('/data/games.json');
   const games = await res.json();
   const section = document.createElement('section');
   section.innerHTML = '<h2>Play Now</h2>';
   const grid = document.createElement('div');
   grid.className = 'grid';
   games.forEach(g => {
-    const card = document.createElement('div');
-    card.className = 'card';
-    card.innerHTML = `
-      <h3>${g.title}</h3>
-      <p>${g.desc || ''}</p>
-      <a href="/game/${g.id}">Play</a>
-    `;
+    const card = createGameCard(g);
     grid.appendChild(card);
   });
   section.appendChild(grid);

--- a/styles/components/game-card.css
+++ b/styles/components/game-card.css
@@ -1,0 +1,37 @@
+.game-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.game-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.game-card .tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.game-card .tag {
+  background: #eee;
+  border-radius: 3px;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+}
+
+.game-card .play {
+  align-self: flex-start;
+  padding: 4px 8px;
+  background: #0070f3;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}

--- a/styles/components/game-grid.css
+++ b/styles/components/game-grid.css
@@ -1,0 +1,17 @@
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1280px) {
+  .grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -12,6 +12,7 @@ const CORE = [
   '/assets/logo.svg',
   '/assets/favicon.png',
   '/games.json',
+  '/data/games.json',
   '/404.html'
 ];
 


### PR DESCRIPTION
## Summary
- add `/data/games.json` dataset
- render Home and All Games grids from data using `GameCard`
- route games via new JSON and preload in service worker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25f71154c8327a99135d72727d04c