### PR TITLE
Adjust timeout resume handling

### DIFF
--- a/shared/game-ui.js
+++ b/shared/game-ui.js
@@ -219,10 +219,10 @@
   // Safety timeout: show error if no ready/error after 8s
   setTimeout(()=>{
     if (!$loading.hasAttribute('hidden')){
-      console.warn('[GG][WARN] No GAME_READY/ERROR signal received within 8s; forcing resume.');
+      console.warn('[GG][WARN] No GAME_READY/ERROR signal received within 8s; attempting graceful resume.');
+      setReady();
       try {
-        clearAnyPause();
-        frame?.contentWindow?.postMessage({type:'GAME_RESUME'}, '*');
+        sendGameResume();
       } catch (err) {
         console.warn('[GG][WARN] Failed to send GAME_RESUME after timeout', err);
       }


### PR DESCRIPTION
## Summary
- update the safety timeout handler to log a warning, clear the loading overlay, and resume the game via `sendGameResume()` when no GAME_READY or GAME_ERROR message arrives

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca6421e4548327991235f107a47c8e