### PR TITLE
Integrate ChessNet into chess gameplay

### DIFF
--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -31,26 +31,6 @@
 <script src="ratings.js?v=5.3"></script>
 <script src="net.js?v=5.3"></script>
 <script type="module" src="chess.js?v=5.3"></script>
-<script>
-(function(){
-  const rating = Ratings.getRating();
-  const btn = document.getElementById('find-match');
-  const status = document.getElementById('lobby-status');
-  const rankings = document.getElementById('rankings');
-  btn.addEventListener('click', () => {
-    ChessNet.onStatus(m => status.textContent = m);
-    ChessNet.onPlayers(list => {
-      rankings.innerHTML = '';
-      list.forEach(p => {
-        const li = document.createElement('li');
-        li.textContent = `${p.name || 'Player'}: ${p.rating}`;
-        rankings.appendChild(li);
-      });
-    });
-    ChessNet.connect('wss://example.com/chess', rating);
-  });
-})();
-</script>
 <script src="../../js/input.js?v=5.3"></script>
 <script src="../../js/remapUI.js?v=5.3"></script>
 <script src="../../js/perfHud.js?v=5.3"></script>


### PR DESCRIPTION
## Summary
- wire ChessNet move, status, and player events into the chess module so the board, lobby messaging, and rankings stay in sync during online play
- send locally played moves over ChessNet, restrict AI/puzzle flows to solo mode, and respect the local color when selecting or premoving pieces
- remove the legacy inline networking script from index.html because the module now owns the matchmaking hooks

## Testing
- npm test *(fails: runner.smoke.test.js flakes with score remaining 0)*
- npm run test:smoke *(fails: same runner smoke flake)*

------
https://chatgpt.com/codex/tasks/task_e_68c9de02e8f88327924dd49356d29874