### PR TITLE
Improve game error handling and diagnostics

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -422,28 +422,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -22,28 +22,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -25,28 +25,48 @@ canvas{background:#0f1320;border:1px solid rgba(255,255,255,.08);border-radius:1
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -41,28 +41,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -40,28 +40,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -61,28 +61,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -42,28 +42,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -19,28 +19,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -61,28 +61,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -49,28 +49,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body>

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -4,28 +4,48 @@
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
+  function postToParent(type, payload){
     try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
+      if (window.parent) window.parent.postMessage(Object.assign({ type: type }, payload || {}), "*");
+    } catch(_) { /* noop */ }
   }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+  function sendGameError(summary, reason, detail){
+    var headline = summary && reason ? summary + ': ' + reason : (summary || reason || 'Game error');
+    var message = String(headline).slice(0, 240);
+    var fullDetail = String(detail || reason || '').slice(0, 4000);
+    postToParent('GAME_ERROR', {
+      message: message,
+      userMessage: summary || message,
+      detail: fullDetail,
+      error: fullDetail
+    });
+  }
+  window.addEventListener('error', function(e){
+    var primary = e && e.message ? String(e.message) : String(e && e.error || e || 'Unknown error');
+    var parts = [primary];
+    if (e && e.filename){
+      var pos = [e.lineno, e.colno].filter(Boolean).join(':');
+      parts.push('Source: ' + e.filename + (pos ? ':' + pos : ''));
+    }
+    if (e && e.error && e.error.stack) parts.push(String(e.error.stack));
+    sendGameError('Script error', primary, parts.join('
+'));
   });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+  window.addEventListener('unhandledrejection', function(e){
+    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : 'Unknown rejection';
+    var stack = e && e.reason && e.reason.stack ? String(e.reason.stack) : '';
+    var detail = stack ? reason + '
+' + stack : reason;
+    sendGameError('Unhandled rejection', reason, detail);
   });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
   var signalled = false;
-  window.addEventListener("message", function(ev){
+  window.addEventListener('message', function(ev){
     if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    if (ev.data.type === 'GAME_READY' || ev.data.type === 'GAME_ERROR') signalled = true;
   });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  function emitReadyOnce(){ if (!signalled) { postToParent('GAME_READY'); signalled = true; } }
+  if (document.readyState === 'complete') { setTimeout(emitReadyOnce, 0); }
+  else { window.addEventListener('load', function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
 </body></html>


### PR DESCRIPTION
## Summary
- enhance the game shell error overlay with actionable next steps and better detection of frame/script failures
- add structured metadata to diag-upgrades so the shell can surface resource errors, hangs, and network issues
- update each game auto-signal snippet to send message/detail payloads instead of bare error strings

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d436952d1c83278fb54076badf6a1e