### PR TITLE
Use resolved playUrl across tools

### DIFF
--- a/scripts/pages/game.js
+++ b/scripts/pages/game.js
@@ -1,14 +1,17 @@
 import { loadStyle } from '../utils.js';
+import { resolveGamePaths } from '../../shared/game-paths.js';
 
 export default async function(outlet, params){
   loadStyle('styles/pages/game.css');
-  let src = `/games/${params.id}/`;
+  let src = `/games/${params.id}/index.html`;
   try {
-    const res = await fetch('/games.json');
-    const games = await res.json();
-    const game = Array.isArray(games) ? games.find(g => g.id === params.id) : null;
-    if (game && game.playUrl) src = game.playUrl;
-  } catch {}
+    const { playPath } = await resolveGamePaths(params.id);
+    if (playPath) {
+      src = playPath;
+    }
+  } catch (err) {
+    console.warn('[GG] unable to resolve game frame path', params?.id, err);
+  }
   const frame = document.createElement('iframe');
   frame.id = 'game-frame';
   frame.src = src;

--- a/tools/missing-games-debug.html
+++ b/tools/missing-games-debug.html
@@ -59,7 +59,8 @@
 
   <div id="list"></div>
 </main>
-<script>
+<script type="module">
+import { resolveGamePaths } from '../shared/game-paths.js';
 (function(){
   const logEl = document.getElementById('log');
   function log(msg, cls=''){ const d=document.createElement('div'); d.className='line '+cls; d.textContent = '['+new Date().toISOString().slice(11,19)+'] '+msg; logEl.append(d); logEl.scrollTop = logEl.scrollHeight; }
@@ -83,7 +84,21 @@
   function clearResults(){ list.innerHTML = ''; jsonPreview.textContent=''; jsonInfo.textContent=''; }
   function preview(obj){ try{ const s=JSON.stringify(obj, null, 2); jsonPreview.innerHTML='<pre>'+s+'</pre>'; }catch(e){ err('preview stringify failed: '+e.message); } }
 
-  const fallbackEntryForSlug = (slug) => `/games/${slug}/index.html`;
+  const fallbackPathForSlug = (slug) => `/games/${slug}/index.html`;
+
+  async function resolveTargetUrl(slug, candidate){
+    const cleanSlug = (slug || '').trim();
+    const preferred = candidate && typeof candidate === 'string' ? candidate.trim() : '';
+    const fallback = preferred || fallbackPathForSlug(cleanSlug || 'unknown');
+    if (!cleanSlug) return fallback;
+    try {
+      const { playPath } = await resolveGamePaths(cleanSlug);
+      if (playPath) return playPath;
+    } catch (e) {
+      warn('resolveTargetUrl: failed for '+cleanSlug+': '+(e && e.message || e));
+    }
+    return fallback;
+  }
 
   function normalizeToDescriptors(data){
     const out = [];
@@ -100,7 +115,7 @@
       const cleanSlug = coerceSlug(slug);
       if (!cleanSlug) return;
       const preferred = entry && typeof entry === 'string' ? entry.trim() : '';
-      out.push({ slug: cleanSlug, url: preferred || fallbackEntryForSlug(cleanSlug) });
+      out.push({ slug: cleanSlug, url: preferred || fallbackPathForSlug(cleanSlug) });
     };
 
     if (Array.isArray(data)){
@@ -162,10 +177,12 @@
       return;
     }
     for (const descriptor of descriptors){
-      const slug = descriptor && descriptor.slug ? descriptor.slug : '(unknown)';
-      const target = descriptor && descriptor.url ? descriptor.url : fallbackEntryForSlug(slug);
+      const cleanSlug = descriptor && descriptor.slug ? String(descriptor.slug).trim() : '';
+      const label = cleanSlug || '(unknown)';
+      const candidate = descriptor && descriptor.url ? descriptor.url : '';
+      const target = await resolveTargetUrl(cleanSlug, candidate);
       const out = await probe(target);
-      list.append(row(slug, target, out));
+      list.append(row(label, target, out));
     }
   }
 
@@ -212,7 +229,7 @@
         descriptors = normalizeToDescriptors(data);
       } else {
         const slugs = text.split(/\s|,|;|\n|\r/).map(s=>s.trim()).filter(Boolean);
-        descriptors = slugs.map(slug => ({ slug, url: fallbackEntryForSlug(slug) }));
+        descriptors = slugs.map(slug => ({ slug, url: fallbackPathForSlug(slug) }));
       }
       ok('Manual parse got '+descriptors.length+' slug(s)');
       await runForDescriptors(descriptors);

--- a/tools/missing-games-v2.html
+++ b/tools/missing-games-v2.html
@@ -31,7 +31,7 @@
 <body>
 <header>
   <h1>Missing Games Checker v2</h1>
-  <div class="small bar">Checks <code>games.json</code> vs. <code>/games/&lt;slug&gt;/index.html</code>. Now with multi-path lookup + paste fallback.</div>
+  <div class="small bar">Checks <code>games.json</code> vs. each game's resolved <code>playUrl</code> (fallback: <code>/games/&lt;slug&gt;/index.html</code>). Now with multi-path lookup + paste fallback.</div>
 </header>
 <main>
   <div class="legend small">
@@ -67,10 +67,25 @@
 
   <div id="list"></div>
 </main>
-<script>
+<script type="module">
+import { resolveGamePaths } from '../shared/game-paths.js';
 const list = document.getElementById('list');
 const jsonInfo = document.getElementById('json-info');
 const jsonPreview = document.getElementById('json-preview');
+
+const fallbackPathForSlug = (slug) => `/games/${slug}/index.html`;
+
+async function resolvePath(slug) {
+  const cleanSlug = (slug || '').trim();
+  if (!cleanSlug) return fallbackPathForSlug('unknown');
+  try {
+    const { playPath } = await resolveGamePaths(cleanSlug);
+    if (playPath) return playPath;
+  } catch (err) {
+    console.warn('[GG][missing-games-v2] Unable to resolve play path for slug', slug, err);
+  }
+  return fallbackPathForSlug(cleanSlug);
+}
 
 function clearResults(){ list.innerHTML = ''; }
 
@@ -129,9 +144,11 @@ async function runForSlugs(slugs){
     return;
   }
   for (const slug of slugs){
-    const path = \`../games/\${slug}/index.html\`;
+    const cleanSlug = (slug || '').trim();
+    const label = cleanSlug || '(unknown)';
+    const path = await resolvePath(cleanSlug);
     const out = await probe(path);
-    list.append(row(slug, path, out));
+    list.append(row(label, path, out));
   }
 }
 

--- a/tools/missing-games-v3.html
+++ b/tools/missing-games-v3.html
@@ -32,7 +32,7 @@
 <body>
 <header>
   <h1>Missing Games Checker v3</h1>
-  <div class="small bar">Checks <code>games.json</code> vs. <code>/games/&lt;slug&gt;/index.html</code> with explicit URL input + full error logs.</div>
+  <div class="small bar">Checks <code>games.json</code> vs. each game's resolved <code>playUrl</code> (fallback: <code>/games/&lt;slug&gt;/index.html</code>) with explicit URL input + full error logs.</div>
 </header>
 <main>
   <div class="legend small">
@@ -75,12 +75,27 @@
 
   <div id="list"></div>
 </main>
-<script>
+<script type="module">
+import { resolveGamePaths } from '../shared/game-paths.js';
 const list = document.getElementById('list');
 const jsonInfo = document.getElementById('json-info');
 const jsonPreview = document.getElementById('json-preview');
 const logs = document.getElementById('logs');
 const jsonUrl = document.getElementById('jsonUrl');
+
+const fallbackPathForSlug = (slug) => `/games/${slug}/index.html`;
+
+async function resolvePath(slug) {
+  const cleanSlug = (slug || '').trim();
+  if (!cleanSlug) return fallbackPathForSlug('unknown');
+  try {
+    const { playPath } = await resolveGamePaths(cleanSlug);
+    if (playPath) return playPath;
+  } catch (err) {
+    console.warn('[GG][missing-games-v3] Unable to resolve play path for slug', slug, err);
+  }
+  return fallbackPathForSlug(cleanSlug);
+}
 
 function log(msg){ const d = document.createElement('div'); d.className='logline'; d.textContent=msg; logs.append(d); }
 function clearResults(){ list.innerHTML = ''; }
@@ -133,9 +148,11 @@ async function runForSlugs(slugs){
     return;
   }
   for (const slug of slugs){
-    const path = \`../games/\${slug}/index.html\`;
+    const cleanSlug = (slug || '').trim();
+    const label = cleanSlug || '(unknown)';
+    const path = await resolvePath(cleanSlug);
     const out = await probe(path);
-    list.append(row(slug, path, out));
+    list.append(row(label, path, out));
   }
 }
 

--- a/tools/missing-games.html
+++ b/tools/missing-games.html
@@ -22,7 +22,7 @@
 <body>
 <header>
   <h1>Missing Games Checker</h1>
-  <div class="small bar">Checks <code>games.json</code> vs. the presence of <code>/games/&lt;slug&gt;/index.html</code>. Uses <code>HEAD</code> requests for speed.</div>
+  <div class="small bar">Checks <code>games.json</code> vs. the resolved <code>playUrl</code> (falls back to <code>/games/&lt;slug&gt;/index.html</code>). Uses <code>HEAD</code> requests for speed.</div>
 </header>
 <main>
   <div class="legend small">
@@ -32,8 +32,24 @@
   </div>
   <div id="list"></div>
 </main>
-<script>
+<script type="module">
+import { resolveGamePaths } from '../shared/game-paths.js';
+
 const list = document.getElementById('list');
+
+const fallbackPathForSlug = (slug) => `/games/${slug}/index.html`;
+
+async function resolvePath(slug) {
+  if (!slug) return fallbackPathForSlug('unknown');
+  try {
+    const { playPath } = await resolveGamePaths(slug);
+    if (playPath) return playPath;
+  } catch (err) {
+    console.warn('[GG][missing-games] Unable to resolve play path for slug', slug, err);
+  }
+  return fallbackPathForSlug(slug);
+}
+
 const probe = async (url) => {
   try {
     const res = await fetch(url, { method: 'HEAD', cache: 'no-store' });
@@ -48,12 +64,12 @@ const probe = async (url) => {
 const row = (slug, path, out) => {
   const div = document.createElement('div');
   div.className = 'row';
-  div.innerHTML = \`
-    <div class="slug">\${slug}</div>
-    <div class="small">\${path}</div>
-    <div class="status \${out.status}">\${out.status.toUpperCase()}</div>
-    <div class="small">\${out.code}</div>
-  \`;
+  div.innerHTML = `
+    <div class="slug">${slug}</div>
+    <div class="small">${path}</div>
+    <div class="status ${out.status}">${out.status.toUpperCase()}</div>
+    <div class="small">${out.code}</div>
+  `;
   return div;
 };
 
@@ -71,7 +87,7 @@ const row = (slug, path, out) => {
   }
   for (const g of games) {
     const slug = g.slug || g.id || g.name || 'unknown';
-    const path = \`../games/\${slug}/index.html\`;
+    const path = await resolvePath(slug);
     const out = await probe(path);
     list.append(row(slug, path, out));
   }


### PR DESCRIPTION
## Summary
- resolve iframe srcs and precache paths via `resolveGamePaths` so non-standard game locations are honored
- update missing-games helper tools to consult the catalog `playUrl`, falling back to the legacy `/games/<slug>/index.html` structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d42919bc9083278d2462785e6cba0b