### PR TITLE
Resume game after ready

### DIFF
--- a/shared/game-ui.js
+++ b/shared/game-ui.js
@@ -208,7 +208,10 @@
   // Listen for game events (from inside iframe)
   window.addEventListener('message', (ev)=>{
     const d = ev.data || {};
-    if (d.type==='GAME_READY'){ clearAnyPause(); setReady(); }
+    if (d.type==='GAME_READY'){
+      setReady();
+      sendGameResume();
+    }
     if (d.type==='GAME_ERROR'){ setError(d.message||'Unknown error'); }
     if (d.type==='GAME_SCORE'){ setScore(d.score); }
   });


### PR DESCRIPTION
## Summary
- trigger a resume message once the game signals it is ready
- rely on the shared resume helper to clear overlays and notify the iframe

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca63663810832796712bc1bebded0e