### PR TITLE
feat(chess): add overlay highlights and error reporting

### DIFF
--- a/games/chess/chess.js
+++ b/games/chess/chess.js
@@ -1,6 +1,13 @@
+import { drawGlow } from '../../shared/fx/canvasFx.js';
+import '../../shared/ui/hud.js';
+import getThemeTokens from '../../shared/skins/index.js';
+import { installErrorReporter } from '../../shared/debug/error-reporter.js';
+
+installErrorReporter();
+getThemeTokens();
+
 (function(){
-const c=document.getElementById('board'), ctx=c.getContext('2d'); const S=60;
-const hud=HUD.create({title:'Chess', onPauseToggle:()=>{}, onRestart:()=>reset()});
+const c=document.getElementById('board'), ctx=c.getContext('2d'); const fx=document.getElementById('fx'), fxCtx=fx.getContext('2d'); const S=60;
 const statusEl=document.getElementById('status');
 const depthEl=document.getElementById('difficulty');
 const puzzleSelect=document.getElementById('puzzle-select');
@@ -278,16 +285,19 @@ function genMovesNoFilter(x,y){ // like genMoves but no legality filter
 }
 
 function status(t){ statusEl.textContent=t; }
+function highlightSquare(x,y,color){ drawGlow(fxCtx, x*S+S/2, y*S+S/2, S*0.6, color); }
 function draw(){
   ctx.clearRect(0,0,c.width,c.height);
+  fxCtx.clearRect(0,0,fx.width,fx.height);
   ctx.drawImage(boardTex,0,0);
   if(sel){
-    ctx.fillStyle='rgba(80,200,255,.25)';
-    ctx.fillRect(sel.x*S, sel.y*S, S,S);
-    ctx.fillStyle='rgba(80,200,255,.25)';
-    moves.forEach(m=>{ ctx.beginPath(); ctx.arc(m.x*S+S/2, m.y*S+S/2, 10, 0, Math.PI*2); ctx.fill(); });
+    highlightSquare(sel.x, sel.y, 'rgba(80,200,255,0.25)');
+    moves.forEach(m=> highlightSquare(m.x, m.y, 'rgba(80,200,255,0.15)'));
   }
-  if(lastMove){ ctx.fillStyle='rgba(255,230,0,0.18)'; ctx.fillRect(lastMove.from.x*S,lastMove.from.y*S,S,S); ctx.fillRect(lastMove.to.x*S,lastMove.to.y*S,S,S); }
+  if(lastMove){
+    highlightSquare(lastMove.from.x, lastMove.from.y, 'rgba(255,230,0,0.25)');
+    highlightSquare(lastMove.to.x, lastMove.to.y, 'rgba(255,230,0,0.25)');
+  }
   for(let y=0;y<8;y++) for(let x=0;x<8;x++){
     if(anim && anim.progress<1 && anim.to.x===x && anim.to.y===y) continue;
     const p=pieceAt(x,y); if(p===EMPTY) continue;
@@ -478,4 +488,5 @@ function checkmate(side){
 }
 addEventListener('keydown', e=>{ if(e.key==='r'||e.key==='R') reset(); });
 reset();
+if (typeof reportReady === 'function') reportReady('chess');
 })();

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -8,7 +8,10 @@
 </head>
 <body style="margin:0;background:#0b1220;color:#e6e7ea;">
 <div style="display:flex;gap:16px;justify-content:center;align-items:flex-start;padding:16px 16px 80px;">
-  <canvas id="board" width="480" height="480" style="border:1px solid #243047;border-radius:12px;background:#0f172a;"></canvas>
+  <div style="position:relative;">
+    <canvas id="board" width="480" height="480" style="border:1px solid #243047;border-radius:12px;background:#0f172a;"></canvas>
+    <canvas id="fx" width="480" height="480" style="position:absolute;left:0;top:0;pointer-events:none;"></canvas>
+  </div>
   <div style="max-width:260px;">
     <h3 style="margin:0 0 8px 0;">Chess</h3>
     <p>Click a piece, then a target square. <br/>Press <b>R</b> to restart. <br/>Press <b>F1</b> for control remap.</p>
@@ -23,12 +26,11 @@
     </div>
   </div>
 </div>
-<script src="../../js/hud.js?v=5.3"></script>
 <script src="ai.js?v=5.3"></script>
 <script src="puzzles.js?v=5.3"></script>
 <script src="ratings.js?v=5.3"></script>
 <script src="net.js?v=5.3"></script>
-<script src="chess.js?v=5.3"></script>
+<script type="module" src="chess.js?v=5.3"></script>
 <script>
 (function(){
   const rating = Ratings.getRating();


### PR DESCRIPTION
## Summary
- remove legacy HUD script and load chess module as ES module
- add overlay canvas highlights powered by shared canvasFx utilities
- hook up error reporting and ready callback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c27f6cc5d08327b3f2f0f1792a83fa