### PR TITLE
Add neon SVG logo

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,10 +8,19 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/global.css" />
+  <link rel="stylesheet" href="styles/components.css" />
 </head>
 <body>
   <header>
-    <a href="/" class="logo" data-link>Gurjot's Game</a>
+    <a href="/" class="logo" data-link>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 32" role="img" aria-label="Gurjot’s Game logo">
+        <title>Gurjot’s Game</title>
+        <g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="4">
+          <path stroke="var(--accent)" d="M16 4h12a12 12 0 1 1 0 24H16V16h8" />
+          <path stroke="var(--accent2)" d="M64 4h12a12 12 0 1 1 0 24H64V16h8" />
+        </g>
+      </svg>
+    </a>
     <nav>
       <a href="/" data-link>Home</a>
       <a href="/games" data-link>All Games</a>

--- a/index.html
+++ b/index.html
@@ -8,10 +8,19 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/global.css" />
+  <link rel="stylesheet" href="styles/components.css" />
 </head>
 <body>
   <header>
-    <a href="/" class="logo" data-link>Gurjot's Game</a>
+    <a href="/" class="logo" data-link>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 32" role="img" aria-label="Gurjot’s Game logo">
+        <title>Gurjot’s Game</title>
+        <g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="4">
+          <path stroke="var(--accent)" d="M16 4h12a12 12 0 1 1 0 24H16V16h8" />
+          <path stroke="var(--accent2)" d="M64 4h12a12 12 0 1 1 0 24H64V16h8" />
+        </g>
+      </svg>
+    </a>
     <nav>
       <a href="/" data-link>Home</a>
       <a href="/games" data-link>All Games</a>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 32" role="img" aria-label="Gurjot’s Game logo">
+  <title>Gurjot’s Game</title>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="4">
+    <path stroke="var(--accent)" d="M16 4h12a12 12 0 1 1 0 24H16V16h8" />
+    <path stroke="var(--accent2)" d="M64 4h12a12 12 0 1 1 0 24H64V16h8" />
+  </g>
+</svg>

--- a/styles/components.css
+++ b/styles/components.css
@@ -1,0 +1,10 @@
+/* Component styles */
+
+/* Logo */
+header .logo svg {
+  height: 1.5rem;
+  width: auto;
+  display: block;
+  filter: drop-shadow(0 0 2px var(--accent)) drop-shadow(0 0 4px var(--accent))
+          drop-shadow(0 0 2px var(--accent2)) drop-shadow(0 0 4px var(--accent2));
+}


### PR DESCRIPTION
## Summary
- Add accessible SVG logo asset and inline it in site headers
- Introduce components stylesheet with neon glow drop-shadow for the logo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c277767de48327b2c36f746994e3e7