### PR TITLE
Align Maze3D three.js modules

### DIFF
--- a/games/maze3d/PointerLockControls.js
+++ b/games/maze3d/PointerLockControls.js
@@ -1,0 +1,163 @@
+// Adapted from three.js r161 (MIT License) PointerLockControls module.
+import {
+        Euler,
+        EventDispatcher,
+        Vector3
+} from 'https://unpkg.com/three@0.161.0/build/three.module.js?module';
+
+const _euler = new Euler( 0, 0, 0, 'YXZ' );
+const _vector = new Vector3();
+
+const _changeEvent = { type: 'change' };
+const _lockEvent = { type: 'lock' };
+const _unlockEvent = { type: 'unlock' };
+
+const _PI_2 = Math.PI / 2;
+
+class PointerLockControls extends EventDispatcher {
+
+	constructor( camera, domElement ) {
+
+		super();
+
+		this.camera = camera;
+		this.domElement = domElement;
+
+		this.isLocked = false;
+
+		// Set to constrain the pitch of the camera
+		// Range is 0 to Math.PI radians
+		this.minPolarAngle = 0; // radians
+		this.maxPolarAngle = Math.PI; // radians
+
+		this.pointerSpeed = 1.0;
+
+		this._onMouseMove = onMouseMove.bind( this );
+		this._onPointerlockChange = onPointerlockChange.bind( this );
+		this._onPointerlockError = onPointerlockError.bind( this );
+
+		this.connect();
+
+	}
+
+	connect() {
+
+		this.domElement.ownerDocument.addEventListener( 'mousemove', this._onMouseMove );
+		this.domElement.ownerDocument.addEventListener( 'pointerlockchange', this._onPointerlockChange );
+		this.domElement.ownerDocument.addEventListener( 'pointerlockerror', this._onPointerlockError );
+
+	}
+
+	disconnect() {
+
+		this.domElement.ownerDocument.removeEventListener( 'mousemove', this._onMouseMove );
+		this.domElement.ownerDocument.removeEventListener( 'pointerlockchange', this._onPointerlockChange );
+		this.domElement.ownerDocument.removeEventListener( 'pointerlockerror', this._onPointerlockError );
+
+	}
+
+	dispose() {
+
+		this.disconnect();
+
+	}
+
+	getObject() { // retaining this method for backward compatibility
+
+		return this.camera;
+
+	}
+
+	getDirection( v ) {
+
+		return v.set( 0, 0, - 1 ).applyQuaternion( this.camera.quaternion );
+
+	}
+
+	moveForward( distance ) {
+
+		// move forward parallel to the xz-plane
+		// assumes camera.up is y-up
+
+		const camera = this.camera;
+
+		_vector.setFromMatrixColumn( camera.matrix, 0 );
+
+		_vector.crossVectors( camera.up, _vector );
+
+		camera.position.addScaledVector( _vector, distance );
+
+	}
+
+	moveRight( distance ) {
+
+		const camera = this.camera;
+
+		_vector.setFromMatrixColumn( camera.matrix, 0 );
+
+		camera.position.addScaledVector( _vector, distance );
+
+	}
+
+	lock() {
+
+		this.domElement.requestPointerLock();
+
+	}
+
+	unlock() {
+
+		this.domElement.ownerDocument.exitPointerLock();
+
+	}
+
+}
+
+// event listeners
+
+function onMouseMove( event ) {
+
+	if ( this.isLocked === false ) return;
+
+	const movementX = event.movementX || event.mozMovementX || event.webkitMovementX || 0;
+	const movementY = event.movementY || event.mozMovementY || event.webkitMovementY || 0;
+
+	const camera = this.camera;
+	_euler.setFromQuaternion( camera.quaternion );
+
+	_euler.y -= movementX * 0.002 * this.pointerSpeed;
+	_euler.x -= movementY * 0.002 * this.pointerSpeed;
+
+	_euler.x = Math.max( _PI_2 - this.maxPolarAngle, Math.min( _PI_2 - this.minPolarAngle, _euler.x ) );
+
+	camera.quaternion.setFromEuler( _euler );
+
+	this.dispatchEvent( _changeEvent );
+
+}
+
+function onPointerlockChange() {
+
+	if ( this.domElement.ownerDocument.pointerLockElement === this.domElement ) {
+
+		this.dispatchEvent( _lockEvent );
+
+		this.isLocked = true;
+
+	} else {
+
+		this.dispatchEvent( _unlockEvent );
+
+		this.isLocked = false;
+
+	}
+
+}
+
+function onPointerlockError() {
+
+	console.error( 'THREE.PointerLockControls: Unable to use Pointer Lock API' );
+
+}
+
+export { PointerLockControls };

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -51,8 +51,8 @@
       </div>
     </div>
   </div>
-  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
-  <script src="https://unpkg.com/three@0.160.0/examples/js/controls/PointerLockControls.js"></script>
+  <script src="https://unpkg.com/three@0.161.0/build/three.min.js"></script>
+  <script src="https://unpkg.com/three@0.161.0/examples/js/controls/PointerLockControls.js"></script>
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="maze3d"></script>
 </body>

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -1,4 +1,4 @@
-import { PointerLockControls } from "https://unpkg.com/three@0.161.0/examples/jsm/controls/PointerLockControls.js";
+import { PointerLockControls } from "./PointerLockControls.js";
 import '/js/three-global-shim.js';
 import { injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.js';
 import { emitEvent } from '../../shared/achievements.js';

--- a/js/three-global-shim.js
+++ b/js/three-global-shim.js
@@ -1,12 +1,15 @@
 // three-global-shim.js (classic) — never uses top-level import
 (function(){
-  if (window.THREE) return;
+  if (window.THREE || window.__THREE_MODULE_LOADING__) return;
+  window.__THREE_MODULE_LOADING__ = true;
   var s=document.createElement('script');
   s.type='module';
   s.textContent = `
-    import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+    import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js?module';
     if (!('THREE' in window)) Object.defineProperty(window, 'THREE', { value: THREE, configurable:false, writable:false });
+    delete window.__THREE_MODULE_LOADING__;
     export default THREE;
   `;
+  s.addEventListener('error', () => { delete window.__THREE_MODULE_LOADING__; });
   document.head.appendChild(s);
 })();


### PR DESCRIPTION
## Summary
- add a local PointerLockControls module pinned to three.js r161 and update Maze3D to use it
- bump Maze3D HTML and global shim to three.js r161 with consistent ?module loader safeguards

## Testing
- play.html?id=maze3d smoke test

------
https://chatgpt.com/codex/tasks/task_e_68ca6c5148608327af79bde54e63fabb