### PR TITLE
fix: import three shim in maze3d

### DIFF
--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -1,3 +1,4 @@
+import '/js/three-global-shim.js';
 import { injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';
 import { connect } from './net.js';


### PR DESCRIPTION
## Summary
- ensure the Maze 3D module explicitly imports the three shim before using the global THREE object

## Testing
- npm run test:unit


------
https://chatgpt.com/codex/tasks/task_e_68c9e57ea86c83279eca6d011fd22dde