### PR TITLE
Add reusable component styles and theming docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ npm start
 
 Open `http://localhost:3000` in a browser and enjoy.
 
+## Branding & Theming
+
+Reusable component styles live in [styles/components.css](styles/components.css) and draw colors and spacing from the global tokens. Apply classes like `.btn`, `.card`, `.chip`, `.toolbar`, `.panel`, `.kbd`, and `.grid` to build accessible, high-contrast UI with large tap targets and visible focus outlines.
+
+
 ## Roadmap
 
 - Additional classic games

--- a/styles/components.css
+++ b/styles/components.css
@@ -1,4 +1,102 @@
-/* Component styles */
+@import "./global.css";
+
+/* Reusable component styles */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 1rem;
+  font-weight: 600;
+  background: var(--accent);
+  color: var(--bg);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  text-decoration: none;
+  cursor: pointer;
+}
+.btn:focus-visible {
+  outline: 2px solid var(--fg);
+  outline-offset: 2px;
+}
+
+.card {
+  background: var(--card-bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--spacing);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 0.75rem;
+  background: var(--card-bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.875rem;
+}
+.chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing);
+  background: var(--card-bg);
+  padding: 0.5rem;
+  border-radius: var(--radius);
+}
+.toolbar > * {
+  min-height: 44px;
+}
+.toolbar > *:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.panel {
+  background: var(--card-bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--spacing);
+}
+
+.kbd {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  background: var(--card-bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.grid {
+  display: grid;
+  gap: var(--spacing);
+  grid-template-columns: 1fr;
+}
+@media (min-width: 600px) {
+  .grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
 
 /* Logo */
 header .logo svg {


### PR DESCRIPTION
## Summary
- add components.css importing design tokens
- implement reusable button, card, chip, toolbar, panel, kbd and grid classes with accessible defaults
- document theming and component usage in README

## Testing
- `npm test` *(fails: HTMLCanvasElement.prototype.getContext not implemented, cannot assign to read only property 'now')*

------
https://chatgpt.com/codex/tasks/task_e_68c27940a90083279f87c86a649c7ecd