### PR TITLE
Add Pong match configuration tests and responsive sizing

### DIFF
--- a/tests/pong.canvas-resize.test.js
+++ b/tests/pong.canvas-resize.test.js
@@ -1,73 +1,81 @@
 /* @vitest-environment jsdom */
-import { describe, it, expect } from 'vitest';
-import fs from 'fs';
-import path from 'path';
-
-// Helper to evaluate a script file in the window context
-function runScript(relativePath) {
-  const code = fs.readFileSync(path.resolve(relativePath), 'utf8');
-  // eslint-disable-next-line no-eval
-  window.eval(code);
-}
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 describe('pong canvas loop', () => {
-  it('resizes via CSS pixels and exposes controls', () => {
-    // Set up DOM with canvas
-    document.body.innerHTML = '<canvas id="game" style="width:452px;height:301px"></canvas>';
+  let originalGetContext;
+  let originalRequestAnimationFrame;
+  let originalCancelAnimationFrame;
+  let cleanup;
 
-    window.devicePixelRatio = 1;
-    // Stub canvas context methods used by the game
-    const ctxStub = {
-      setTransform() {},
-      clearRect() {},
-      fillRect() {},
-      beginPath() {},
-      moveTo() {},
-      lineTo() {},
-      stroke() {},
-      setLineDash() {},
-      fill() {},
-      arc() {},
-      fillText() {},
-      fillStyle: '',
-      strokeStyle: '',
-      font: '',
-      textAlign: ''
-    };
+  const ctxStub = {
+    setTransform() {},
+    clearRect() {},
+    fillRect() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    setLineDash() {},
+    fill() {},
+    arc() {},
+    fillText() {},
+    save() {},
+    restore() {},
+    measureText(text = '') {
+      return { width: text.length * 10 };
+    },
+    fillStyle: '',
+    strokeStyle: '',
+    font: '',
+    textAlign: '',
+    textBaseline: '',
+    globalAlpha: 1,
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = '<canvas id="game" style="width:452px;height:301px"></canvas>';
+    cleanup = undefined;
+
+    originalGetContext = window.HTMLCanvasElement.prototype.getContext;
     window.HTMLCanvasElement.prototype.getContext = () => ctxStub;
 
-    // Prevent animation loop from continuing
+    originalRequestAnimationFrame = window.requestAnimationFrame;
+    originalCancelAnimationFrame = window.cancelAnimationFrame;
     window.requestAnimationFrame = () => 0;
     window.cancelAnimationFrame = () => {};
-    window.ResizeObserver = undefined;
+  });
 
-    runScript('js/canvasLoop.global.js');
-    window.GG = { incPlays() {}, addXP() {}, setMeta() {}, addAch() {} };
+  afterEach(() => {
+    if (typeof cleanup === 'function') {
+      cleanup();
+    }
+    document.body.innerHTML = '';
+    window.HTMLCanvasElement.prototype.getContext = originalGetContext;
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    if (window.__pongTest) delete window.__pongTest;
+  });
 
-    runScript('games/pong/pauseOverlay.js');
-    runScript('games/pong/pong.js');
+  it('resizes via CSS pixels and exposes controls', async () => {
+    const { boot } = await import('../games/pong/main.js');
+    boot();
+    cleanup = window.__pongTest?.cleanup;
+
     const canvas = document.getElementById('game');
+    expect(canvas).toBeTruthy();
     expect({ w: canvas.width, h: canvas.height }).toEqual({ w: 452, h: 301 });
 
-    // Simulate CSS resize and window resize event
     canvas.style.width = '652px';
     canvas.style.height = '435px';
     window.dispatchEvent(new Event('resize'));
     expect({ w: canvas.width, h: canvas.height }).toEqual({ w: 652, h: 435 });
 
-    expect(typeof window.pong.start).toBe('function');
-    expect(typeof window.pong.stop).toBe('function');
-    expect(typeof window.pong.dispose).toBe('function');
+    expect(typeof window.__pongTest?.handleScore).toBe('function');
+    expect(typeof window.__pongTest?.startNewMatch).toBe('function');
 
-    const overlay = document.querySelector('.pause-overlay[data-game="pong"]');
-    expect(overlay).toBeTruthy();
-    expect(overlay.classList.contains('hidden')).toBe(true);
-
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-    expect(overlay.classList.contains('hidden')).toBe(false);
-
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-    expect(overlay.classList.contains('hidden')).toBe(true);
+    const state = window.__pongTest?.getState?.();
+    expect(state).toBeTruthy();
+    expect(state).toMatchObject({ leftScore: 0, rightScore: 0, matchOver: false });
   });
 });
 

--- a/tests/pong.match.test.js
+++ b/tests/pong.match.test.js
@@ -1,0 +1,147 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const ctxFactory = () => ({
+  setTransform() {},
+  clearRect() {},
+  fillRect() {},
+  beginPath() {},
+  moveTo() {},
+  lineTo() {},
+  stroke() {},
+  setLineDash() {},
+  fill() {},
+  arc() {},
+  fillText() {},
+  save() {},
+  restore() {},
+  measureText(text = '') {
+    return { width: text.length * 10 };
+  },
+  globalAlpha: 1,
+  fillStyle: '#000',
+  strokeStyle: '#000',
+  font: '',
+  textAlign: 'left',
+  textBaseline: 'alphabetic',
+});
+
+describe('pong match configuration', () => {
+  let originalGetContext;
+  let originalRequestAnimationFrame;
+  let originalCancelAnimationFrame;
+  let frameQueue;
+  let cleanup;
+
+  function stepFrames(count = 1) {
+    for (let i = 0; i < count; i += 1) {
+      const cb = frameQueue.shift();
+      if (!cb) break;
+      cb();
+    }
+  }
+
+  beforeEach(() => {
+    frameQueue = [];
+    cleanup = undefined;
+    document.body.innerHTML = '<canvas id="game"></canvas>';
+
+    const ctxStub = ctxFactory();
+    originalGetContext = window.HTMLCanvasElement.prototype.getContext;
+    window.HTMLCanvasElement.prototype.getContext = () => ctxStub;
+
+    originalRequestAnimationFrame = window.requestAnimationFrame;
+    originalCancelAnimationFrame = window.cancelAnimationFrame;
+    window.requestAnimationFrame = (cb) => {
+      frameQueue.push(cb);
+      return frameQueue.length;
+    };
+    window.cancelAnimationFrame = () => {};
+  });
+
+  afterEach(() => {
+    if (typeof cleanup === 'function') {
+      cleanup();
+    }
+    frameQueue = [];
+    document.body.innerHTML = '';
+    window.HTMLCanvasElement.prototype.getContext = originalGetContext;
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    if (window.__pongTest) {
+      delete window.__pongTest;
+    }
+  });
+
+  it('honors target score and win-by-two configuration', async () => {
+    const { boot } = await import('../games/pong/main.js');
+    boot({ targetScore: 3, winByTwo: true });
+    stepFrames(1);
+
+    const hooks = window.__pongTest;
+    cleanup = hooks.cleanup;
+
+    expect(hooks.config.targetScore).toBe(3);
+    expect(hooks.config.winByTwo).toBe(true);
+
+    hooks.handleScore('left');
+    hooks.handleScore('left');
+    hooks.handleScore('right');
+    hooks.handleScore('right');
+
+    let state = hooks.getState();
+    expect(state.leftScore).toBe(2);
+    expect(state.rightScore).toBe(2);
+    expect(state.matchOver).toBe(false);
+
+    hooks.handleScore('left');
+    state = hooks.getState();
+    expect(state.leftScore).toBe(3);
+    expect(state.matchOver).toBe(false);
+
+    hooks.handleScore('left');
+    state = hooks.getState();
+    expect(state.leftScore).toBe(4);
+    expect(state.matchOver).toBe(true);
+    expect(state.winner).toBe('left');
+    expect(state.paused).toBe(true);
+  });
+
+  it('resets match state for consecutive wins', async () => {
+    const { boot } = await import('../games/pong/main.js');
+    boot({ targetScore: 2, winByTwo: false });
+    stepFrames(1);
+
+    let hooks = window.__pongTest;
+    cleanup = hooks.cleanup;
+
+    hooks.handleScore('right');
+    hooks.handleScore('right');
+
+    let state = hooks.getState();
+    expect(state.matchOver).toBe(true);
+    expect(state.winner).toBe('right');
+    expect(state.rightScore).toBe(2);
+
+    hooks.startNewMatch();
+    state = hooks.getState();
+    expect(state.matchOver).toBe(false);
+    expect(state.leftScore).toBe(0);
+    expect(state.rightScore).toBe(0);
+    expect(state.winner).toBe(null);
+    expect(state.paused).toBe(false);
+    expect(state.servePending).toBe(true);
+
+    hooks.handleScore('left');
+    hooks.handleScore('left');
+    state = hooks.getState();
+    expect(state.matchOver).toBe(true);
+    expect(state.winner).toBe('left');
+
+    // Ensure cleanup removes hooks for subsequent tests
+    cleanup();
+    cleanup = undefined;
+    hooks = window.__pongTest;
+    expect(hooks).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the Pong canvas sizes itself from CSS hints and reacts to window resize events while keeping match state consistent
- add jsdom-based coverage for target score and win-by-two match resets via the exported test hooks
- refresh the canvas resize smoke test to exercise the modern Pong module APIs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb4072ba2483279e880bfe31624320