### PR TITLE
Add serve and pause state handling to Pong

### DIFF
--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -1,5 +1,11 @@
 // Minimal playable Pong (canvas id='game')
+let previousCleanup;
+
 export function boot() {
+  if (typeof previousCleanup === 'function') {
+    previousCleanup();
+    previousCleanup = undefined;
+  }
   const canvas = document.getElementById('game');
   if (!canvas) return console.error('[pong] missing #game canvas');
   const ctx = canvas.getContext('2d');
@@ -13,19 +19,75 @@ export function boot() {
 
   const left = { x: 24, y: (H - paddleH) / 2, vy: 0, score: 0 };
   const right = { x: W - 24 - paddleW, y: (H - paddleH) / 2, vy: 0, score: 0 };
-  const ball = { x: W / 2, y: H / 2, vx: speed, vy: speed * 0.6 };
+  const ball = { x: W / 2, y: H / 2, vx: 0, vy: 0 };
 
   const keys = new Set();
-  addEventListener('keydown', e => keys.add(e.key));
-  addEventListener('keyup', e => keys.delete(e.key));
+  let paused = false;
+  let servePending = true;
+  let serveDirection = 1;
+  let overlayNeedsDraw = true;
 
-  function resetBall(direction = 1) {
-    ball.x = W/2; ball.y = H/2;
-    ball.vx = direction * speed;
-    ball.vy = (Math.random() * 2 - 1) * speed;
+  function awaitServe(direction = serveDirection) {
+    servePending = true;
+    serveDirection = direction;
+    ball.x = W / 2;
+    ball.y = H / 2;
+    ball.vx = 0;
+    ball.vy = 0;
+    left.vy = 0;
+    right.vy = 0;
+    overlayNeedsDraw = true;
   }
 
+  function resetBall(direction = serveDirection) {
+    servePending = false;
+    serveDirection = direction;
+    ball.x = W / 2;
+    ball.y = H / 2;
+    ball.vx = direction * speed;
+    ball.vy = (Math.random() * 2 - 1) * speed;
+    overlayNeedsDraw = true;
+  }
+
+  awaitServe(serveDirection);
+
+  function handleKeydown(e) {
+    const key = e.key;
+
+    if (key === 'p' || key === 'P' || key === 'Escape') {
+      e.preventDefault();
+      paused = !paused;
+      if (paused) {
+        left.vy = 0;
+        right.vy = 0;
+      }
+      overlayNeedsDraw = true;
+      return;
+    }
+
+    if ((key === ' ' || key === 'Space' || key === 'Enter') && servePending && !paused) {
+      e.preventDefault();
+      resetBall(serveDirection);
+      return;
+    }
+
+    if (key === ' ' || key === 'Space' || key === 'ArrowUp' || key === 'ArrowDown') {
+      e.preventDefault();
+    }
+
+    keys.add(key);
+  }
+
+  function handleKeyup(e) {
+    keys.delete(e.key);
+  }
+
+  addEventListener('keydown', handleKeydown);
+  addEventListener('keyup', handleKeyup);
+
   function update() {
+    if (servePending) return;
+
     left.vy = (keys.has('w')||keys.has('W') ? -speed*1.1 : 0) + (keys.has('s')||keys.has('S') ? speed*1.1 : 0);
     right.vy = (keys.has('ArrowUp')?-speed*1.1:0) + (keys.has('ArrowDown')?speed*1.1:0);
 
@@ -48,8 +110,8 @@ export function boot() {
       if (hitRight) ball.x = right.x - ballR - 1;
     }
 
-    if (ball.x < -ballR) { right.score++; resetBall(-1); }
-    if (ball.x > W + ballR) { left.score++; resetBall(1); }
+    if (ball.x < -ballR) { right.score++; awaitServe(-1); }
+    if (ball.x > W + ballR) { left.score++; awaitServe(1); }
   }
 
   function draw() {
@@ -66,8 +128,71 @@ export function boot() {
     ctx.fillText(String(right.score), W*0.75, 48);
   }
 
+  function drawPauseOverlay() {
+    if (!paused) return;
+    ctx.save();
+    ctx.fillStyle = 'rgba(0,0,0,0.55)';
+    ctx.fillRect(0,0,W,H);
+    ctx.fillStyle = '#fff';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.font = 'bold 48px system-ui, sans-serif';
+    ctx.fillText('Paused', W/2, H/2 - 32);
+    ctx.font = '24px system-ui, sans-serif';
+    ctx.fillText('Press P or Esc to resume', W/2, H/2 + 16);
+    ctx.restore();
+  }
+
+  function drawServePrompt() {
+    if (!servePending) return;
+    ctx.save();
+    const message = paused ? 'Serve ready: press Space or Enter' : 'Press Space or Enter to serve';
+    ctx.font = '24px system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const textY = paused ? H / 2 + 72 : H * 0.65;
+    const metrics = ctx.measureText(message);
+    const padding = 18;
+    const boxWidth = metrics.width + padding * 2;
+    const boxHeight = 42;
+    ctx.fillStyle = 'rgba(0,0,0,0.6)';
+    ctx.fillRect(W / 2 - boxWidth / 2, textY - boxHeight / 2, boxWidth, boxHeight);
+    ctx.fillStyle = '#fff';
+    ctx.fillText(message, W / 2, textY);
+    ctx.restore();
+  }
+
+  function drawOverlay() {
+    drawPauseOverlay();
+    drawServePrompt();
+  }
+
   let raf;
-  function loop(){ update(); draw(); raf = requestAnimationFrame(loop); }
+  function loop(){
+    if (!paused) {
+      update();
+      draw();
+      drawOverlay();
+      overlayNeedsDraw = true;
+    } else if (overlayNeedsDraw) {
+      drawOverlay();
+      overlayNeedsDraw = false;
+    }
+    raf = requestAnimationFrame(loop);
+  }
   loop();
-  addEventListener('beforeunload', ()=>cancelAnimationFrame(raf));
+
+  const handleUnload = () => cleanup();
+  let cleaned = false;
+  function cleanup() {
+    if (cleaned) return;
+    cleaned = true;
+    cancelAnimationFrame(raf);
+    removeEventListener('keydown', handleKeydown);
+    removeEventListener('keyup', handleKeyup);
+    removeEventListener('beforeunload', handleUnload);
+  }
+
+  addEventListener('beforeunload', handleUnload);
+  previousCleanup = cleanup;
 }


### PR DESCRIPTION
## Summary
- keep Pong's ball stationary between points until the serve key is pressed and ignore paddle motion while waiting
- add keyboard handling for serving and pausing, plus canvas overlays for pending serves and the paused state
- guard global listeners with reusable cleanup so rebooting the game doesn't duplicate handlers

## Testing
- npm run test:unit *(fails: existing runner gameplay smoke test expects score to advance)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ddf45ad48327981e2481c090a435