### PR TITLE
Restore chess shell layout and validate DOM hooks

### DIFF
--- a/games/chess/chess.js
+++ b/games/chess/chess.js
@@ -6,14 +6,34 @@ import { installErrorReporter } from '../../shared/debug/error-reporter.js';
 installErrorReporter();
 getThemeTokens();
 
+function requireElementById(id){
+  const el=document.getElementById(id);
+  if(!el) throw new Error(`Chess: required element #${id} was not found.`);
+  return el;
+}
+
+function requireCanvas(id){
+  const el=requireElementById(id);
+  if(!(el instanceof HTMLCanvasElement)) throw new Error(`Chess: element #${id} must be a <canvas>.`);
+  return el;
+}
+
+function require2dContext(canvas){
+  const ctx=canvas.getContext('2d');
+  if(!ctx) throw new Error(`Chess: canvas #${canvas.id} does not provide a 2D context.`);
+  return ctx;
+}
+
 (function(){
-const c=document.getElementById('board'), ctx=c.getContext('2d'); const fx=document.getElementById('fx'), fxCtx=fx.getContext('2d'); const S=60;
-const statusEl=document.getElementById('status');
-const depthEl=document.getElementById('difficulty');
-const puzzleSelect=document.getElementById('puzzle-select');
-const lobbyStatusEl=document.getElementById('lobby-status');
-const rankingsList=document.getElementById('rankings');
-const findMatchBtn=document.getElementById('find-match');
+const c=requireCanvas('board'), ctx=require2dContext(c);
+const fx=requireCanvas('fx'), fxCtx=require2dContext(fx);
+const S=60;
+const statusEl=requireElementById('status');
+const depthEl=/** @type {HTMLSelectElement} */ (requireElementById('difficulty'));
+const puzzleSelect=/** @type {HTMLSelectElement} */ (requireElementById('puzzle-select'));
+const lobbyStatusEl=requireElementById('lobby-status');
+const rankingsList=/** @type {HTMLOListElement} */ (requireElementById('rankings'));
+const findMatchBtn=/** @type {HTMLButtonElement} */ (requireElementById('find-match'));
 const COLS=8, ROWS=8;
 const EMPTY = '.';
 // Simple FEN start

--- a/gameshells/chess/index.html
+++ b/gameshells/chess/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Chess (2D) — Gurjot's Games</title>
+    <link rel="stylesheet" href="/css/styles.css?v=5.3" />
     <script type="importmap">
     {
       "imports": {
@@ -13,22 +14,74 @@
     }
     </script>
   </head>
-  <body>
-    <canvas id="game-canvas" width="800" height="600" aria-label="Chess (2D) canvas"></canvas>
-    <div id="hud">
-      <div id="score" aria-live="polite">0</div>
-      <button id="pause-btn" aria-pressed="false">Pause</button>
-    </div>
+  <body style="margin:0;background:#0b1220;color:#e6e7ea;">
+    <main style="display:flex;gap:16px;justify-content:center;align-items:flex-start;padding:16px 16px 80px;">
+      <div style="position:relative;">
+        <canvas
+          id="board"
+          width="480"
+          height="480"
+          aria-label="Chess board"
+          style="border:1px solid #243047;border-radius:12px;background:#0f172a;"
+        ></canvas>
+        <canvas
+          id="fx"
+          width="480"
+          height="480"
+          aria-hidden="true"
+          style="position:absolute;left:0;top:0;pointer-events:none;"
+        ></canvas>
+      </div>
+      <aside style="max-width:260px;">
+        <h1 style="margin:0 0 8px 0;font-size:1.5rem;">Chess</h1>
+        <p style="margin:0 0 12px;">
+          Click a piece, then a target square.<br />
+          Press <b>R</b> to restart.<br />
+          Press <b>F1</b> for control remap.
+        </p>
+        <label for="difficulty">Difficulty:</label>
+        <select id="difficulty" style="display:block;margin:4px 0 12px;">
+          <option value="1">Easy</option>
+          <option value="2" selected>Medium</option>
+          <option value="3">Hard</option>
+          <option value="4">Expert</option>
+        </select>
+        <label for="puzzle-select">Puzzles:</label>
+        <select id="puzzle-select" style="display:block;margin:4px 0 12px;">
+          <option value="-1">Free Play</option>
+        </select>
+        <div id="status" role="status" aria-live="polite" style="min-height:1.5em;"></div>
+        <section id="lobby" aria-label="Online play" style="margin-top:16px;">
+          <button id="find-match" type="button">Find Match</button>
+          <div id="lobby-status" style="min-height:1.5em;"></div>
+          <ol id="rankings"></ol>
+        </section>
+      </aside>
+    </main>
     <script src="/js/bootstrap/gg.js"></script>
     <script src="/js/preflight.js"></script>
     <script type="module" src="/js/three-global-shim.js"></script>
     <script type="module">
       import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
-        ensureCanvas("game-canvas");
-        ensureElement("#score");
+        ensureCanvas("board");
+        ensureCanvas("fx");
+        ensureElement("#status");
+        ensureElement("#difficulty");
+        ensureElement("#puzzle-select");
+        ensureElement("#lobby");
+        ensureElement("#lobby-status");
+        ensureElement("#rankings");
+        ensureElement("#find-match");
       });
     </script>
-    <script type="module" src="/games/chess/chess.js"></script>
+    <script src="/games/chess/ai.js?v=5.3"></script>
+    <script src="/games/chess/puzzles.js?v=5.3"></script>
+    <script src="/games/chess/ratings.js?v=5.3"></script>
+    <script src="/games/chess/net.js?v=5.3"></script>
+    <script type="module" src="/games/chess/chess.js?v=5.3"></script>
+    <script src="/js/input.js?v=5.3"></script>
+    <script src="/js/remapUI.js?v=5.3"></script>
+    <script src="/js/perfHud.js?v=5.3"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expand the chess game shell to restore the dedicated board, HUD controls, and required scripts
- add DOM guard helpers in the chess engine to verify canvases and controls exist before use

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68c9e57ada588327861b3e3e7a19c320