### PR TITLE
Ensure game canvas compatibility

### DIFF
--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -22,7 +22,13 @@ let currentFps = 0;
 function reportReady(slug){ postReady({ slug }); }
 async function init(){
 const canvas = document.getElementById('game');
+if (!(canvas instanceof HTMLCanvasElement)) {
+  throw new Error('Canvas element #game not found');
+}
 const ctx = canvas.getContext('2d');
+if (!ctx) {
+  throw new Error('2D rendering context not available');
+}
 const DPR = Math.min(2, window.devicePixelRatio||1);
 particles = createParticleSystem(ctx);
 

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -10,7 +10,13 @@ recordLastPlayed('platformer');
 emitEvent({ type: 'play', slug: 'platformer' });
 
 const cvs = document.getElementById('game');
+if (!(cvs instanceof HTMLCanvasElement)) {
+  throw new Error('Canvas element #game not found');
+}
 const ctx = cvs.getContext('2d');
+if (!ctx) {
+  throw new Error('2D rendering context not available');
+}
 const W = cvs.width, H = cvs.height;
 
 let map = [];

--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -9,7 +9,13 @@ import '../../shared/skins/index.js';
 import * as ErrorReporter from '../../shared/debug/error-reporter.js';
 
 const canvas = document.getElementById('game');
+if (!(canvas instanceof HTMLCanvasElement)) {
+  throw new Error('Canvas element #game not found');
+}
 const ctx = canvas.getContext('2d');
+if (!ctx) {
+  throw new Error('2D rendering context not available');
+}
 
 // Build HUD UI
 const hudRoot = document.createElement('div');

--- a/games/pong/pong.js
+++ b/games/pong/pong.js
@@ -1,5 +1,11 @@
 const canvas = document.getElementById('game');
+if (!(canvas instanceof HTMLCanvasElement)) {
+  throw new Error('Canvas element #game not found');
+}
 const ctx = canvas.getContext('2d');
+if (!ctx) {
+  throw new Error('2D rendering context not available');
+}
 function ctxSave() { if (ctx.save) ctx.save(); }
 function ctxRestore() { if (ctx.restore) ctx.restore(); }
 

--- a/games/runner/editor.js
+++ b/games/runner/editor.js
@@ -2,7 +2,13 @@
 // Provides drag-and-drop placement for obstacles and background layers
 
 const canvas = document.getElementById('game');
+if (!(canvas instanceof HTMLCanvasElement)) {
+  throw new Error('Canvas element #game not found');
+}
 const ctx = canvas.getContext('2d');
+if (!ctx) {
+  throw new Error('2D rendering context not available');
+}
 
 const level = {
   obstacles: [],

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -12,7 +12,13 @@ const help = games.find(g => g.id === 'runner')?.help || {};
 window.helpData = help;
 async function init(){
 const canvas = document.getElementById('game');
+if (!(canvas instanceof HTMLCanvasElement)) {
+  throw new Error('Canvas element #game not found');
+}
 const ctx = canvas.getContext('2d');
+if (!ctx) {
+  throw new Error('2D rendering context not available');
+}
 const DPR = Math.min(2, window.devicePixelRatio||1);
 
 let clouds=[],buildings=[],foreground=[];

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -4,7 +4,13 @@ import { emitEvent } from '../../shared/achievements.js';
 import Net from './net.js';
 
 const cvs = document.getElementById('game');
+if (!(cvs instanceof HTMLCanvasElement)) {
+  throw new Error('Canvas element #game not found');
+}
 const ctx = cvs.getContext('2d');
+if (!ctx) {
+  throw new Error('2D rendering context not available');
+}
 const W = cvs.width, H = cvs.height;
 
 const scoreEl = document.getElementById('score');

--- a/js/compat-shim.js
+++ b/js/compat-shim.js
@@ -1,6 +1,6 @@
 // compat-shim.js
 // Lightweight, non-invasive shims to help older game modules boot on a static site.
-// - Creates common DOM targets (#game-root exists already, we add #game and a <canvas id="canvas"> if missing)
+// - Creates common DOM targets (#game-root exists already, we ensure a <canvas id="game"> exists)
 // - Provides a VERY SMALL window.GG stub if not defined (avoid "GG is not defined" hard failures)
 // This tries not to interfere with games that already set these up themselves.
 
@@ -14,27 +14,65 @@
     return el;
   }
 
-  function ensureCanvas(id, parent){
-    var c = document.getElementById(id);
-    if (c && c.getContext) return c;
-    c = document.createElement('canvas');
-    c.id = id;
+  function createPlaceholderCanvas(id, parent){
+    var c = document.createElement('canvas');
+    if (id) c.id = id;
     c.width = window.innerWidth || 800;
     c.height = window.innerHeight || 600;
+    c.dataset.compatShimPlaceholder = '1';
     (parent || document.body).appendChild(c);
     return c;
   }
 
+  function ensureMounted(node, parent){
+    if (node && !node.parentElement) (parent || document.body).appendChild(node);
+  }
+
+  function uniqueId(base){
+    if (!document.getElementById(base)) return base;
+    var i = 1;
+    while (document.getElementById(base + '-' + i)) i++;
+    return base + '-' + i;
+  }
+
   // Mount area
   var root = document.querySelector('#game-root') || ensureEl('div', 'game-root', document.body);
-  // Common legacy IDs some games expect:
-  var gameDiv = document.getElementById('game') || (function(){ 
-    var d = document.createElement('div'); d.id = 'game'; root.appendChild(d); return d; 
-  })();
-  // If no canvas exists at all, provide a generic one.
-  if (!document.querySelector('canvas')) {
-    ensureCanvas('canvas', gameDiv);
+  var canvas = null;
+  var mount = document.getElementById('game');
+
+  if (!mount) {
+    canvas = createPlaceholderCanvas('game', root);
+  } else if (mount instanceof HTMLCanvasElement) {
+    canvas = mount;
+    ensureMounted(canvas, root);
+  } else {
+    ensureMounted(mount, root);
+    var existing = mount.querySelector('canvas');
+    if (existing && typeof existing.getContext === 'function') {
+      canvas = existing;
+    } else {
+      canvas = createPlaceholderCanvas('game', mount);
+    }
+    if (canvas !== mount) {
+      if (mount.id === 'game') {
+        mount.dataset.compatShimOriginalId = 'game';
+        mount.id = uniqueId('game-container');
+      }
+      if (canvas.id && canvas.id !== 'game') {
+        canvas.dataset.compatShimPreviousId = canvas.id;
+      }
+      if (canvas.id !== 'game') {
+        canvas.id = 'game';
+      }
+    }
   }
+
+  if (!canvas) {
+    canvas = createPlaceholderCanvas('game', root);
+  }
+
+  ensureMounted(canvas, root);
+  var isPlaceholder = canvas.dataset.compatShimPlaceholder === '1';
 
   // Minimal GG stub (only if absent)
   if (!('GG' in window)) {
@@ -59,11 +97,9 @@
 
   // Resize canvas to fit viewport if it's our placeholder
   function fit(){
-    var c = document.getElementById('canvas');
-    if (c && c.parentElement === gameDiv) {
-      c.width = window.innerWidth;
-      c.height = window.innerHeight;
-    }
+    if (!isPlaceholder) return;
+    canvas.width = window.innerWidth || 800;
+    canvas.height = window.innerHeight || 600;
   }
   window.addEventListener('resize', fit, { passive: true });
   fit();


### PR DESCRIPTION
## Summary
- update the compatibility shim to guarantee a `<canvas id="game">` exists and resize only shim-created placeholders
- add guards in canvas-based games so they resolve the `#game` canvas before requesting a 2D context

## Testing
- npm test *(fails: tools/healthcheck.mjs expects `game.path` to be defined)*
- npx vitest run *(fails: tests/sw.test.js expects cached key `gg-v6`)*

------
https://chatgpt.com/codex/tasks/task_e_68c983b6b9248327bb9e980da5d0c893