### PR TITLE
Fix Tetris shell canvas setup

### DIFF
--- a/gameshells/tetris/index.html
+++ b/gameshells/tetris/index.html
@@ -14,18 +14,32 @@
     </script>
   </head>
   <body>
-    <canvas id="game-canvas" width="800" height="600" aria-label="Tetris canvas"></canvas>
+    <canvas
+      id="t"
+      width="300"
+      height="600"
+      data-basew="300"
+      data-baseh="600"
+      aria-label="Tetris canvas"
+    ></canvas>
     <div id="hud">
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
     <script src="/js/bootstrap/gg.js"></script>
     <script src="/js/preflight.js"></script>
+    <script src="/js/resizeCanvas.global.js"></script>
+    <script src="/js/gameUtil.js"></script>
+    <script src="/js/sfx.js"></script>
+    <script src="/games/tetris/engine.js"></script>
+    <script src="/games/tetris/replay.js"></script>
     <script type="module" src="/js/three-global-shim.js"></script>
     <script type="module">
       import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
-        ensureCanvas("game-canvas");
+        const { canvas } = ensureCanvas("t");
+        const extraCanvas = document.getElementById("gameCanvas");
+        if (extraCanvas && extraCanvas !== canvas) extraCanvas.remove();
         ensureElement("#score");
       });
     </script>


### PR DESCRIPTION
## Summary
- restore the shell canvas id and sizing Tetris expects so the engine finds the element
- include the legacy helper scripts that expose fitCanvasToParent, GG, SFX, TetrisEngine, and Replay before loading the module, and remove the extra preflight canvas

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9e57265f483278a2532f495564fe5