### PR TITLE
Scope landing grid to hero art

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -61,7 +61,7 @@ body{
 .orb-1{background:radial-gradient(circle at 30% 30%,#7dd3fc 0,#2563eb 60%,transparent 70%);width:200px;height:200px;right:40px;top:10px}
 .orb-2{background:radial-gradient(circle at 70% 70%,#a78bfa 0,#7c3aed 60%,transparent 70%);width:140px;height:140px;right:160px;bottom:20px}
 .orb-3{background:radial-gradient(circle at 50% 50%,#f472b6 0,#be185d 60%,transparent 70%);width:120px;height:120px;right:0;bottom:60px}
-.gg-grid{position:absolute;inset:0;background-image:linear-gradient(rgba(255,255,255,.06) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.06) 1px,transparent 1px);background-size:24px 24px;mask-image:radial-gradient(circle at 70% 30%,rgba(0,0,0,.7),transparent 70%)}
+.gg-hero-art .gg-grid{position:absolute;inset:0;pointer-events:none;background-image:linear-gradient(rgba(255,255,255,.06) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.06) 1px,transparent 1px);background-size:24px 24px;mask-image:radial-gradient(circle at 70% 30%,rgba(0,0,0,.7),transparent 70%)}
 
 .gg-grid-wrap{padding:10px 0 60px}
 .gg-status{color:var(--muted);margin-bottom:10px}


### PR DESCRIPTION
## Summary
- scope decorative grid to hero art section to avoid affecting game list
- ensure decorative grid doesn't intercept clicks

## Testing
- `npm test` *(fails: import errors across several games)*
- `npx vitest run` *(fails: service worker cache management)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fa263d6c8327abcb58b590d47120