### PR TITLE
refactor: fetch JSON assets instead of import assertions

### DIFF
--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -11,7 +11,7 @@ import { createFpsMonitor } from '../../shared/util/fps.js';
 import { installErrorReporter } from '../../shared/debug/error-reporter.js';
 import { postReady } from '../../shared/debug/post-ready.js';
 import signature from 'console-signature';
-import games from '../../games.json' assert { type: 'json' };
+const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
 
 const help = games.find(g => g.id === 'asteroids')?.help || {};
 window.helpData = help;

--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -8,7 +8,7 @@ import { FXAAShader } from 'https://unpkg.com/three@0.160.0/examples/jsm/shaders
 import { SSAOPass } from 'https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/SSAOPass.js';
 import { registerSW } from '../../shared/sw.js';
 import { injectBackButton, injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
-import games from '../../games.json' assert { type: 'json' };
+const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
 import { emitEvent } from '../../shared/achievements.js';
 import { World, Body } from '../box-core/physics.js';
 

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -9,7 +9,7 @@ import { mountCameraPresets } from "./ui/cameraPresets.js";
 import { envDataUrl } from "./textures/env.js";
 import { log, warn } from '../../tools/reporters/console-signature.js';
 import { injectHelpButton } from '../../shared/ui.js';
-import games from '../../games.json' assert { type: 'json' };
+const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
 
 log('chess3d', '[Chess3D] booting');
 

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -2,7 +2,7 @@ import { injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.
 import { emitEvent } from '../../shared/achievements.js';
 import { connect } from './net.js';
 import { generateMaze, seedRandom } from './generator.js';
-import games from '../../games.json' assert { type: 'json' };
+const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
 
 const help = games.find(g => g.id === 'maze3d')?.help || {};
 injectHelpButton({ gameId: 'maze3d', ...help });

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1,7 +1,7 @@
 import { injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 import * as net from './net.js';
-import games from '../../games.json' assert { type: 'json' };
+const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
 import { TILE, levels, isSolid, isSlope, maskFor } from './tiles.js';
 
 const help = games.find(g => g.id === 'platformer')?.help || {};

--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -1,6 +1,6 @@
 import { Controls, createGamepad } from '../../src/runtime/controls.ts';
 import { attachPauseOverlay, injectHelpButton, saveBestScore, shareScore } from '../../shared/ui.js';
-import games from '../../games.json' assert { type: 'json' };
+const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
 import { GameEngine } from '../../shared/gameEngine.js';

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -6,7 +6,7 @@ import { getMission, updateMission, formatMission, clearMission } from '../../sh
 import { renderFallbackPanel } from '../../shared/fallback.js';
 import { GameEngine } from '../../shared/gameEngine.js';
 import signature from 'console-signature';
-import games from '../../games.json' assert { type: 'json' };
+const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
 
 const help = games.find(g => g.id === 'runner')?.help || {};
 window.helpData = help;

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1,5 +1,5 @@
 import { injectBackButton, injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
-import games from '../../games.json' assert { type: 'json' };
+const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
 import { emitEvent } from '../../shared/achievements.js';
 import Net from './net.js';
 


### PR DESCRIPTION
## Summary
- load `games.json` via `fetch` in game entry modules instead of JSON module imports

## Testing
- `npm run health` *(fails: The "path" argument must be of type string. Received undefined)*
- `npx vitest run` *(fails: expected [ 'gg-v6' ] but received additional caches)*

------
https://chatgpt.com/codex/tasks/task_e_68c35361696c8327869133795c3a114d