### PR TITLE
Improve help overlay accessibility

### DIFF
--- a/shared/ui.js
+++ b/shared/ui.js
@@ -178,6 +178,7 @@ export function attachHelpOverlay({ gameId, steps }) {
   overlay.setAttribute('aria-modal', 'true');
   overlay.innerHTML = `
     <div class="panel">
+      <button class="close-icon" aria-label="Close">\u00d7</button>
       <div class="step-content"></div>
       <div class="footer">
         <span class="step-indicator"></span>
@@ -200,11 +201,17 @@ export function attachHelpOverlay({ gameId, steps }) {
     overlay.querySelector('.step-indicator').textContent = `${index + 1}/${steps.length}`;
   };
 
-  const hide = () => overlay.classList.add('hidden');
+  const onKeyDown = e => { if (e.key === 'Escape') hide(); };
+  const hide = () => {
+    overlay.classList.add('hidden');
+    document.removeEventListener('keydown', onKeyDown);
+    document.querySelector('.help-btn')?.focus();
+  };
   const show = () => {
     index = 0;
     render();
     overlay.classList.remove('hidden');
+    document.addEventListener('keydown', onKeyDown);
     try {
       const raw = localStorage.getItem('seenHints') || '{}';
       const obj = JSON.parse(raw);
@@ -213,6 +220,7 @@ export function attachHelpOverlay({ gameId, steps }) {
     } catch {}
   };
 
+  overlay.addEventListener('click', e => { if (e.target === overlay) hide(); });
   overlay.querySelector('.next-btn').onclick = () => {
     if (index < steps.length - 1) {
       index++;
@@ -222,6 +230,7 @@ export function attachHelpOverlay({ gameId, steps }) {
     }
   };
   overlay.querySelector('.close-btn').onclick = hide;
+  overlay.querySelector('.close-icon').onclick = hide;
 
   let seen = false;
   try {

--- a/styles.css
+++ b/styles.css
@@ -153,6 +153,7 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
 }
 .help-overlay.hidden { display:none; }
 .help-overlay .panel {
+  position:relative;
   background: var(--panel-bg);
   color: var(--panel-fg);
   padding:24px;
@@ -167,6 +168,18 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
 .help-overlay .footer .actions { display:flex; gap:6px; }
 .help-overlay .step-indicator { font-size:14px; opacity:.8; }
 .help-overlay button { margin-left:6px; }
+
+.help-overlay .close-icon {
+  position:absolute;
+  top:8px;
+  right:8px;
+  background:none;
+  border:none;
+  font-size:18px;
+  line-height:1;
+  cursor:pointer;
+  margin:0;
+}
 
 /* Utility badges/tags */
 .chip { display:inline-flex; align-items:center; gap:6px; padding:6px 10px; border:1px solid var(--border); border-radius:999px; background:rgba(255,255,255,0.04) }

--- a/tests/help-overlay.test.js
+++ b/tests/help-overlay.test.js
@@ -26,4 +26,33 @@ describe('attachHelpOverlay', () => {
     expect(overlay).toBeTruthy();
     expect(overlay.classList.contains('hidden')).toBe(true);
   });
+
+  it('hides on Escape and returns focus to help button', () => {
+    document.body.innerHTML = '<button class="help-btn">?</button>';
+    localStorage.setItem('seenHints', JSON.stringify({ game1: true }));
+    const { show } = attachHelpOverlay({ gameId: 'game1', steps });
+    show();
+    const overlay = document.querySelector('.help-overlay');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(overlay.classList.contains('hidden')).toBe(true);
+    expect(document.activeElement.classList.contains('help-btn')).toBe(true);
+  });
+
+  it('closes when clicking backdrop', () => {
+    document.body.innerHTML = '<button class="help-btn">?</button>';
+    localStorage.setItem('seenHints', JSON.stringify({ game1: true }));
+    const { show } = attachHelpOverlay({ gameId: 'game1', steps });
+    show();
+    const overlay = document.querySelector('.help-overlay');
+    overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(overlay.classList.contains('hidden')).toBe(true);
+  });
+
+  it('renders an accessible close icon', () => {
+    const { show } = attachHelpOverlay({ gameId: 'game1', steps });
+    show();
+    const closeIcon = document.querySelector('.help-overlay .close-icon');
+    expect(closeIcon).toBeTruthy();
+    expect(closeIcon.getAttribute('aria-label')).toBe('Close');
+  });
 });


### PR DESCRIPTION
## Summary
- Add Escape key handler and backdrop click to close help overlay while returning focus to the trigger button.
- Introduce a visible "X" close icon with dedicated styling for better accessibility.
- Expand tests to cover new closing behaviors and focus management.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2622d128883278759875b106e120f