### PR TITLE
Prevent page scroll during Tetris controls

### DIFF
--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -364,7 +364,11 @@ function applyAction(a){
 }
 
 addEventListener('keydown',e=>{
-  if(e.key.toLowerCase()==='g'){
+  const key=e.key||'';
+  const keyLower=key.toLowerCase();
+  const shouldPrevent=e.code==='Space'||key.startsWith('Arrow');
+  if(shouldPrevent) e.preventDefault();
+  if(keyLower==='g'){
     showGhost=!showGhost;
     localStorage.setItem('tetris:ghost',showGhost?'1':'0');
     updateGhost();
@@ -375,7 +379,7 @@ addEventListener('keydown',e=>{
     if(e.code==='Space'){ started=true; Replay.start(); return; }
     return;
   }
-  if(over && e.key.toLowerCase()==='r'){
+  if(over && keyLower==='r'){
     grid=Array.from({length:ROWS},()=>Array(COLS).fill(0));
     bag=[]; initGame();
     score=0; level=1; lines=0; holdM=null; canHold=true;
@@ -383,7 +387,7 @@ addEventListener('keydown',e=>{
     updateGhost();
     return;
   }
-  if(e.key.toLowerCase()==='p'){ paused=!paused; return; }
+  if(keyLower==='p'){ paused=!paused; return; }
   if(paused || over || clearAnim) return;
 
   if(e.key==='ArrowLeft'){ applyAction('left'); Replay.recordAction('left'); }
@@ -391,7 +395,7 @@ addEventListener('keydown',e=>{
   if(e.key==='ArrowUp'){ applyAction('rotate'); Replay.recordAction('rotate'); }
   if(e.key==='ArrowDown'){ applyAction('down'); Replay.recordAction('down'); }
   if(e.code==='Space'){ applyAction('hardDrop'); Replay.recordAction('hardDrop'); }
-  if(e.key.toLowerCase()==='c'){ applyAction('hold'); Replay.recordAction('hold'); }
+  if(keyLower==='c'){ applyAction('hold'); Replay.recordAction('hold'); }
 });
 
 


### PR DESCRIPTION
## Summary
- prevent default browser behavior when using arrow keys or space in the Tetris keydown handler to avoid page scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb29f07d048327af3e3f300a681797