### PR TITLE
Add help button overlay to games

### DIFF
--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -7,7 +7,7 @@ import { ShaderPass } from 'https://unpkg.com/three@0.160.0/examples/jsm/postpro
 import { FXAAShader } from 'https://unpkg.com/three@0.160.0/examples/jsm/shaders/FXAAShader.js';
 import { SSAOPass } from 'https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/SSAOPass.js';
 import { registerSW } from '../../shared/sw.js';
-import { injectBackButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
+import { injectBackButton, injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 
 const params = new URLSearchParams(location.search);
@@ -44,6 +44,14 @@ document.getElementById('exportBtn')?.style.setProperty('display', 'none');
 
 registerSW();
 injectBackButton();
+const helpSteps = [
+  {
+    objective: 'Collect the glowing orbs',
+    controls: 'WASD move • Mouse look • Space jump • R reset',
+    tips: 'Touch orbs to earn points'
+  }
+];
+injectHelpButton({ gameId: 'box3d', steps: helpSteps });
 recordLastPlayed('box3d');
 emitEvent({ type: 'play', slug: 'box3d' });
 

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -8,8 +8,18 @@ import { mountThemePicker } from "./ui/themePicker.js";
 import { mountCameraPresets } from "./ui/cameraPresets.js";
 import { envDataUrl } from "./textures/env.js";
 import { log, warn } from '../../tools/reporters/console-signature.ts';
+import { injectHelpButton } from '../../shared/ui.js';
 
 log('chess3d', '[Chess3D] booting');
+
+const helpSteps = [
+  {
+    objective: 'Checkmate the opposing king',
+    controls: 'Drag pieces • Use presets for views',
+    tips: 'Adjust difficulty from the dropdown'
+  }
+];
+injectHelpButton({ gameId: 'chess3d', steps: helpSteps });
 
 const stage = document.getElementById('stage');
 const statusEl = document.getElementById('status');

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -1,7 +1,15 @@
-import { recordLastPlayed, shareScore } from '../../shared/ui.js';
+import { injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 import { connect } from './net.js';
 
+const helpSteps = [
+  {
+    objective: 'Reach the maze exit',
+    controls: 'WASD move • Mouse look • P pause • R restart',
+    tips: 'Use the minimap for navigation'
+  }
+];
+injectHelpButton({ gameId: 'maze3d', steps: helpSteps });
 recordLastPlayed('maze3d');
 
 const scene = new THREE.Scene();

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1,7 +1,15 @@
-import { recordLastPlayed, shareScore } from '../../shared/ui.js';
+import { injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 import * as net from './net.js';
 
+const helpSteps = [
+  {
+    objective: 'Reach the end of the level',
+    controls: 'Arrow keys move • Space/Up jump • P pause • R restart',
+    tips: 'Collect items and avoid enemies'
+  }
+];
+injectHelpButton({ gameId: 'platformer', steps: helpSteps });
 recordLastPlayed('platformer');
 emitEvent({ type: 'play', slug: 'platformer' });
 

--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -1,6 +1,6 @@
 import { createGamepad } from '../../shared/controls.js';
 import { Controls } from '../../src/runtime/controls.ts';
-import { attachPauseOverlay, saveBestScore, shareScore } from '../../shared/ui.js';
+import { attachPauseOverlay, injectHelpButton, saveBestScore, shareScore } from '../../shared/ui.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
 
@@ -70,6 +70,15 @@ sndSel.onchange = ()=> { sounds = sndSel.value; };
 
 // Pause overlay
 const overlay = attachPauseOverlay({ onResume: ()=> running=true, onRestart: ()=> restart() });
+
+const helpSteps = [
+  {
+    objective: 'Score 11 points to win',
+    controls: 'W/S or ↑/↓ move • Space/Enter serve • P pause • R restart',
+    tips: 'Change difficulty from the menu'
+  }
+];
+injectHelpButton({ gameId: 'pong', steps: helpSteps });
 
 // Audio (synthesized with WebAudio)
 const AC = window.AudioContext ? new AudioContext() : null;

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1,4 +1,4 @@
-import { injectBackButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
+import { injectBackButton, injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 import Net from './net.js';
 
@@ -11,6 +11,14 @@ const bestEl  = document.getElementById('best');
 const shareBtn = document.getElementById('shareBtn');
 
 injectBackButton();
+const helpSteps = [
+  {
+    objective: 'Survive and score points',
+    controls: 'WASD move • Space shoot • P pause • R restart',
+    tips: 'Use T for turret and F for wall'
+  }
+];
+injectHelpButton({ gameId: 'shooter', steps: helpSteps });
 recordLastPlayed('shooter');
 emitEvent({ type: 'play', slug: 'shooter' });
 

--- a/shared/game-boot.js
+++ b/shared/game-boot.js
@@ -1,6 +1,6 @@
 // shared/game-boot.js
 // Usage in a game page: <script type="module" src="../../shared/game-boot.js" data-slug="runner"></script>
-import { injectBackButton, recordLastPlayed } from './ui.js';
+import { injectBackButton, injectHelpButton, recordLastPlayed } from './ui.js';
 import { recordPlay } from './quests.js';
 import { renderFallbackPanel } from './fallback.js';
 
@@ -11,6 +11,7 @@ const urlSlug = pathSegments.slice(-1)[0];
 const slug = currentScript?.dataset?.slug || urlSlug || 'unknown';
 
 injectBackButton('/');
+injectHelpButton({ gameId: slug, steps: window.helpSteps || [] });
 recordLastPlayed(slug);
 
 async function track(){

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -54,6 +54,45 @@ export function injectBackButton(href = '../../') {
   a.href = href;
 }
 
+export function injectHelpButton(opts) {
+  // ensure styles are injected once
+  if (!document.head.querySelector('style[data-help-btn]')) {
+    const style = document.createElement('style');
+    style.setAttribute('data-help-btn', '');
+    style.textContent = `
+      .help-btn {
+        position: fixed;
+        top: 10px;
+        right: 10px;
+        width: 32px;
+        height: 32px;
+        padding: 0;
+        background: var(--button-bg);
+        color: var(--fg);
+        border-radius: 50%;
+        border: 1px solid var(--button-border);
+        z-index: 1000;
+        cursor: pointer;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  let btn = document.querySelector('.help-btn');
+  if (!btn) {
+    btn = document.createElement('button');
+    btn.className = 'help-btn';
+    btn.textContent = '?';
+    document.body.appendChild(btn);
+  }
+
+  let overlay;
+  btn.onclick = () => {
+    overlay = overlay || attachHelpOverlay(opts || { gameId: 'unknown', steps: [] });
+    overlay.show();
+  };
+}
+
 export function recordLastPlayed(slug) {
   try {
     const raw = localStorage.getItem('lastPlayed');


### PR DESCRIPTION
## Summary
- add `injectHelpButton` to inject a persistent help button and display help overlays
- call `injectHelpButton` from `game-boot.js` for games using the boot script
- wire non-boot games to `injectHelpButton` so the help overlay is available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c260e16058832799b13f2be31df100