### PR TITLE
feat(asteroids): add enemy classes and dt physics

### DIFF
--- a/games/asteroids/enemies.js
+++ b/games/asteroids/enemies.js
@@ -1,0 +1,90 @@
+export const patternTables = {
+  zigzag: [
+    { vy: 1.5, time: 60 },
+    { vy: -1.5, time: 60 }
+  ],
+  spiral: { interval: 0.2, speed: 3, step: Math.PI / 6 },
+  targeted: { interval: 1.5, speed: 5 }
+};
+
+export class Saucer {
+  constructor(x, y, dir = 1, pattern = patternTables.zigzag) {
+    this.type = 'saucer';
+    this.x = x;
+    this.y = y;
+    this.vx = dir * 2.2; // per frame units
+    this.vy = 0;
+    this.r = 12;
+    this.hp = 2;
+    this.fire = 0;
+    this.pattern = pattern;
+    this.pIndex = 0;
+    this.pTime = pattern[0].time;
+  }
+
+  update(dt, ship, bullets) {
+    const mul = dt * 60; // convert seconds to frame units
+    this.pTime -= mul;
+    if (this.pTime <= 0) {
+      this.pIndex = (this.pIndex + 1) % this.pattern.length;
+      this.pTime += this.pattern[this.pIndex].time;
+    }
+    this.vy = this.pattern[this.pIndex].vy;
+
+    this.x += this.vx * mul;
+    this.y += this.vy * mul;
+
+    this.fire -= dt;
+    if (this.fire <= 0) {
+      this.fire = 1.2 + Math.random() * 0.8;
+      const dx = ship.x - this.x;
+      const dy = ship.y - this.y;
+      const a = Math.atan2(dy, dx);
+      const sp = 4.5;
+      bullets.push({ x: this.x, y: this.y, vx: Math.cos(a) * sp, vy: Math.sin(a) * sp, life: 180, enemy: true });
+    }
+  }
+}
+
+export class Boss {
+  constructor(x, y, dir = 1) {
+    this.type = 'boss';
+    this.x = x;
+    this.y = y;
+    this.vx = dir * 3; // per frame units
+    this.vy = 0;
+    this.r = 20;
+    this.hp = 8;
+    this.spiralAngle = 0;
+    this.spiralTimer = patternTables.spiral.interval;
+    this.targetTimer = patternTables.targeted.interval;
+  }
+
+  update(dt, ship, bullets) {
+    const mul = dt * 60;
+    this.x += this.vx * mul;
+    this.y += this.vy * mul;
+
+    // spiral shots
+    this.spiralTimer -= dt;
+    if (this.spiralTimer <= 0) {
+      this.spiralTimer += patternTables.spiral.interval;
+      const sp = patternTables.spiral.speed;
+      bullets.push({ x: this.x, y: this.y, vx: Math.cos(this.spiralAngle) * sp, vy: Math.sin(this.spiralAngle) * sp, life: 200, enemy: true });
+      this.spiralAngle += patternTables.spiral.step;
+    }
+
+    // targeted shots
+    this.targetTimer -= dt;
+    if (this.targetTimer <= 0) {
+      this.targetTimer += patternTables.targeted.interval;
+      const dx = ship.x - this.x;
+      const dy = ship.y - this.y;
+      const a = Math.atan2(dy, dx);
+      const sp = patternTables.targeted.speed;
+      bullets.push({ x: this.x, y: this.y, vx: Math.cos(a) * sp, vy: Math.sin(a) * sp, life: 200, enemy: true });
+    }
+  }
+}
+
+export default { Saucer, Boss, patternTables };

--- a/games/asteroids/net.js
+++ b/games/asteroids/net.js
@@ -11,7 +11,8 @@ const cbs = {
   ship: [],
   shot: [],
   rocks: [],
-  players: []
+  players: [],
+  enemy: []
 };
 
 function connect(){
@@ -32,6 +33,7 @@ function connect(){
     else if (type === 'ship' && msg.id !== myId){ cbs.ship.forEach(f=>f(msg.id, msg.ship)); }
     else if (type === 'shot' && msg.id !== myId){ cbs.shot.forEach(f=>f(msg.id, msg.bullet)); }
     else if (type === 'rocks'){ cbs.rocks.forEach(f=>f(msg.rocks)); }
+    else if (type === 'enemy' && msg.id !== myId){ cbs.enemy.forEach(f=>f(msg.enemy)); }
     else if (type === 'stats' && msg.id !== myId){
       players[msg.id] = { score: msg.score, lives: msg.lives };
       cbs.players.forEach(f=>f(players));
@@ -56,11 +58,13 @@ function send(type, data){
 function sendShip(ship){ send('ship', { ship }); }
 function sendShot(bullet){ send('shot', { bullet }); }
 function sendRocks(rocks){ send('rocks', { rocks }); }
+function sendEnemy(enemy){ send('enemy', { enemy }); }
 function sendStats(score, lives){ send('stats', { score, lives }); }
 
 function onShip(cb){ cbs.ship.push(cb); }
 function onShot(cb){ cbs.shot.push(cb); }
 function onRocks(cb){ cbs.rocks.push(cb); }
+function onEnemy(cb){ cbs.enemy.push(cb); }
 function onPlayers(cb){ cbs.players.push(cb); }
 
-export { connect, disconnect, sendShip, sendShot, sendRocks, sendStats, onShip, onShot, onRocks, onPlayers, players };
+export { connect, disconnect, sendShip, sendShot, sendRocks, sendEnemy, sendStats, onShip, onShot, onRocks, onEnemy, onPlayers, players };


### PR DESCRIPTION
## Summary
- use shared GameEngine with delta-time physics for ship, rocks, bullets and particles
- add saucer and boss enemy classes with pattern tables and firing patterns
- sync enemy spawns in co-op sessions via websocket

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c26ec4d80c83278132cf7776c88798