### PR TITLE
Handle missing game data gracefully

### DIFF
--- a/scripts/home.js
+++ b/scripts/home.js
@@ -24,9 +24,18 @@ fetch('/data/games.json')
   .then(r => r.json())
   .then(data => {
     games = Array.isArray(data) ? data : [];
-    renderGrid();
-    renderRoute();
-  });
+    if (games.length) {
+      renderGrid();
+      renderRoute();
+    } else {
+      showError();
+    }
+  })
+  .catch(err => showError());
+
+function showError() {
+  grid.innerHTML = '<p class="error">No games available. Please try again later.</p>';
+}
 
 function renderGrid() {
   grid.innerHTML = '';


### PR DESCRIPTION
## Summary
- Show a friendly message in `#gamesGrid` when game data fails to load or returns empty
- Catch fetch errors on the home page

## Testing
- `npm test` *(fails: import failed / document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ebd18d4083278f4e025b0d690768