### PR TITLE
Add game over modal to 2048

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -5,6 +5,62 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>2048</title>
   <link rel="stylesheet" href="../../css/styles.css?v=5.3">
+  <style>
+    #gameOverOverlay {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+      background: rgba(15, 23, 42, 0.6);
+      z-index: 1500;
+    }
+    #gameOverOverlay.hidden { display: none; }
+    #gameOverOverlay .modal-panel {
+      background: #111827;
+      color: #e6e7ea;
+      border-radius: 12px;
+      padding: 28px 32px;
+      max-width: 320px;
+      width: 100%;
+      text-align: center;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
+      font-family: Inter,system-ui;
+    }
+    #gameOverOverlay .modal-panel h3 {
+      margin: 0 0 12px;
+      font-size: 22px;
+      font-weight: 600;
+    }
+    #gameOverOverlay .modal-panel p {
+      margin: 0 0 20px;
+      line-height: 1.5;
+      font-size: 15px;
+    }
+    #gameOverOverlay .overlay-actions {
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    #gameOverOverlay .overlay-actions button {
+      border-radius: 10px;
+      border: 1px solid #334155;
+      padding: 10px 18px;
+      font: 600 15px Inter,system-ui;
+      cursor: pointer;
+      background: #1f2937;
+      color: #e6e7ea;
+      min-width: 110px;
+      touch-action: manipulation;
+    }
+    #gameOverOverlay .overlay-actions button:focus {
+      outline: 2px solid #38bdf8;
+      outline-offset: 2px;
+    }
+  </style>
 </head>
 <body style="margin:0;">
   <div id="lobby" style="text-align:center;padding:40px;">
@@ -35,6 +91,19 @@
         <option value="5">Hard</option>
       </select>
       <button id="themeToggle" style="border:1px solid #243047;background:#111827;color:#e6e7ea;padding:8px 16px;border-radius:8px;margin-left:8px;cursor:pointer;">Theme</button>
+    </div>
+    <p style="text-align:center;margin:0 16px 52px;color:#6b7280;font:500 14px/1.5 Inter,system-ui;">
+      Use <strong>Restart</strong> (or press <kbd>R</kbd>) to start a fresh board, and <strong>Back</strong> to return to the lobby when a round ends.
+    </p>
+  </div>
+  <div id="gameOverOverlay" class="hidden" role="dialog" aria-modal="true" aria-hidden="true" tabindex="-1">
+    <div class="modal-panel" role="document">
+      <h3 id="gameOverTitle">Game over</h3>
+      <p id="gameOverMessage">No moves left. Try again?</p>
+      <div class="overlay-actions">
+        <button id="overlayRestart" type="button">Restart</button>
+        <button id="overlayBack" type="button">Back</button>
+      </div>
     </div>
   </div>
   <script src="../../js/hud.js?v=5.3"></script>


### PR DESCRIPTION
## Summary
- show a themed game-over modal with restart and back actions in the 2048 client
- reset board state and hide the overlay when restarting or undoing a move
- add overlay markup, styling, and updated restart/back instructions to the 2048 page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c99133f6248327ad9d2822b5f61e36