### PR TITLE
fix landing descriptions

### DIFF
--- a/js/landing.js
+++ b/js/landing.js
@@ -118,7 +118,7 @@ async function loadGamesJson(){
   allGames = list.map(g => ({ 
       id: g.id || g.slug || g.name,
       title: g.title || g.name,
-      description: g.description || '',
+      description: g.description || g.desc || '',
       tags: g.tags || g.genres || [],
       thumbnail: g.thumbnail || g.image || g.cover || null
   })).filter(g => g.id && g.title);


### PR DESCRIPTION
## Summary
- use legacy `desc` field if `description` missing in `loadGamesJson`

## Testing
- `node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('games.json'));const list=(Array.isArray(data)?data:Array.isArray(data.games)?data.games:[]).map(g=>({id:g.id||g.slug||g.name,title:g.title||g.name,description:g.description||g.desc||'',tags:g.tags||g.genres||[],thumbnail:g.thumbnail||g.image||g.cover||null})).filter(g=>g.id&&g.title);console.log(list[0].description);"`
- `npm test` *(fails: import failed: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fb69b0f88327b6fa62006213f13a