### PR TITLE
Update pause/resume messaging to GAME_* events

### DIFF
--- a/shared/game-ui.js
+++ b/shared/game-ui.js
@@ -123,11 +123,19 @@
       const pauseBtn = root.querySelector('#gg-pause');
       if (pauseBtn){ pauseBtn.setAttribute('aria-pressed','false'); }
       if (window.GG_HUD && typeof window.GG_HUD.hidePause==='function') window.GG_HUD.hidePause();
-      frame?.contentWindow?.postMessage({ type: 'GAME_RESUME' }, '*');
     } catch (err) {}
   }
 
-  clearAnyPause();
+  function sendGamePause(){
+    frame?.contentWindow?.postMessage({type:'GAME_PAUSE'}, '*');
+  }
+
+  function sendGameResume(){
+    clearAnyPause();
+    frame?.contentWindow?.postMessage({type:'GAME_RESUME'}, '*');
+  }
+
+  sendGameResume();
 
   // Keyboard shortcuts
   document.addEventListener('keydown', (e)=>{
@@ -179,11 +187,11 @@
       // currently visible -> resume
       $paused.setAttribute('hidden','');
       root.querySelector('#gg-pause').setAttribute('aria-pressed','false');
-      frame.contentWindow?.postMessage({type:'GG_RESUME'}, '*');
+      sendGameResume();
     } else {
       $paused.removeAttribute('hidden');
       root.querySelector('#gg-pause').setAttribute('aria-pressed','true');
-      frame.contentWindow?.postMessage({type:'GG_PAUSE'}, '*');
+      sendGamePause();
     }
   }
   function restart(){

--- a/shared/hiscore.js
+++ b/shared/hiscore.js
@@ -7,8 +7,8 @@ export function error(message){ try{ parent.postMessage({type:'GAME_ERROR', mess
 export function attachShellControls({ onPause, onResume, onRestart, onMute } = {}){
   window.addEventListener('message', (ev)=>{
     const d = ev.data||{};
-    if (d.type==='GG_PAUSE') onPause && onPause();
-    if (d.type==='GG_RESUME') onResume && onResume();
+    if (d.type==='GG_PAUSE' || d.type==='GAME_PAUSE') onPause && onPause();
+    if (d.type==='GG_RESUME' || d.type==='GAME_RESUME') onResume && onResume();
     if (d.type==='GG_RESTART') onRestart && onRestart();
     if (d.type==='GG_SET_MUTE') onMute && onMute(!!d.value);
   });


### PR DESCRIPTION
## Summary
- send GAME_PAUSE and GAME_RESUME events from the shared shell for all pause/resume flows
- ensure resume actions clear overlays before emitting GAME_RESUME to support force-unpause logic
- allow shared hiscore helper to respond to both legacy GG_* and new GAME_* pause events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca6198bf088327ba4d3edb5bb0a8e6