### PR TITLE
Add readiness notification to 2048 boot sequence

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -320,3 +320,4 @@ applyTheme();
 reset(true);
 gameLoop.start();
 net?.send('move',{grid,score});
+window.DIAG?.ready?.();


### PR DESCRIPTION
## Summary
- call the diagnostic ready hook after the 2048 game completes its initialisation

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68cb2510e93883279529bc6fa034d378