### PR TITLE
Handle guard fallback without duplicating history

### DIFF
--- a/scripts/router.js
+++ b/scripts/router.js
@@ -36,7 +36,8 @@ export class Router {
         const params = {};
         r.keys.forEach((k, i) => params[k] = decodeURIComponent(match[i + 1]));
         if (r.guard && !(await r.guard(params))) {
-          return this.navigate('/');
+          history.replaceState({}, '', '/');
+          return this.resolve('/');
         }
         const mod = await r.loader(params);
         this.outlet.innerHTML = '';

--- a/src/router.ts
+++ b/src/router.ts
@@ -49,7 +49,8 @@ export class Router {
         const params: Params = {};
         r.keys.forEach((k, i) => params[k] = decodeURIComponent(match[i + 1]));
         if (r.guard && !(await r.guard(params))) {
-          return this.navigate('/');
+          history.replaceState({}, '', '/');
+          return this.resolve('/');
         }
         const mod = await r.loader(params);
         this.outlet.innerHTML = '';

--- a/tests/router.guard.test.js
+++ b/tests/router.guard.test.js
@@ -1,0 +1,40 @@
+/* @vitest-environment jsdom */
+import { describe, expect, test, vi } from 'vitest';
+import { Router } from '../scripts/router.js';
+
+describe('Router guard navigation', () => {
+  test('guard failure replaces current history entry', async () => {
+    const originalPathname = location.pathname;
+    history.replaceState({}, '', originalPathname);
+
+    const pushSpy = vi.spyOn(history, 'pushState');
+    const replaceSpy = vi.spyOn(history, 'replaceState');
+
+    const outlet = document.createElement('div');
+    const router = new Router(outlet);
+    const fallbackHandler = vi.fn();
+    const fallbackLoader = vi.fn(async () => ({ default: fallbackHandler }));
+    router.register('/', fallbackLoader);
+
+    const guardedLoader = vi.fn(async () => ({ default: vi.fn() }));
+    const guard = vi.fn().mockResolvedValue(false);
+    router.register('/protected', guardedLoader, guard);
+
+    const initialLength = history.length;
+
+    await router.navigate('/protected');
+
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(guardedLoader).not.toHaveBeenCalled();
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(history.length).toBe(initialLength + 1);
+    expect(location.pathname).toBe('/');
+    expect(fallbackLoader).toHaveBeenCalledTimes(1);
+    expect(fallbackHandler).toHaveBeenCalledTimes(1);
+
+    pushSpy.mockRestore();
+    replaceSpy.mockRestore();
+    history.replaceState({}, '', originalPathname);
+  });
+});


### PR DESCRIPTION
## Summary
- replace guard failure redirects with a history.replaceState('/') + resolve('/') flow in both router implementations
- add a jsdom unit test that verifies guarded navigation falls back to the root without adding an extra history entry

## Testing
- npm run test:unit *(fails: tests/sw.test.js > service worker cache management > removes outdated caches on activate)*

------
https://chatgpt.com/codex/tasks/task_e_68caf8744fcc8327a57b1d6fd9d7dd3d