### PR TITLE
Refactor 2048 engine and hint system

### DIFF
--- a/games/2048/engine.js
+++ b/games/2048/engine.js
@@ -1,0 +1,164 @@
+export function copyGrid(grid){
+  return grid.map(r=>r.slice());
+}
+
+function slideRowLeft(row){
+  const a=row.filter(v=>v); let gained=0;
+  for(let i=0;i<a.length-1;i++){
+    if(a[i]===a[i+1]){ a[i]*=2; gained+=a[i]; a.splice(i+1,1); }
+  }
+  while(a.length<row.length) a.push(0);
+  return {row:a,gained};
+}
+
+export function computeMove(grid, dir){
+  const N=grid.length;
+  const after=Array.from({length:N},()=>Array(N).fill(0));
+  const animations=[]; let moved=false; let gained=0;
+  if(dir===0){
+    for(let y=0;y<N;y++){
+      let target=0, lastMerge=-1;
+      for(let x=0;x<N;x++){
+        const v=grid[y][x]; if(!v) continue;
+        if(after[y][target]===0){
+          after[y][target]=v; if(target!==x) moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:target,toY:y});
+        }else if(after[y][target]===v && lastMerge!==target){
+          after[y][target]+=v; gained+=after[y][target]; lastMerge=target; moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:target,toY:y});
+        }else{
+          target++; after[y][target]=v; if(target!==x) moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:target,toY:y});
+        }
+      }
+    }
+  }else if(dir===2){
+    for(let y=0;y<N;y++){
+      let target=0, lastMerge=-1;
+      for(let x=0;x<N;x++){
+        const v=grid[y][N-1-x]; if(!v) continue;
+        const fromX=N-1-x, toX=N-1-target;
+        if(after[y][toX]===0){
+          after[y][toX]=v; if(fromX!==toX) moved=true;
+          animations.push({value:v,fromX,fromY:y,toX,toY:y});
+        }else if(after[y][toX]===v && lastMerge!==target){
+          after[y][toX]+=v; gained+=after[y][toX]; lastMerge=target; moved=true;
+          animations.push({value:v,fromX,fromY:y,toX,toY:y});
+        }else{
+          target++; const nx=N-1-target; after[y][nx]=v; if(fromX!==nx) moved=true;
+          animations.push({value:v,fromX,fromY:y,toX:nx,toY:y});
+        }
+      }
+    }
+  }else if(dir===1){
+    for(let x=0;x<N;x++){
+      let target=0, lastMerge=-1;
+      for(let y=0;y<N;y++){
+        const v=grid[y][x]; if(!v) continue;
+        if(after[target][x]===0){
+          after[target][x]=v; if(target!==y) moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:x,toY:target});
+        }else if(after[target][x]===v && lastMerge!==target){
+          after[target][x]+=v; gained+=after[target][x]; lastMerge=target; moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:x,toY:target});
+        }else{
+          target++; after[target][x]=v; if(target!==y) moved=true;
+          animations.push({value:v,fromX:x,fromY:y,toX:x,toY:target});
+        }
+      }
+    }
+  }else if(dir===3){
+    for(let x=0;x<N;x++){
+      let target=0, lastMerge=-1;
+      for(let y=0;y<N;y++){
+        const v=grid[N-1-y][x]; if(!v) continue;
+        const fromY=N-1-y, toY=N-1-target;
+        if(after[toY][x]===0){
+          after[toY][x]=v; if(fromY!==toY) moved=true;
+          animations.push({value:v,fromX:x,fromY,toX:x,toY});
+        }else if(after[toY][x]===v && lastMerge!==target){
+          after[toY][x]+=v; gained+=after[toY][x]; lastMerge=target; moved=true;
+          animations.push({value:v,fromX:x,fromY,toX:x,toY});
+        }else{
+          target++; const ny=N-1-target; after[ny][x]=v; if(fromY!==ny) moved=true;
+          animations.push({value:v,fromX:x,fromY,toX:x,toY:ny});
+        }
+      }
+    }
+  }
+  return {after, animations, moved, gained};
+}
+
+export function pushState(history, grid, score){
+  const h=[...history,{grid:copyGrid(grid),score}];
+  if(h.length>10) h.shift();
+  return h;
+}
+
+export function undo(history){
+  if(history.length<=1) return null;
+  const h=history.slice(0,-1);
+  const {grid,score}=h[h.length-1];
+  return {grid:copyGrid(grid),score,history:h};
+}
+
+export function canMove(grid){
+  const N=grid.length;
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+    if(grid[y][x]===0) return true;
+    if(x+1<N && grid[y][x]===grid[y][x+1]) return true;
+    if(y+1<N && grid[y][x]===grid[y+1][x]) return true;
+  }
+  return false;
+}
+
+export function simulate(grid, score, dir){
+  const {after,moved,gained}=computeMove(grid,dir);
+  if(!moved) return null;
+  return {grid:after,score:score+gained,max:Math.max(...after.flat())};
+}
+
+function heuristic(grid){
+  let max=0, empty=0;
+  for(const row of grid) for(const v of row){
+    if(v===0) empty++; else if(v>max) max=v;
+  }
+  return max + empty;
+}
+
+function expectimax(grid, depth, isPlayer){
+  if(depth===0 || !canMove(grid)) return heuristic(grid);
+  if(isPlayer){
+    let best=-Infinity;
+    for(let d=0;d<4;d++){
+      const {after,moved,gained}=computeMove(grid,d);
+      if(!moved) continue;
+      const val=gained+expectimax(after, depth-1, false);
+      if(val>best) best=val;
+    }
+    return best===-Infinity?heuristic(grid):best;
+  }else{
+    const cells=[]; const N=grid.length;
+    for(let y=0;y<N;y++) for(let x=0;x<N;x++) if(grid[y][x]===0) cells.push([x,y]);
+    if(!cells.length) return heuristic(grid);
+    let total=0;
+    for(const [x,y] of cells){
+      const g2=copyGrid(grid); g2[y][x]=2;
+      total+=0.9*expectimax(g2, depth-1, true);
+      const g4=copyGrid(grid); g4[y][x]=4;
+      total+=0.1*expectimax(g4, depth-1, true);
+    }
+    return total/cells.length;
+  }
+}
+
+export function getHint(grid, depth){
+  let bestDir=null, bestVal=-Infinity;
+  for(let d=0;d<4;d++){
+    const {after,moved,gained}=computeMove(grid,d);
+    if(!moved) continue;
+    const val=gained+expectimax(after, depth-1, false);
+    if(val>bestVal){ bestVal=val; bestDir=d; }
+  }
+  return bestDir;
+}

--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -29,12 +29,17 @@
         <option value="7">7×7</option>
         <option value="8">8×8</option>
       </select>
+      <select id="diffSel" style="border:1px solid #243047;background:#111827;color:#e6e7ea;padding:8px 16px;border-radius:8px;margin-left:8px;cursor:pointer;">
+        <option value="1">Easy</option>
+        <option value="3" selected>Medium</option>
+        <option value="5">Hard</option>
+      </select>
       <button id="themeToggle" style="border:1px solid #243047;background:#111827;color:#e6e7ea;padding:8px 16px;border-radius:8px;margin-left:8px;cursor:pointer;">Theme</button>
     </div>
   </div>
   <script src="../../js/hud.js?v=5.3"></script>
   <script src="net.js?v=5.3"></script>
-  <script src="g2048.js?v=5.3"></script>
+  <script type="module" src="g2048.js?v=5.3"></script>
   <script src="../../js/input.js?v=5.3"></script>
   <script src="../../js/remapUI.js?v=5.3"></script>
   <script src="../../js/perfHud.js?v=5.3"></script>


### PR DESCRIPTION
## Summary
- Extract 2048 board logic into a pure `engine.js` with move/undo and expectimax hinting
- Switch to shared `GameEngine` loop for delta-time tile animations
- Add difficulty setting for deeper hints and load game script as module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c26ec1e2f88327880dfcc4c2d21411