### PR TITLE
test: add axe-core accessibility check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "acorn": "^8.15.0",
+        "axe-core": "^4.10.3",
         "jsdom": "^24.0.0",
         "service-worker-mock": "^2.0.5",
         "vitest": "^1.6.0"
@@ -990,6 +991,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "acorn": "^8.15.0",
+    "axe-core": "^4.10.3",
     "jsdom": "^24.0.0",
     "service-worker-mock": "^2.0.5",
     "vitest": "^1.6.0"

--- a/tests/help-overlay.a11y.test.js
+++ b/tests/help-overlay.a11y.test.js
@@ -1,0 +1,20 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { attachHelpOverlay } from '../shared/ui.js';
+import axe from 'axe-core';
+
+const opts = { gameId: 'game1', objective: 'Win', controls: 'Arrows', tips: ['Good luck'], steps: ['Step'] };
+
+describe('help overlay accessibility', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('has no critical axe violations', async () => {
+    const { show } = attachHelpOverlay(opts);
+    show();
+    const results = await axe.run(document);
+    expect(results.violations.filter(v => v.impact === 'critical').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add axe-core dev dependency
- introduce accessibility test for help overlay and assert no critical violations

## Testing
- `npm test`
- `npm test tests/help-overlay.a11y.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c26c11487883279755c90c3743801f