### PR TITLE
feat: add theme and dom helpers

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,4 +1,5 @@
 import { createRouter } from './router.js';
+import { toggleTheme, toggleMotion } from './theme.js';
 
 const outlet = document.getElementById('app');
 const router = createRouter(outlet);
@@ -23,3 +24,6 @@ router.resolve(location.pathname);
 window.addEventListener('DOMContentLoaded', () => {
   document.body.classList.add('loaded');
 });
+
+window.toggleTheme = toggleTheme;
+window.toggleMotion = toggleMotion;

--- a/scripts/dom.js
+++ b/scripts/dom.js
@@ -1,0 +1,2 @@
+export const qs = (sel, el = document) => el.querySelector(sel);
+export const qsa = (sel, el = document) => [...el.querySelectorAll(sel)];

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -1,0 +1,46 @@
+const THEME_KEY = 'gg.theme';
+const MOTION_KEY = 'gg.motion';
+
+const darkQuery = matchMedia('(prefers-color-scheme: dark)');
+const reduceQuery = matchMedia('(prefers-reduced-motion: reduce)');
+
+function applyTheme(theme) {
+  let t = theme || localStorage.getItem(THEME_KEY) || 'system';
+  const mode = t === 'system' ? (darkQuery.matches ? 'dark' : 'light') : t;
+  document.documentElement.dataset.theme = mode;
+  return t;
+}
+
+function applyMotion(motion) {
+  let m = motion || localStorage.getItem(MOTION_KEY) || 'system';
+  const reduced = m === 'system' ? reduceQuery.matches : m === 'reduced';
+  document.documentElement.dataset.motion = reduced ? 'reduced' : 'normal';
+  return m;
+}
+
+export function toggleTheme() {
+  const current = localStorage.getItem(THEME_KEY) || 'system';
+  const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
+  localStorage.setItem(THEME_KEY, next);
+  applyTheme(next);
+  return next;
+}
+
+export function toggleMotion() {
+  const current = localStorage.getItem(MOTION_KEY) || 'system';
+  const next = current === 'reduced' ? 'system' : 'reduced';
+  localStorage.setItem(MOTION_KEY, next);
+  applyMotion(next);
+  return next;
+}
+
+applyTheme();
+applyMotion();
+
+darkQuery.addEventListener('change', () => {
+  if ((localStorage.getItem(THEME_KEY) || 'system') === 'system') applyTheme('system');
+});
+
+reduceQuery.addEventListener('change', () => {
+  if ((localStorage.getItem(MOTION_KEY) || 'system') === 'system') applyMotion('system');
+});


### PR DESCRIPTION
## Summary
- add DOM query helpers
- manage theme and motion preferences with localStorage
- expose global toggle functions

## Testing
- `npm test` *(fails: HTMLCanvasElement.prototype.getContext not implemented; TypeError: Cannot assign to read only property 'now')*

------
https://chatgpt.com/codex/tasks/task_e_68c27948c3488327b16c21624a8e8a97