### PR TITLE
Add descriptions for chess and 2048 entries in games.json

### DIFF
--- a/games.json
+++ b/games.json
@@ -79,6 +79,14 @@
     "id": "chess",
     "title": "Chess (2D)",
     "path": "games/chess/index.html",
+    "desc": "Traditional chess for two players.",
+    "tags": [
+      "classic",
+      "board"
+    ],
+    "new": false,
+    "emoji": "♟️",
+    "addedAt": "2025-08-20",
     "help": {
       "objective": "Checkmate the opponent's king",
       "controls": "Click pieces to move",
@@ -90,11 +98,14 @@
     "id": "chess3d",
     "title": "Chess 3D (Local)",
     "path": "games/chess3d/index.html",
+    "desc": "A three-dimensional chess experiment.",
     "new": true,
     "tags": [
       "3D",
       "offline"
     ],
+    "emoji": "♖",
+    "addedAt": "2025-08-27",
     "help": {
       "objective": "Checkmate your opponent in 3D",
       "controls": "Drag to rotate • Click pieces to move",
@@ -106,6 +117,14 @@
     "id": "g2048",
     "title": "2048",
     "path": "games/2048/index.html",
+    "desc": "Slide numbers to reach 2048.",
+    "tags": [
+      "puzzle",
+      "2D"
+    ],
+    "new": false,
+    "emoji": "🔢",
+    "addedAt": "2025-08-20",
     "help": {
       "objective": "Reach the 2048 tile",
       "controls": "Arrow keys move",


### PR DESCRIPTION
## Summary
- add full metadata for Chess, Chess 3D, and 2048
- ensure games.json passes admin validation

## Testing
- `node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('games.json','utf8'));const ids=new Set();const probs=[];data.forEach((g,i)=>{['id','title','path','desc'].forEach(k=>{if(!g[k])probs.push(`Game[${i}] missing ${k}`)});if(ids.has(g.id))probs.push('Duplicate id '+g.id);ids.add(g.id);if(!/^games\\//.test(g.path))probs.push('Bad path '+g.path);if(g.thumb && !/^assets\\//.test(g.thumb))probs.push('Thumb should be under assets/: '+g.thumb);});console.log(probs.length?('Issues:\\n'+probs.join('\\n')):'Looks good ✅');"`
- `npm test` *(fails: import failed: document is not defined, missing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fa6c189883279c8f421baa649fb3