### PR TITLE
Add health check page and endpoint

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,14 @@
+import { runHealthcheck } from '../tools/healthcheck.mjs';
+
+export default async function handler(req, res){
+  try {
+    const results = await runHealthcheck();
+    res.setHeader('Content-Type', 'application/json');
+    res.statusCode = results.every(r => r.status === 'ok') ? 200 : 500;
+    res.end(JSON.stringify(results));
+  } catch (err) {
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: err.message }));
+  }
+}

--- a/health/index.html
+++ b/health/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game Healthcheck</title>
+  <style>
+    body { font-family: sans-serif; }
+    li.ok { color: green; }
+    li.fail { color: red; }
+  </style>
+</head>
+<body>
+  <h1>Game Health</h1>
+  <ul id="results"></ul>
+  <script type="module">
+    async function init(){
+      const res = await fetch('../games.json');
+      const games = await res.json();
+      const results = document.getElementById('results');
+      const frames = new Map();
+      for (const g of games){
+        const li = document.createElement('li');
+        li.textContent = `${g.id}: loading`;
+        results.appendChild(li);
+        const iframe = document.createElement('iframe');
+        iframe.src = '../' + g.path;
+        iframe.style.display = 'none';
+        document.body.appendChild(iframe);
+        frames.set(iframe.contentWindow, { id: g.id, li });
+      }
+      window.addEventListener('message', e => {
+        if (e.data === 'loaded' && frames.has(e.source)){
+          const { id, li } = frames.get(e.source);
+          li.textContent = `${id}: ok`;
+          li.className = 'ok';
+          frames.delete(e.source);
+        }
+      });
+      setTimeout(() => {
+        for (const { id, li } of frames.values()){
+          li.textContent = `${id}: fail`;
+          li.className = 'fail';
+        }
+        frames.clear();
+      }, 10000);
+    }
+    init();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "vitest run",
+    "test": "npm run health && vitest run",
     "sitemap": "node tools/generate-sitemap.mjs",
     "sw-manifest": "node tools/generate-sw-manifest.mjs",
     "health": "node tools/healthcheck.mjs"

--- a/tests/help-overlay.a11y.test.js
+++ b/tests/help-overlay.a11y.test.js
@@ -9,6 +9,8 @@ describe('help overlay accessibility', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
     localStorage.clear();
+    // axe-core uses canvas for color contrast calculations, which jsdom lacks.
+    HTMLCanvasElement.prototype.getContext = () => null;
   });
 
   it('has no critical axe violations', async () => {


### PR DESCRIPTION
## Summary
- add /health page that loads each game in a hidden iframe and listens for `loaded` messages
- expose Node healthcheck endpoint and reuse existing healthcheck logic
- run healthcheck during `npm test` and fail when games are unhealthy

## Testing
- `npm test` *(fails: pong: import failed: Unknown file extension ".ts" for /workspace/Game/src/runtime/controls.ts, snake: import failed: document is not defined, breakout: import failed: GG is not defined, chess3d: import failed: document is not defined, g2048: missing g2048.js?v=5.3, asteroids: import failed: Unknown file extension ".ts" for /workspace/Game/src/runtime/controls.ts, box3d: import failed: Illegal return statement, maze3d: import failed: document is not defined, platformer: import failed: document is not defined, runner: import failed: Unknown file extension ".ts" for /workspace/Game/src/runtime/controls.ts, shooter: import failed: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c27f703c0c8327ab85bd97a0d760d2