### PR TITLE
Align 2048 slug with game ID

### DIFF
--- a/games.json
+++ b/games.json
@@ -37,7 +37,7 @@
   },
   {
     "title": "2048",
-    "slug": "2048",
+    "slug": "g2048",
     "entry": "/games/2048/2048.js",
     "module": false
   },


### PR DESCRIPTION
## Summary
- Update 2048 slug to `g2048` in `games.json`
- Confirm other modules reference `g2048`

## Testing
- `npm test` *(fails: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined)*
- `python3 -m http.server 8000 & curl -I http://localhost:8000/game.html?id=g2048`

------
https://chatgpt.com/codex/tasks/task_e_68c34bc8da7083278a33fd53fcd55912