### PR TITLE
chore: bump service worker cache version and precache assets

### DIFF
--- a/precache-manifest.js
+++ b/precache-manifest.js
@@ -1,6 +1,6 @@
 // v1.1 precache list; keep tiny and versioned
 self.__GG_PRECACHE_MANIFEST = [
-  '/index.html?v=20250911162413',
-  '/css/landing.css?v=20250911162413',
-  '/js/landing.js?v=20250911162413'
+  '/index.html?v=20250911172711',
+  '/css/landing.css?v=20250911172711',
+  '/js/landing.js?v=20250911172711'
 ];

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // v1.1 service worker (safe, minimal).
 // CACHE_VERSION bumped to force users to receive the new landing right away.
-const CACHE_VERSION = 'gg-v3-20250911162413';
+const CACHE_VERSION = 'gg-v4-20250911172711';
 const PRECACHE = 'precache-' + CACHE_VERSION;
 const RUNTIME = 'runtime-' + CACHE_VERSION;
 
@@ -21,7 +21,7 @@ self.addEventListener('activate', (event) => {
     await self.clients.claim();
     // Clean up old caches
     const names = await caches.keys();
-    await Promise.all(names.map(n => (n.includes('gg-v3-') || n.includes(CACHE_VERSION)) ? null : caches.delete(n)));
+    await Promise.all(names.map(n => n.includes(CACHE_VERSION) ? null : caches.delete(n)));
   })());
 });
 


### PR DESCRIPTION
## Summary
- bump service worker cache version to gg-v4 with current timestamp
- simplify activate phase cache cleanup to drop non-matching caches
- refresh precache manifest entries with timestamped URLs

## Testing
- `npm test` *(fails: import errors in healthcheck)*

------
https://chatgpt.com/codex/tasks/task_e_68c30659720883278ce6811fe5dc6701