### PR TITLE
Reset breakout power-ups on restart

### DIFF
--- a/games/breakout/breakout.js
+++ b/games/breakout/breakout.js
@@ -73,6 +73,7 @@ addEventListener('keydown',e=>{
   if(e.key==='ArrowLeft')paddle.x=Math.max(0,paddle.x-24);
   if(e.key==='ArrowRight')paddle.x=Math.min(c.width-paddle.w,paddle.x+24);
   if(e.key.toLowerCase()==='r'&&lives<=0){
+    powerEngine.reset();
     score=0;lives=3;level=1;
     loadLevel();resetBall();
     runStart=performance.now();endTime=null;submitted=false;

--- a/games/breakout/powerups.js
+++ b/games/breakout/powerups.js
@@ -18,5 +18,12 @@ export class PowerUpEngine {
     }
     this.active = this.active.filter(p => p.remaining > 0);
   }
+
+  reset() {
+    for (const p of this.active) {
+      p.remove();
+    }
+    this.active = [];
+  }
 }
 export default PowerUpEngine;


### PR DESCRIPTION
## Summary
- add a reset routine to the breakout power-up engine that removes all active effects
- invoke the power-up reset when restarting after game over so ball speed returns to normal

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9ddfd2aec8327bd6aced0d3cce0b2