### PR TITLE
Improve theme contrast and ripple visibility

### DIFF
--- a/styles.themes.css
+++ b/styles.themes.css
@@ -4,6 +4,7 @@
 
 :root {
   --bg:#0b0b0f; --fg:#eaeaf2; --card:#14141d; --border:#1f1f2a; --chip:#2a2a36;
+  --button-bg:#2a2a36; --button-border:#1f1f2a;
   --accent:#6ee7b7; --font: system-ui, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
   --bg-img:none;
 }
@@ -11,6 +12,7 @@
 /* Minimal White (default available) */
 .skin-minimal {
   --bg:#fafafa; --fg:#0b0b0f; --card:#ffffff; --border:#e5e7eb; --chip:#eef2f7;
+  --button-bg:#e5e7eb; --button-border:#d1d5db;
   --accent:#111827; --font: "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
   --bg-img: none;
 }
@@ -18,8 +20,9 @@
 /* Neon Cyberpunk (unlocks at 5 plays) */
 @font-face { font-family: "Orbitron"; src: local("Orbitron"); font-display: swap; }
 .skin-neon {
-  --bg:#0a0014; --fg:#e2f1ff; --card:#120026; --border:#2d0052; --chip:#1a0036;
-  --accent:#e11d48; --font: "Orbitron", system-ui, sans-serif;
+    --bg:#0a0014; --fg:#e2f1ff; --card:#120026; --border:#2d0052; --chip:#1a0036;
+    --button-bg:#1a0036; --button-border:#2d0052;
+    --accent:#e11d48; --font: "Orbitron", system-ui, sans-serif;
   --bg-img: radial-gradient(50% 50% at 50% 50%, rgba(225,29,72,0.12) 0%, rgba(0,0,0,0) 60%), radial-gradient(50% 50% at 80% 20%, rgba(59,130,246,0.12) 0%, rgba(0,0,0,0) 50%);
 }
 .skin-neon .card { box-shadow: 0 0 0 1px rgba(225,29,72,.3), 0 8px 30px rgba(0,0,0,.35); }
@@ -29,10 +32,11 @@
 /* Retro CRT (unlocks at 10 plays) */
 @font-face { font-family: "PressStart2P"; src: local("Press Start 2P"); font-display: swap; }
 .skin-retro {
-  --bg:#0b0f0a; --fg:#e8f0d8; --card:#0d130b; --border:#19321a; --chip:#112610;
-  --accent:#9ae66e; --font: "PressStart2P", monospace;
-  --bg-img: repeating-linear-gradient(0deg, rgba(255,255,255,0.02), rgba(255,255,255,0.02) 1px, transparent 1px, transparent 3px);
-}
+    --bg:#0b0f0a; --fg:#e8f0d8; --card:#0d130b; --border:#19321a; --chip:#112610;
+    --button-bg:#112610; --button-border:#19321a;
+    --accent:#9ae66e; --font: "PressStart2P", monospace;
+    --bg-img: repeating-linear-gradient(0deg, rgba(255,255,255,0.02), rgba(255,255,255,0.02) 1px, transparent 1px, transparent 3px);
+  }
 .skin-retro .card { filter: contrast(1.1) saturate(0.9); }
 .skin-retro .title { text-transform: uppercase; letter-spacing: 0.04em; }
 .skin-retro .site-header { text-shadow: 0 0 8px rgba(154,230,110,0.45); }

--- a/styles/home.css
+++ b/styles/home.css
@@ -72,7 +72,7 @@ body.loaded {
   position: absolute;
   width: 20px;
   height: 20px;
-  background: currentColor;
+  background: var(--accent);
   border-radius: 50%;
   transform: translate(-50%, -50%) scale(0);
   opacity: 0.3;


### PR DESCRIPTION
## Summary
- Define `--button-bg` and `--button-border` for each theme to ensure adequate contrast with foreground text
- Use a semi-transparent accent color for button ripple effects so they remain visible across themes

## Testing
- `npm test` *(fails: import failed: document is not defined, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c282addb44832791e5025d8b576c9a