### PR TITLE
feat: add reusable game loop engine

### DIFF
--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -4,6 +4,7 @@ import { attachPauseOverlay, injectHelpButton, saveBestScore, shareScore } from 
 import games from '../../games.json' assert { type: 'json' };
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
+import { GameEngine } from '../../shared/gameEngine.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -126,18 +127,6 @@ function updateAI(){
   right.y += clamp(delta, -speed, speed);
 }
 
-// Game loop with fixed timestep
-let last = performance.now(), acc = 0, dt = 1000/60;
-function loop(t){
-  requestAnimationFrame(loop);
-  acc += t-last; last = t;
-  while (acc >= dt){
-    tick(dt/1000);
-    acc -= dt;
-  }
-  render();
-}
-requestAnimationFrame(loop);
 
 // Tick/update
 function tick(dt){
@@ -257,6 +246,11 @@ function render(){
     ctx.globalAlpha = 1;
   }
 }
+
+const engine = new GameEngine();
+engine.update = tick;
+engine.render = render;
+engine.start();
 
 // Session timing
 startSessionTimer('pong');

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -1,0 +1,41 @@
+export class GameEngine {
+  constructor({ fps = 60 } = {}) {
+    this.fps = fps;
+    this.dt = 1000 / fps;
+    this.acc = 0;
+    this.last = 0;
+    this.rafId = null;
+    this.running = false;
+  }
+
+  start() {
+    if (this.running) return;
+    this.running = true;
+    this.last = performance.now();
+    const loop = (t) => {
+      if (!this.running) return;
+      this.rafId = requestAnimationFrame(loop);
+      this.acc += t - this.last;
+      this.last = t;
+      while (this.acc >= this.dt) {
+        this.update(this.dt / 1000);
+        this.acc -= this.dt;
+      }
+      this.render();
+    };
+    this.rafId = requestAnimationFrame(loop);
+  }
+
+  stop() {
+    this.running = false;
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+  }
+
+  // Hooks
+  update(_dt) {}
+  render() {}
+}
+export default GameEngine;


### PR DESCRIPTION
## Summary
- add generic GameEngine with start/stop/update/render hooks
- refactor Pong main to use new engine instead of manual requestAnimationFrame loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c26d47403c83279c761bc472e84326