### PR TITLE
Ensure loader creates t canvas

### DIFF
--- a/js/game-loader.js
+++ b/js/game-loader.js
@@ -14,10 +14,10 @@
 
   (function(){
     const root = document.getElementById('game-root') || (function(){ const d=document.createElement('div'); d.id='game-root'; document.body.appendChild(d); return d; })();
-    const ids=['status','level','lives','board','game','c','canvas','gameCanvas','fx','hud','score'];
+    const ids=['status','level','lives','board','game','c','canvas','gameCanvas','fx','hud','score','t'];
     ids.forEach(id=>{
       if(document.getElementById(id)) return;
-      const el = (id==='c'||id==='board'||id==='game'||id==='canvas'||id==='gameCanvas'||id==='fx') ? document.createElement('canvas') : document.createElement('div');
+      const el = (id==='c'||id==='board'||id==='game'||id==='canvas'||id==='gameCanvas'||id==='fx'||id==='t') ? document.createElement('canvas') : document.createElement('div');
       el.id=id; root.appendChild(el);
       if (el.tagName==='CANVAS' && typeof window.fitCanvasToParent==='function') window.fitCanvasToParent(el);
     });


### PR DESCRIPTION
## Summary
- ensure the loader creates a `<canvas id="t">` element for modules that expect it
- treat the new `t` identifier as a canvas element when building the fallback DOM

## Testing
- npm run test:unit
- npx http-server . -p 4173 # manually visited http://127.0.0.1:4173/game.html?id=tetris

------
https://chatgpt.com/codex/tasks/task_e_68ca6c5fa14483279772b0eed637d160