### PR TITLE
Prevent browser scroll during Tetris controls

### DIFF
--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -366,8 +366,10 @@ function applyAction(a){
 addEventListener('keydown',e=>{
   const key=e.key||'';
   const keyLower=key.toLowerCase();
-  const shouldPrevent=e.code==='Space'||key.startsWith('Arrow');
-  if(shouldPrevent) e.preventDefault();
+  const preventKeys=new Set(['ArrowLeft','ArrowRight','ArrowUp','ArrowDown',' ']);
+  if(e.code==='Space' || preventKeys.has(key) || key==='Spacebar'){
+    e.preventDefault();
+  }
   if(keyLower==='g'){
     showGhost=!showGhost;
     localStorage.setItem('tetris:ghost',showGhost?'1':'0');


### PR DESCRIPTION
## Summary
- prevent browser scroll by calling `preventDefault` for space and arrow key controls in Tetris

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb406d0c408327b31e59024e3b7bac