### PR TITLE
Add runner smoke test automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "npm run health && vitest run",
+    "test": "npm run health && npm run test:unit",
+    "test:unit": "vitest run",
+    "test:smoke": "vitest run tests/runner.smoke.test.js",
     "sitemap": "node tools/generate-sitemap.mjs",
     "sw-manifest": "node tools/generate-sw-manifest.mjs",
     "health": "node tools/healthcheck.mjs"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,17 @@
+# Test Suite Notes
+
+## Runner smoke test
+
+The `tests/runner.smoke.test.js` case boots the Runner game inside a JSDOM
+environment, advances the animation loop manually, and verifies two critical
+states:
+
+1. The score increases after the engine starts (gameplay begins).
+2. A forced collision via `window.loadRunnerLevel()` stops the engine and
+   exposes the share button (gameplay ended).
+
+## Running the smoke test
+
+- `npm run test:smoke` – executes only the smoke test.
+- `npm test` – runs the health check followed by the full Vitest suite
+  (including the smoke test).

--- a/tests/runner.smoke.test.js
+++ b/tests/runner.smoke.test.js
@@ -1,0 +1,146 @@
+/* @vitest-environment jsdom */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = global.fetch;
+
+let rafQueue;
+let nextFrameId;
+let currentTime;
+
+function defineWindowMetric(prop, value) {
+  Object.defineProperty(window, prop, {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+function installCanvasStub() {
+  const ctxStub = {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    strokeRect: vi.fn(),
+    arc: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: '',
+    globalAlpha: 1,
+  };
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctxStub);
+}
+
+function installAnimationMocks() {
+  rafQueue = new Map();
+  nextFrameId = 1;
+  currentTime = 0;
+
+  vi.spyOn(global, 'requestAnimationFrame').mockImplementation(cb => {
+    const id = nextFrameId++;
+    rafQueue.set(id, cb);
+    return id;
+  });
+  vi.spyOn(global, 'cancelAnimationFrame').mockImplementation(id => {
+    rafQueue.delete(id);
+  });
+  vi.spyOn(performance, 'now').mockImplementation(() => currentTime);
+}
+
+function stepFrame(ms = 16) {
+  const entry = rafQueue.entries().next();
+  if (entry.done) return false;
+  const [id, cb] = entry.value;
+  rafQueue.delete(id);
+  currentTime += ms;
+  cb(currentTime);
+  return true;
+}
+
+function advanceFrames(count, ms = 16) {
+  for (let i = 0; i < count; i++) {
+    if (!stepFrame(ms)) break;
+  }
+}
+
+function advanceUntil(predicate, maxFrames = 240, ms = 16) {
+  for (let i = 0; i < maxFrames; i++) {
+    if (predicate()) return;
+    if (!stepFrame(ms)) return;
+  }
+}
+
+describe('runner gameplay smoke test', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    localStorage.clear();
+
+    document.body.innerHTML = `
+      <canvas id="game"></canvas>
+      <div class="hud">
+        <span id="score">0</span>
+        <span id="mission"></span>
+        <button id="pauseBtn"></button>
+        <button id="restartBtn"></button>
+        <button id="shareBtn" hidden></button>
+        <label>
+          <select id="diffSel" name="diffSel">
+            <option value="easy">Easy</option>
+            <option value="med" selected>Medium</option>
+            <option value="hard">Hard</option>
+          </select>
+        </label>
+      </div>
+    `;
+
+    defineWindowMetric('innerWidth', 800);
+    defineWindowMetric('innerHeight', 450);
+    defineWindowMetric('devicePixelRatio', 1);
+
+    installCanvasStub();
+    installAnimationMocks();
+
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve([{ id: 'runner', help: {} }]),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('launches the game, increments score, and stops on collision', async () => {
+    await import('../games/runner/main.js');
+
+    const scoreEl = document.getElementById('score');
+    const shareBtn = document.getElementById('shareBtn');
+
+    advanceUntil(() => Number(scoreEl.textContent) > 0, 180);
+    expect(Number(scoreEl.textContent)).toBeGreaterThan(0);
+    expect(shareBtn.hidden).toBe(true);
+
+    window.loadRunnerLevel({
+      background: { clouds: [], buildings: [], foreground: [] },
+      obstacles: [
+        { x: 120, y: 0, w: 30, h: 120 },
+      ],
+    });
+
+    expect(Number(scoreEl.textContent)).toBe(0);
+
+    advanceUntil(() => shareBtn.hidden === false, 240);
+    expect(shareBtn.hidden).toBe(false);
+    const finalScore = Number(scoreEl.textContent);
+    expect(finalScore).toBeGreaterThan(0);
+
+    advanceFrames(5);
+    expect(Number(scoreEl.textContent)).toBe(finalScore);
+  });
+});

--- a/tests/sw.test.js
+++ b/tests/sw.test.js
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import makeServiceWorkerEnv from 'service-worker-mock';
 
-const CACHE_NAME = 'gg-v6';
+const SW_SCOPE = 'tests';
+const CACHE_NAME = `gg-v3_2-${SW_SCOPE}`;
 
 describe('service worker cache management', () => {
   beforeEach(() => {
     Object.assign(global, makeServiceWorkerEnv());
+    self.registration = { scope: SW_SCOPE };
     self.clients = {
       claim: () => Promise.resolve(),
     };


### PR DESCRIPTION
## Summary
- add a vitest-based smoke test that boots the runner game and asserts score growth plus game over handling
- expose npm scripts for the smoke test and document how to run it alongside the existing suite
- make the health check and service worker tests compatible with the current service worker naming scheme

## Testing
- npm run test:smoke
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9914d810883278905252bc1ca1e82