### PR TITLE
Remove redundant copyGrid helper from 2048 client

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -99,8 +99,6 @@ function updateCanvas(){
   c.height = 40 + N*S + (N-1)*GAP + 30;
 }
 
-function copyGrid(g){ return g.map(r=>r.slice()); }
-
 function applyTheme(){
   const t=themes[currentTheme];
   document.body.style.background=currentTheme==='dark'?'#0b1220':'#fafafa';


### PR DESCRIPTION
## Summary
- remove the local copyGrid definition from the 2048 client so it reuses the engine helper

## Testing
- node --input-type=module (jsdom harness to trigger multiplayer start, move, and undo)
- npm run test:unit *(fails: tests/runner.smoke.test.js "launches the game, increments score, and stops on collision")*

------
https://chatgpt.com/codex/tasks/task_e_68c9ddf953808327b880b4f13314aba5