### PR TITLE
Fix Breakout shell compatibility

### DIFF
--- a/gameshells/breakout/index.html
+++ b/gameshells/breakout/index.html
@@ -14,21 +14,13 @@
     </script>
   </head>
   <body>
-    <canvas id="game-canvas" width="800" height="600" aria-label="Breakout canvas"></canvas>
-    <div id="hud">
-      <div id="score" aria-live="polite">0</div>
-      <button id="pause-btn" aria-pressed="false">Pause</button>
-    </div>
+    <canvas id="b" width="1000" height="800" aria-label="Breakout canvas"></canvas>
     <script src="/js/bootstrap/gg.js"></script>
     <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
-    <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
-      window.addEventListener("DOMContentLoaded", () => {
-        ensureCanvas("game-canvas");
-        ensureElement("#score");
-      });
-    </script>
+    <script src="/js/resizeCanvas.global.js"></script>
+    <script src="/js/gameUtil.js"></script>
+    <script src="/js/sfx.js"></script>
+    <script src="/shared/leaderboard.js"></script>
     <script type="module" src="/games/breakout/breakout.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restore the Breakout shell canvas element expected by the game logic
- load the legacy helper scripts that provide canvas resizing, GG stats, SFX, and leaderboard globals

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68c9e5778eec8327a6a80c7d71929c87