### PR TITLE
Make healthcheck accept modern games catalog

### DIFF
--- a/tools/healthcheck.mjs
+++ b/tools/healthcheck.mjs
@@ -8,15 +8,31 @@ async function exists(p){
   catch{ return false; }
 }
 
-async function checkGame(root, game){
-  const result = { id: game.id || game.slug || game.title || 'unknown', status: 'ok', reason: '' };
-  const entryRel = typeof game.entry === 'string' ? game.entry.replace(/^\//, '') : null;
-  const indexRel = (() => {
-    if (typeof game.path === 'string'){
-      return game.path.replace(/^\//, '');
+function cleanPath(p){
+  return p.replace(/^\//, '').split('?')[0].split('#')[0];
+}
+
+function normalizePlayUrl(url){
+  try{
+    const parsed = new URL(url, 'https://example.com');
+    const pathname = parsed.pathname.replace(/^\//, '');
+    if (!pathname){
+      return null;
     }
-    if (typeof game.playUrl === 'string'){
-      const cleaned = game.playUrl.replace(/^\//, '');
+    if (pathname.endsWith('/')){
+      return path.join(pathname, 'index.html');
+    }
+    if (pathname.endsWith('.html')){
+      return pathname;
+    }
+    return path.join(pathname, 'index.html');
+  }
+  catch{
+    if (typeof url === 'string' && url.trim()){
+      const cleaned = cleanPath(url.trim());
+      if (!cleaned){
+        return null;
+      }
       if (cleaned.endsWith('/')){
         return path.join(cleaned, 'index.html');
       }
@@ -26,12 +42,23 @@ async function checkGame(root, game){
       return path.join(cleaned, 'index.html');
     }
     return null;
-  })();
-  const indexPath = indexRel
-    ? path.join(root, indexRel)
-    : entryRel
-      ? path.join(root, path.dirname(entryRel), 'index.html')
-      : null;
+  }
+}
+
+async function checkGame(root, game){
+  const result = { id: game.id || game.slug || game.title || 'unknown', status: 'ok', reason: '' };
+  const entryRel = typeof game.entry === 'string' ? cleanPath(game.entry) : null;
+  const pathRel = typeof game.path === 'string' ? cleanPath(game.path) : null;
+  const playRel = typeof game.playUrl === 'string' ? normalizePlayUrl(game.playUrl) : null;
+  const slugRel = typeof game.slug === 'string' ? path.join('games', game.slug, 'index.html') : null;
+  const fallbackRel = typeof game.id === 'string' ? path.join('games', game.id, 'index.html') : null;
+
+  const indexRel = pathRel
+    || playRel
+    || (entryRel ? path.join(path.dirname(entryRel), 'index.html') : null)
+    || slugRel
+    || fallbackRel;
+  const indexPath = indexRel ? path.join(root, indexRel) : null;
   if (!indexPath){
     result.status = 'fail';
     result.reason = 'missing path info';
@@ -63,7 +90,14 @@ async function checkGame(root, game){
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
 export async function runHealthcheck(){
-  const data = JSON.parse(await readFile(path.join(root, 'games.json'), 'utf8'));
+  const raw = JSON.parse(await readFile(path.join(root, 'games.json'), 'utf8'));
+  const data = Array.isArray(raw)
+    ? raw
+    : Array.isArray(raw.games)
+      ? raw.games
+      : typeof raw === 'object' && raw
+        ? Object.keys(raw).map(key => ({ id: key, ...raw[key] }))
+        : [];
   const results = [];
   for (const game of data){
     results.push(await checkGame(root, game));


### PR DESCRIPTION
## Summary
- normalize paths coming from entry, path, or playUrl so games without legacy fields still validate
- fall back to slug/id-based index.html detection and accept array, map, or {games: []} catalogs

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d428f0ac1c83278be9a7c6425aca20