### PR TITLE
Prefer modern gameshell wrappers with legacy fallback

### DIFF
--- a/game.html
+++ b/game.html
@@ -143,9 +143,31 @@
 
       // Load the game iframe
       pillSlug.textContent = "slug: " + (slug || "—");
-      const src = slug ? `./games/${slug}/index.html` : "./404.html";
-      frame.src = src;
-      write(`iframe src set → ${src}`);
+
+      function setFrameSrc(src, note) {
+        frame.src = src;
+        write(`iframe src set → ${src}${note ? ` (${note})` : ""}`);
+      }
+
+      if (!slug) {
+        setFrameSrc("./404.html");
+      } else {
+        const modernSrc = `./gameshells/${slug}/index.html`;
+        const legacySrc = `./games/${slug}/index.html`;
+
+        write(`checking modern wrapper → ${modernSrc}`);
+        fetch(modernSrc, { method: "HEAD" })
+          .then((resp) => {
+            if (resp.ok) {
+              setFrameSrc(modernSrc, "modern wrapper");
+            } else {
+              setFrameSrc(legacySrc, `legacy fallback (status ${resp.status})`);
+            }
+          })
+          .catch((err) => {
+            setFrameSrc(legacySrc, `legacy fallback (${err && err.message ? err.message : err})`);
+          });
+      }
 
       // Signal handling
       let signalled = false;


### PR DESCRIPTION
## Summary
- prefer loading game shells from `gameshells/<slug>/index.html` when available
- fall back to the legacy `games/<slug>/index.html` path if the wrapper is missing and log the outcome

## Testing
- manual verification of `game.html?slug=g2048` and `game.html?slug=pong` via local `python -m http.server`


------
https://chatgpt.com/codex/tasks/task_e_68cc4af7874883278233ce4946e91356