### PR TITLE
feat: add fx utilities and HUD components

### DIFF
--- a/shared/debug/error-reporter.js
+++ b/shared/debug/error-reporter.js
@@ -1,0 +1,30 @@
+// shared/debug/error-reporter.js
+// Basic error logging utility. Sends errors to an endpoint or console.
+
+export function installErrorReporter(endpoint){
+  function send(type, payload){
+    if (!endpoint){
+      console.error(type, payload);
+      return;
+    }
+    try {
+      navigator.sendBeacon(endpoint, JSON.stringify({ type, ...payload }));
+    } catch {
+      try {
+        fetch(endpoint, {
+          method: 'POST',
+          body: JSON.stringify({ type, ...payload }),
+          headers: { 'content-type': 'application/json' },
+          keepalive: true
+        });
+      } catch {}
+    }
+  }
+  window.addEventListener('error', e => {
+    send('error', { message: e.error?.message || e.message, stack: e.error?.stack });
+  });
+  window.addEventListener('unhandledrejection', e => {
+    const r = e.reason;
+    send('unhandledrejection', { message: r?.message || String(r), stack: r?.stack });
+  });
+}

--- a/shared/debug/post-ready.js
+++ b/shared/debug/post-ready.js
@@ -1,0 +1,14 @@
+// shared/debug/post-ready.js
+// Posts a message to the parent window when the document is ready.
+
+export function postReady(data = {}){
+  function send(){
+    try { window.parent && window.parent.postMessage({ type: 'ready', ...data }, '*'); }
+    catch {}
+  }
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    send();
+  } else {
+    window.addEventListener('DOMContentLoaded', send, { once: true });
+  }
+}

--- a/shared/fx/canvasFx.js
+++ b/shared/fx/canvasFx.js
@@ -1,0 +1,73 @@
+// shared/fx/canvasFx.js
+// Small canvas helpers for particles, trails and glow effects.
+
+const TAU = Math.PI * 2;
+
+export function createParticleSystem(ctx) {
+  const particles = [];
+  function add(x, y, opts = {}) {
+    const speed = opts.speed ?? 1;
+    const dir = opts.direction ?? Math.random() * TAU;
+    particles.push({
+      x,
+      y,
+      vx: opts.vx ?? Math.cos(dir) * speed,
+      vy: opts.vy ?? Math.sin(dir) * speed,
+      life: opts.life ?? 60,
+      size: opts.size ?? 2,
+      color: opts.color ?? 'white',
+      decay: opts.decay ?? 0.95,
+    });
+  }
+  function update() {
+    for (let i = particles.length - 1; i >= 0; i--) {
+      const p = particles[i];
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vx *= p.decay;
+      p.vy *= p.decay;
+      p.life--;
+      if (p.life <= 0) particles.splice(i, 1);
+    }
+  }
+  function draw() {
+    particles.forEach(p => {
+      const alpha = Math.max(p.life / 60, 0);
+      ctx.globalAlpha = alpha;
+      ctx.fillStyle = p.color;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, TAU);
+      ctx.fill();
+    });
+    ctx.globalAlpha = 1;
+  }
+  return { add, update, draw, particles };
+}
+
+export function createTrail(max = 20) {
+  const points = [];
+  function add(x, y) {
+    points.push({ x, y });
+    if (points.length > max) points.shift();
+  }
+  function draw(ctx, opts = {}) {
+    if (points.length < 2) return;
+    ctx.strokeStyle = opts.color || 'white';
+    ctx.lineWidth = opts.width || 2;
+    ctx.beginPath();
+    ctx.moveTo(points[0].x, points[0].y);
+    for (let i = 1; i < points.length; i++) ctx.lineTo(points[i].x, points[i].y);
+    ctx.stroke();
+  }
+  return { add, draw, points };
+}
+
+export function drawGlow(ctx, x, y, radius, color = 'rgba(255,255,255,0.5)') {
+  const g = ctx.createRadialGradient(x, y, 0, x, y, radius);
+  g.addColorStop(0, color);
+  g.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = g;
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, TAU);
+  ctx.fill();
+}

--- a/shared/skins/index.js
+++ b/shared/skins/index.js
@@ -1,0 +1,32 @@
+// shared/skins/index.js
+// Expose CSS token values defined in styles/tokens.css.
+
+function ensureTokensCss(){
+  if (typeof document === 'undefined') return;
+  if (document.head.querySelector('link[data-theme-tokens]')) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = new URL('../../styles/tokens.css', import.meta.url).href;
+  link.setAttribute('data-theme-tokens', '');
+  document.head.appendChild(link);
+}
+
+export function getThemeTokens(theme){
+  if (typeof document === 'undefined') return {};
+  ensureTokensCss();
+  const root = document.documentElement;
+  const prev = root.dataset.theme;
+  if (theme) root.dataset.theme = theme;
+  const styles = getComputedStyle(root);
+  const tokens = {};
+  for (let i = 0; i < styles.length; i++) {
+    const prop = styles[i];
+    if (prop.startsWith('--')) {
+      tokens[prop.slice(2)] = styles.getPropertyValue(prop).trim();
+    }
+  }
+  if (theme) root.dataset.theme = prev;
+  return tokens;
+}
+
+export default getThemeTokens;

--- a/shared/ui/hud.css
+++ b/shared/ui/hud.css
@@ -1,0 +1,11 @@
+/* shared/ui/hud.css */
+.hud {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: var(--z-overlay, 400);
+  font-family: var(--font-sans, sans-serif);
+}

--- a/shared/ui/hud.js
+++ b/shared/ui/hud.js
@@ -1,0 +1,67 @@
+// shared/ui/hud.js
+// Minimal HUD utilities: toast notifications and modal dialogs.
+
+function loadStyle(href){
+  if (typeof document === 'undefined') return;
+  if (!document.head.querySelector(`link[href="${href}"]`)) {
+    const l = document.createElement('link');
+    l.rel = 'stylesheet';
+    l.href = href;
+    document.head.appendChild(l);
+  }
+}
+
+const base = new URL('./', import.meta.url);
+['hud.css','toast.css','modals.css'].forEach(f => {
+  try { loadStyle(new URL(f, base).href); } catch {}
+});
+
+let root;
+function ensureRoot(){
+  if (!root) {
+    root = document.createElement('div');
+    root.className = 'hud';
+    document.body.appendChild(root);
+  }
+  return root;
+}
+
+export function showToast(msg, opts = {}){
+  const el = document.createElement('div');
+  el.className = 'toast';
+  el.textContent = msg;
+  const dur = opts.duration ?? 3000;
+  ensureRoot().appendChild(el);
+  setTimeout(() => el.remove(), dur);
+  return el;
+}
+
+export function showModal(content, opts = {}){
+  const wrap = document.createElement('div');
+  wrap.className = 'modal-backdrop';
+  const modal = document.createElement('div');
+  modal.className = 'modal';
+  if (typeof content === 'string') modal.innerHTML = content;
+  else modal.appendChild(content);
+  wrap.appendChild(modal);
+  ensureRoot().appendChild(wrap);
+
+  function close(){
+    wrap.remove();
+    if (opts.onClose) opts.onClose();
+  }
+
+  if (opts.closeButton !== false){
+    const btn = document.createElement('button');
+    btn.className = 'modal-close';
+    btn.textContent = '×';
+    btn.onclick = close;
+    modal.appendChild(btn);
+  }
+  wrap.addEventListener('click', e => { if (e.target === wrap) close(); });
+  return { element: wrap, close };
+}
+
+export function clearHud(){
+  if (root) root.innerHTML = '';
+}

--- a/shared/ui/modals.css
+++ b/shared/ui/modals.css
@@ -1,0 +1,34 @@
+/* shared/ui/modals.css */
+.hud .modal-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
+
+.hud .modal {
+  background: var(--panel-bg, #fff);
+  color: var(--panel-fg, #000);
+  padding: var(--space-4, 16px);
+  border-radius: var(--radius-md, 8px);
+  max-width: 90%;
+  box-shadow: var(--shadow-lg, 0 10px 30px rgba(0,0,0,0.15));
+  position: relative;
+}
+
+.hud .modal-close {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+}

--- a/shared/ui/toast.css
+++ b/shared/ui/toast.css
@@ -1,0 +1,19 @@
+/* shared/ui/toast.css */
+.hud .toast {
+  position: absolute;
+  top: var(--space-4, 16px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--panel-bg, #000);
+  color: var(--panel-fg, #fff);
+  padding: var(--space-2, 8px) var(--space-4, 16px);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-md, 0 4px 6px rgba(0,0,0,0.1));
+  pointer-events: auto;
+  animation: toast-fade-in 0.2s;
+}
+
+@keyframes toast-fade-in {
+  from { opacity: 0; transform: translate(-50%, -10px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}

--- a/shared/util/fps.js
+++ b/shared/util/fps.js
@@ -1,0 +1,25 @@
+// shared/util/fps.js
+// Utility to monitor frame rate and provide a scale factor.
+
+export function createFpsMonitor(){
+  let last = performance.now();
+  let fps = 60;
+  const samples = [];
+  function frame(){
+    const now = performance.now();
+    const delta = now - last;
+    last = now;
+    const current = 1000 / delta;
+    samples.push(current);
+    if (samples.length > 60) samples.shift();
+    fps = samples.reduce((a, b) => a + b, 0) / samples.length;
+    return fps;
+  }
+  function getFps(){
+    return fps;
+  }
+  function getScale(base = 60){
+    return fps / base;
+  }
+  return { frame, getFps, getScale };
+}


### PR DESCRIPTION
## Summary
- add canvas effect helpers for particles, trails and glow
- expose theme tokens through new skins module
- implement HUD utilities with toasts and modals plus CSS
- add debug helpers for error reporting and ready signalling
- provide FPS monitor for dynamic effect scaling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c27db5e2688327906e8b47f02e06ff