### PR TITLE
Support game lookup by slug or id

### DIFF
--- a/game.html
+++ b/game.html
@@ -73,7 +73,7 @@
     initI18n();
 
     const params = new URLSearchParams(location.search);
-    const slug = params.get('slug');
+    const slug = params.get('slug') || params.get('id');
     const heroEl = document.getElementById('hero');
     const pageTitle = document.getElementById('pageTitle');
     if (!slug) {
@@ -91,7 +91,7 @@
         const res = await fetch('./games.json', { cache: 'no-store' });
         const data = await res.json();
         const games = Array.isArray(data.games) ? data.games : (Array.isArray(data) ? data : []);
-        const game = games.find(g => g.slug === slug);
+        const game = games.find(g => (g.slug || g.id) === slug);
         if (!game) throw new Error('not found');
         renderGame(game, games);
       } catch (e) {

--- a/games.json
+++ b/games.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "pong",
+    "slug": "pong",
     "title": "Pong Classic",
     "path": "games/pong/index.html",
     "desc": "A snappy canvas remake of the arcade legend.",
@@ -14,12 +15,18 @@
     "help": {
       "objective": "Score 11 points to win",
       "controls": "W/S or ↑/↓ move • Space/Enter serve • P pause • R restart",
-      "tips": ["Change difficulty from the menu"],
-      "steps": ["Hit the ball past your opponent to score", "First to 11 wins"]
+      "tips": [
+        "Change difficulty from the menu"
+      ],
+      "steps": [
+        "Hit the ball past your opponent to score",
+        "First to 11 wins"
+      ]
     }
   },
   {
     "id": "snake",
+    "slug": "snake",
     "title": "Snake",
     "path": "games/snake/index.html",
     "desc": "Eat, grow, don't bonk into yourself.",
@@ -33,12 +40,20 @@
     "help": {
       "objective": "Grow the snake by eating apples",
       "controls": "Arrow keys move",
-      "tips": ["Avoid running into yourself", "Plan ahead"],
-      "steps": ["Use arrow keys to steer", "Collect apples to grow", "Don't crash into walls or yourself"]
+      "tips": [
+        "Avoid running into yourself",
+        "Plan ahead"
+      ],
+      "steps": [
+        "Use arrow keys to steer",
+        "Collect apples to grow",
+        "Don't crash into walls or yourself"
+      ]
     }
   },
   {
     "id": "tetris",
+    "slug": "tetris",
     "title": "Tetris",
     "path": "games/tetris/index.html",
     "desc": "Classic falling blocks. Clear lines, level up.",
@@ -52,12 +67,20 @@
     "help": {
       "objective": "Clear lines by arranging falling blocks",
       "controls": "←/→ move • ↑ rotate • ↓ soft drop • Space hard drop",
-      "tips": ["Plan for Tetris clears", "Don't stack too high"],
-      "steps": ["Move pieces with arrow keys", "Rotate with ↑", "Drop with Space"]
+      "tips": [
+        "Plan for Tetris clears",
+        "Don't stack too high"
+      ],
+      "steps": [
+        "Move pieces with arrow keys",
+        "Rotate with ↑",
+        "Drop with Space"
+      ]
     }
   },
   {
     "id": "breakout",
+    "slug": "breakout",
     "title": "Breakout",
     "path": "games/breakout/index.html",
     "desc": "Smash bricks, power-ups, chase the score.",
@@ -71,12 +94,19 @@
     "help": {
       "objective": "Break all the bricks",
       "controls": "Mouse or ←/→ move paddle",
-      "tips": ["Catch power-ups", "Watch the ball speed"],
-      "steps": ["Move paddle to keep the ball in play", "Clear every brick to win"]
+      "tips": [
+        "Catch power-ups",
+        "Watch the ball speed"
+      ],
+      "steps": [
+        "Move paddle to keep the ball in play",
+        "Clear every brick to win"
+      ]
     }
   },
   {
     "id": "chess",
+    "slug": "chess",
     "title": "Chess (2D)",
     "path": "games/chess/index.html",
     "desc": "Traditional chess for two players.",
@@ -90,12 +120,19 @@
     "help": {
       "objective": "Checkmate the opponent's king",
       "controls": "Click pieces to move",
-      "tips": ["Control the center", "Develop pieces"],
-      "steps": ["Select a piece", "Move to a highlighted square"]
+      "tips": [
+        "Control the center",
+        "Develop pieces"
+      ],
+      "steps": [
+        "Select a piece",
+        "Move to a highlighted square"
+      ]
     }
   },
   {
     "id": "chess3d",
+    "slug": "chess3d",
     "title": "Chess 3D (Local)",
     "path": "games/chess3d/index.html",
     "desc": "A three-dimensional chess experiment.",
@@ -109,12 +146,19 @@
     "help": {
       "objective": "Checkmate your opponent in 3D",
       "controls": "Drag to rotate • Click pieces to move",
-      "tips": ["Use the camera to view the board", "Plan ahead"],
-      "steps": ["Drag to rotate the board", "Click a piece then its destination"]
+      "tips": [
+        "Use the camera to view the board",
+        "Plan ahead"
+      ],
+      "steps": [
+        "Drag to rotate the board",
+        "Click a piece then its destination"
+      ]
     }
   },
   {
     "id": "g2048",
+    "slug": "g2048",
     "title": "2048",
     "path": "games/2048/index.html",
     "desc": "Slide numbers to reach 2048.",
@@ -128,12 +172,19 @@
     "help": {
       "objective": "Reach the 2048 tile",
       "controls": "Arrow keys move",
-      "tips": ["Merge same numbers", "Keep highest tile in a corner"],
-      "steps": ["Use arrows to slide tiles", "Combine tiles to increase numbers"]
+      "tips": [
+        "Merge same numbers",
+        "Keep highest tile in a corner"
+      ],
+      "steps": [
+        "Use arrows to slide tiles",
+        "Combine tiles to increase numbers"
+      ]
     }
   },
   {
     "id": "asteroids",
+    "slug": "asteroids",
     "title": "Asteroids",
     "path": "games/asteroids/index.html",
     "desc": "Pilot your ship and blast space rocks.",
@@ -147,12 +198,19 @@
     "help": {
       "objective": "Destroy all asteroids",
       "controls": "←/→ rotate • ↑ thrust • Space fire",
-      "tips": ["Use momentum", "Avoid collisions"],
-      "steps": ["Rotate and thrust to move", "Shoot asteroids to break them"]
+      "tips": [
+        "Use momentum",
+        "Avoid collisions"
+      ],
+      "steps": [
+        "Rotate and thrust to move",
+        "Shoot asteroids to break them"
+      ]
     }
   },
   {
     "id": "box3d",
+    "slug": "box3d",
     "title": "3D Box Playground",
     "path": "games/box3d/index.html",
     "desc": "A tiny Three.js scene—rotate and vibe.",
@@ -166,12 +224,18 @@
     "help": {
       "objective": "Collect the glowing orbs",
       "controls": "WASD move • Mouse look • Space jump • R reset",
-      "tips": ["Touch orbs to score"],
-      "steps": ["Explore the scene", "Collect all orbs"]
+      "tips": [
+        "Touch orbs to score"
+      ],
+      "steps": [
+        "Explore the scene",
+        "Collect all orbs"
+      ]
     }
   },
   {
     "id": "maze3d",
+    "slug": "maze3d",
     "title": "Maze 3D",
     "path": "games/maze3d/index.html",
     "desc": "Wander a first-person labyrinth to find the exit.",
@@ -184,12 +248,18 @@
     "help": {
       "objective": "Find the exit of the maze",
       "controls": "WASD/Arrow keys move • Mouse look",
-      "tips": ["Watch for dead ends"],
-      "steps": ["Navigate the corridors", "Locate the exit"]
+      "tips": [
+        "Watch for dead ends"
+      ],
+      "steps": [
+        "Navigate the corridors",
+        "Locate the exit"
+      ]
     }
   },
   {
     "id": "platformer",
+    "slug": "platformer",
     "title": "Pixel Platformer",
     "path": "games/platformer/index.html",
     "desc": "Run and jump across platforms to reach the goal.",
@@ -202,12 +272,19 @@
     "help": {
       "objective": "Reach the goal flag",
       "controls": "←/→ move • Space jump",
-      "tips": ["Avoid spikes", "Time your jumps"],
-      "steps": ["Run and jump across platforms", "Reach the flag"]
+      "tips": [
+        "Avoid spikes",
+        "Time your jumps"
+      ],
+      "steps": [
+        "Run and jump across platforms",
+        "Reach the flag"
+      ]
     }
   },
   {
     "id": "runner",
+    "slug": "runner",
     "title": "City Runner",
     "path": "games/runner/index.html",
     "desc": "Dash through the city and avoid obstacles.",
@@ -220,12 +297,18 @@
     "help": {
       "objective": "Run as far as you can",
       "controls": "↑/Space jump • ↓ slide",
-      "tips": ["Timing jumps is key"],
-      "steps": ["Jump over obstacles", "Slide under barriers"]
+      "tips": [
+        "Timing jumps is key"
+      ],
+      "steps": [
+        "Jump over obstacles",
+        "Slide under barriers"
+      ]
     }
   },
   {
     "id": "shooter",
+    "slug": "shooter",
     "title": "Alien Shooter",
     "path": "games/shooter/index.html",
     "desc": "Blast waves of invaders and survive.",
@@ -238,8 +321,14 @@
     "help": {
       "objective": "Survive waves of aliens",
       "controls": "Arrow keys move • Space shoot",
-      "tips": ["Collect power-ups", "Keep moving"],
-      "steps": ["Move to dodge", "Shoot enemies to survive"]
+      "tips": [
+        "Collect power-ups",
+        "Keep moving"
+      ],
+      "steps": [
+        "Move to dodge",
+        "Shoot enemies to survive"
+      ]
     }
   }
 ]


### PR DESCRIPTION
## Summary
- Allow `game.html` to read `id` query parameter when `slug` is missing
- Match games by `slug` or `id` and add `slug` field to games data

## Testing
- `npm test` *(fails: import failed, document is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c2fb6e890483278c2f80283d83dbdd