### PR TITLE
Fix healthcheck path resolution for playUrl

### DIFF
--- a/tools/healthcheck.mjs
+++ b/tools/healthcheck.mjs
@@ -11,7 +11,22 @@ async function exists(p){
 async function checkGame(root, game){
   const result = { id: game.id || game.slug || game.title || 'unknown', status: 'ok', reason: '' };
   const entryRel = typeof game.entry === 'string' ? game.entry.replace(/^\//, '') : null;
-  const indexRel = typeof game.path === 'string' ? game.path.replace(/^\//, '') : null;
+  const indexRel = (() => {
+    if (typeof game.path === 'string'){
+      return game.path.replace(/^\//, '');
+    }
+    if (typeof game.playUrl === 'string'){
+      const cleaned = game.playUrl.replace(/^\//, '');
+      if (cleaned.endsWith('/')){
+        return path.join(cleaned, 'index.html');
+      }
+      if (cleaned.endsWith('.html')){
+        return cleaned;
+      }
+      return path.join(cleaned, 'index.html');
+    }
+    return null;
+  })();
   const indexPath = indexRel
     ? path.join(root, indexRel)
     : entryRel


### PR DESCRIPTION
## Summary
- update the healthcheck script to resolve game index files from playUrl entries when path metadata is missing
- preserve support for legacy path and entry fields while inferring index.html for directory URLs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d426e7f1bc83279e6d5d4136fd90ad