### PR TITLE
Skip caching non-HTTP requests in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -59,10 +59,19 @@ self.addEventListener('fetch', event => {
   event.respondWith(
     fetch(request)
       .then(resp => {
-        const copy = resp.clone();
-        caches.open(VERSION).then(cache => cache.put(request, copy));
+        const url = new URL(request.url);
+        if (url.protocol.startsWith('http')) {
+          const copy = resp.clone();
+          caches.open(VERSION).then(cache => cache.put(request, copy));
+        }
         return resp;
       })
-      .catch(() => caches.match(request).then(r => r || offlineFallback(request)))
+      .catch(err => {
+        const url = new URL(request.url);
+        if (url.protocol.startsWith('http')) {
+          return caches.match(request).then(r => r || offlineFallback(request));
+        }
+        throw err;
+      })
   );
 });


### PR DESCRIPTION
## Summary
- Prevent the service worker from caching requests with non-http protocols
- Continue caching HTTP(S) responses and fallback to offline page when needed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c269da82308327a17673060fbb22d5