### PR TITLE
Stop soft loading overlay after game ready

### DIFF
--- a/js/game-shell.js
+++ b/js/game-shell.js
@@ -266,6 +266,7 @@ function renderError(msg, e){
 window.addEventListener('message', function(ev){
   var data = ev.data || {};
   if(data.type === 'GAME_READY'){
+    if (state.timer) { try { clearTimeout(state.timer); } catch(_){} state.timer = null; }
     var _ov = ensureOverlays();
     try { _ov.loader.style.display='none'; } catch(_) {}
     try { _ov.err.classList.remove('show'); } catch(_) {}


### PR DESCRIPTION
## Summary
- clear the soft-loading timeout once the game reports GAME_READY so the overlay cannot reappear after load completes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0523e32883279ff8c73e743b5427