### PR TITLE
Add Replay shim recordAction and interface methods

### DIFF
--- a/shared/gg-shim.js
+++ b/shared/gg-shim.js
@@ -28,7 +28,24 @@
     window.SFX = { load(){}, play(){}, mute(){}, unmute(){}, stop(){} };
   }
   if (typeof window.Replay !== 'object') {
-    window.Replay = { recordPiece(){}, reset(){}, start(){}, export(){ return ''; } };
+    window.Replay = {
+      start(){},
+      stop(){ return { pieces: [], actions: [] }; },
+      recordPiece(){},
+      recordAction(){},
+      reset(){},
+      export(){ return ''; },
+      exportData(){ return ''; },
+      download(){},
+      load(){ return Promise.resolve({ nextPiece(){}, tick(){ return []; } }); },
+      nextPiece(){},
+      tick(){ return []; },
+      Player: class {
+        constructor(){ this.pieces = []; this.actions = []; }
+        nextPiece(){ return this.pieces.shift(); }
+        tick(){ return []; }
+      }
+    };
   }
   console.log('[gg-shim] installed helpers: GG, SFX, Replay, fitCanvasToParent');
 })();


### PR DESCRIPTION
## Summary
- extend the fallback Replay shim to include a recordAction no-op
- provide stub implementations for the Replay methods used by Tetris to prevent runtime errors when the shim is active

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb28a9e4a083279fa44c5f4bbbab53