### PR TITLE
Ensure games load through shared shell

### DIFF
--- a/scripts/pages/game.js
+++ b/scripts/pages/game.js
@@ -2,12 +2,22 @@ import { loadStyle } from '../utils.js';
 
 export default async function(outlet, params){
   loadStyle('styles/pages/game.css');
-  let src = `/games/${params.id}/`;
+  const slug = params.id;
+  const query = new URLSearchParams(location.search);
+  const forceLegacy = query.has('legacy') || (query.get('shell') || '').toLowerCase() === 'legacy' || query.get('noshell') === '1';
+  const buildShellUrl = (id) => {
+    const url = new URL('/game.html', location.origin);
+    url.searchParams.set('slug', id);
+    return `${url.pathname}${url.search}`;
+  };
+  let src = forceLegacy ? `/games/${slug}/` : buildShellUrl(slug);
   try {
     const res = await fetch('/games.json');
     const games = await res.json();
     const game = Array.isArray(games) ? games.find(g => g.id === params.id) : null;
-    if (game && game.playUrl) src = game.playUrl;
+    if (game && game.playUrl){
+      if (forceLegacy) src = String(game.playUrl);
+    }
   } catch {}
   const frame = document.createElement('iframe');
   frame.id = 'game-frame';


### PR DESCRIPTION
## Summary
- update the in-app game route to embed `game.html` and only fall back to legacy URLs when explicitly requested
- teach the diagnostics bootstrap script to redirect top-level legacy game pages into the shared shell automatically

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4291078188327931f178e1e2e4e93