### PR TITLE
Document theme preferences and game data updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ flowchart TD
 
 Shared design tokens live in `styles/tokens.css`. The file defines color palettes for light and dark themes, spacing, radii, shadows, z-index layers, and typography. All style sheets import these variables, and dark mode is activated by setting `data-theme="dark"` on the root element.
 
+## Theme and Motion Preferences
+
+Token variables power the design system and are reused throughout the app for color, spacing, and typography.
+The interface includes a dark-mode toggle that flips the `data-theme` attribute on the root element and stores the choice in `localStorage`.
+Animations honor the user's `prefers-reduced-motion` setting, reducing transitions when motion should be minimized.
+
 ## Installation
 
 ```bash

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -11,3 +11,20 @@ flowchart LR
 
 The client-side interface communicates with modular game logic. State is saved locally, while optional APIs provide multiplayer and leaderboards.
 
+## Updating Game Data
+
+Game metadata displayed on the landing page lives in `/data/games.json`.
+To add a new entry:
+
+1. Open `data/games.json`.
+2. Copy an existing object and update its fields:
+   - `id` – unique slug for the game
+   - `title` – display name
+   - `short` – brief description
+   - `tags` – array of categories
+   - `difficulty` – `easy`, `medium`, or `hard`
+   - `released` – release date in `YYYY-MM-DD`
+   - `playUrl` – path to the game's root
+3. Ensure the JSON remains valid and each object is comma-separated.
+4. Run `npm run health` to verify the metadata.
+

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -6,4 +6,8 @@ For consistent screenshots:
 - Disable browser extensions and UI overlays.
 - Save images as PNG with descriptive names, e.g., `tetris-start.png`.
 - Store screenshots in `docs/images/` and reference them with relative paths.
+ 
+## Landing Page and Logo
 
+The new landing page displays a grid of game cards beneath a vibrant pixel-style logo.
+Each card shows the game's icon, title, and tags, providing a quick overview of available titles.


### PR DESCRIPTION
## Summary
- Explain how token variables drive theming, with dark-mode toggle and motion preferences
- Add steps for adding entries to `data/games.json`
- Describe the refreshed landing page and logo

## Testing
- `npm test`
- `npm run health` *(fails: import errors and missing assets in several games)*

------
https://chatgpt.com/codex/tasks/task_e_68c27e88d8d48327a65bb73e5b947a4c