### PR TITLE
Adjust safety timeout to resume game

### DIFF
--- a/shared/game-ui.js
+++ b/shared/game-ui.js
@@ -216,7 +216,13 @@
   // Safety timeout: show error if no ready/error after 8s
   setTimeout(()=>{
     if (!$loading.hasAttribute('hidden')){
-      setError('No GAME_READY/ERROR signal received within 8s.');
+      console.warn('[GG][WARN] No GAME_READY/ERROR signal received within 8s; forcing resume.');
+      try {
+        clearAnyPause();
+        frame?.contentWindow?.postMessage({type:'GAME_RESUME'}, '*');
+      } catch (err) {
+        console.warn('[GG][WARN] Failed to send GAME_RESUME after timeout', err);
+      }
     }
   }, 8000);
 })();


### PR DESCRIPTION
## Summary
- replace the 8-second safety timeout error overlay with a warning that resumes the game
- ensure the timeout clears any pause state and posts a GAME_RESUME message instead of triggering setError

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca6239335083279bd2e9842952f7cd