### PR TITLE
feat: add help overlay with localStorage persistence

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -141,6 +141,33 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
 }
 .pause-overlay button { margin:6px; }
 
+/* Help overlay */
+.help-overlay {
+  position:fixed;
+  inset:0;
+  backdrop-filter:blur(4px);
+  background:rgba(0,0,0,.35);
+  display:grid;
+  place-items:center;
+  z-index:999;
+}
+.help-overlay.hidden { display:none; }
+.help-overlay .panel {
+  background: var(--panel-bg);
+  color: var(--panel-fg);
+  padding:24px;
+  border-radius:12px;
+  max-width:360px;
+  text-align:left;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.45);
+}
+.help-overlay section { margin-bottom:12px; }
+.help-overlay h4 { margin:0 0 4px 0; font:700 16px Inter,system-ui; }
+.help-overlay .footer { display:flex; justify-content:space-between; align-items:center; margin-top:12px; }
+.help-overlay .footer .actions { display:flex; gap:6px; }
+.help-overlay .step-indicator { font-size:14px; opacity:.8; }
+.help-overlay button { margin-left:6px; }
+
 /* Utility badges/tags */
 .chip { display:inline-flex; align-items:center; gap:6px; padding:6px 10px; border:1px solid var(--border); border-radius:999px; background:rgba(255,255,255,0.04) }
 .chip .dot { width:8px; height:8px; border-radius:50%; background: var(--accent); }

--- a/tests/help-overlay.test.js
+++ b/tests/help-overlay.test.js
@@ -1,0 +1,29 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { attachHelpOverlay } from '../shared/ui.js';
+
+const steps = [{ objective: 'Win', controls: 'Arrows', tips: 'Good luck' }];
+
+describe('attachHelpOverlay', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('shows overlay automatically on first run and sets localStorage flag', () => {
+    attachHelpOverlay({ gameId: 'game1', steps });
+    const overlay = document.querySelector('.help-overlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay.classList.contains('hidden')).toBe(false);
+    const seen = JSON.parse(localStorage.getItem('seenHints'));
+    expect(seen.game1).toBe(true);
+  });
+
+  it('does not auto show when already seen', () => {
+    localStorage.setItem('seenHints', JSON.stringify({ game1: true }));
+    attachHelpOverlay({ gameId: 'game1', steps });
+    const overlay = document.querySelector('.help-overlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay.classList.contains('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable help overlay with step navigation and first-run storage
- style help overlay and step indicator
- test help overlay first-run and persistence behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25ffee68c8327b6b3019004de937d