### PR TITLE
Handle missing leaderboard in Snake daily mode

### DIFF
--- a/games/snake/snake.js
+++ b/games/snake/snake.js
@@ -28,8 +28,20 @@ const toggle = document.getElementById('dailyToggle');
 toggle.checked = DAILY_MODE;
 function renderScores(){
   const box = document.getElementById('dailyScores');
-  if(!DAILY_MODE){ box.style.display = 'none'; return; }
-  const scores = LB.getTopScores('snake', DAILY_SEED, 5);
+  if(!box) return;
+  if(!DAILY_MODE){
+    box.style.display = 'none';
+    box.innerHTML = '';
+    return;
+  }
+  const lb = window.LB;
+  if(!lb || typeof lb.getTopScores !== 'function'){
+    box.style.display = 'none';
+    box.innerHTML = '';
+    return;
+  }
+  box.style.display = '';
+  const scores = lb.getTopScores('snake', DAILY_SEED, 5) || [];
   box.innerHTML = scores.map(s=>`<li>${s.score}</li>`).join('');
 }
 window.renderScores = renderScores;


### PR DESCRIPTION
## Summary
- guard the Snake daily leaderboard rendering when the LB bundle is absent
- hide the daily scores list whenever the leaderboard service or daily mode is unavailable

## Testing
- npm run test:unit *(fails: runner gameplay smoke test did not increment score)*
- npm run test:smoke *(fails: runner gameplay smoke test did not increment score)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ddf7c014832783a431a141e8fc0e