### PR TITLE
Guard Tetris reportReady usage

### DIFF
--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -455,10 +455,10 @@ function loop(ts){
 }
 
 if(mode==='replay'){
-  Replay.load(`./replays/${replayFile}`).then(()=>{initGame();started=true;requestAnimationFrame(loop);reportReady('tetris');});
+  Replay.load(`./replays/${replayFile}`).then(()=>{initGame();started=true;requestAnimationFrame(loop);if(typeof reportReady==='function') reportReady('tetris');});
 }else{
   initGame();
   if(mode==='spectate') started=true;
   requestAnimationFrame(loop);
-  reportReady('tetris');
+  if(typeof reportReady==='function') reportReady('tetris');
 }


### PR DESCRIPTION
## Summary
- guard the Tetris reportReady callbacks so they only run when defined

## Testing
- Manual testing
  - python -m http.server 4173 (in repo root)
  - Verified http://127.0.0.1:4173/games/tetris/play.html loads without console errors when reportReady is undefined
  - Verified the page loads and calls reportReady when a stub is injected

------
https://chatgpt.com/codex/tasks/task_e_68cb23cb11c883279a9d3191e59e757b