### PR TITLE
Fix OrbitControls import for box3d

### DIFF
--- a/games/box3d/main.js
+++ b/games/box3d/main.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module';
 import { injectBackButton, recordLastPlayed, saveBestScore } from '../../shared/ui.js';
 
 const GAME_ID = 'box3d';


### PR DESCRIPTION
## Summary
- update the box3d OrbitControls import to use the `?module` variant so the CDN resolves its three dependency
- verified the box3d shell no longer throws a module specifier resolution error

## Testing
- npm test
- Manual: started a static server and opened `/gameshells/box3d/index.html` to confirm no module specifier errors appear in the console

------
https://chatgpt.com/codex/tasks/task_e_68c9e565b4288327b00b1c4a87f6a781