### PR TITLE
Publish games catalog to public assets

### DIFF
--- a/public/games.json
+++ b/public/games.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "pong",
+    "title": "Pong Classic",
+    "short": "A snappy canvas remake of the arcade legend.",
+    "tags": [
+      "classic",
+      "2D"
+    ],
+    "difficulty": "easy",
+    "released": "2025-08-20",
+    "playUrl": "/games/pong/"
+  },
+  {
+    "id": "snake",
+    "title": "Snake",
+    "short": "Eat, grow, don't bonk into yourself.",
+    "tags": [
+      "classic",
+      "2D"
+    ],
+    "difficulty": "easy",
+    "released": "2025-08-25",
+    "playUrl": "/games/snake/"
+  },
+  {
+    "id": "tetris",
+    "title": "Tetris",
+    "short": "Classic falling blocks. Clear lines, level up.",
+    "tags": [
+      "classic",
+      "2D"
+    ],
+    "difficulty": "medium",
+    "released": "2025-08-26",
+    "playUrl": "/games/tetris/"
+  },
+  {
+    "id": "breakout",
+    "title": "Breakout",
+    "short": "Smash bricks, power-ups, chase the score.",
+    "tags": [
+      "classic",
+      "2D"
+    ],
+    "difficulty": "medium",
+    "released": "2025-08-26",
+    "playUrl": "/games/breakout/"
+  },
+  {
+    "id": "chess",
+    "title": "Chess (2D)",
+    "short": "Traditional chess for two players.",
+    "tags": [
+      "classic",
+      "board"
+    ],
+    "difficulty": "hard",
+    "released": "2025-08-20",
+    "playUrl": "/games/chess/"
+  },
+  {
+    "id": "chess3d",
+    "title": "Chess 3D (Local)",
+    "short": "A three-dimensional chess experiment.",
+    "tags": [
+      "3D",
+      "offline"
+    ],
+    "difficulty": "hard",
+    "released": "2025-08-27",
+    "playUrl": "/games/chess3d/"
+  },
+  {
+    "id": "g2048",
+    "title": "2048",
+    "short": "Slide numbers to reach 2048.",
+    "tags": [
+      "puzzle",
+      "2D"
+    ],
+    "difficulty": "medium",
+    "released": "2025-08-20",
+    "playUrl": "/games/2048/"
+  },
+  {
+    "id": "asteroids",
+    "title": "Asteroids",
+    "short": "Pilot your ship and blast space rocks.",
+    "tags": [
+      "classic",
+      "2D"
+    ],
+    "difficulty": "hard",
+    "released": "2025-08-27",
+    "playUrl": "/games/asteroids/"
+  },
+  {
+    "id": "maze3d",
+    "title": "Maze 3D",
+    "short": "Wander a first-person labyrinth to find the exit.",
+    "tags": [
+      "3D"
+    ],
+    "difficulty": "medium",
+    "released": "2025-08-27",
+    "playUrl": "/games/maze3d/"
+  },
+  {
+    "id": "platformer",
+    "title": "Pixel Platformer",
+    "short": "Run and jump across platforms to reach the goal.",
+    "tags": [
+      "2D"
+    ],
+    "difficulty": "medium",
+    "released": "2025-08-27",
+    "playUrl": "/games/platformer/"
+  },
+  {
+    "id": "runner",
+    "title": "City Runner",
+    "short": "Dash through the city and avoid obstacles.",
+    "tags": [
+      "2D"
+    ],
+    "difficulty": "medium",
+    "released": "2025-08-27",
+    "playUrl": "/games/runner/"
+  },
+  {
+    "id": "shooter",
+    "title": "Alien Shooter",
+    "short": "Blast waves of invaders and survive.",
+    "tags": [
+      "2D"
+    ],
+    "difficulty": "hard",
+    "released": "2025-08-27",
+    "playUrl": "/games/shooter/"
+  }
+]

--- a/tools/sync-game-catalog.mjs
+++ b/tools/sync-game-catalog.mjs
@@ -7,6 +7,7 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const gamesPath = path.join(rootDir, 'games.json');
 const offlinePath = path.join(rootDir, 'data', 'games-offline.js');
 const normalizedPath = path.join(rootDir, 'data', 'games-normalized.json');
+const publicGamesPath = path.join(rootDir, 'public', 'games.json');
 
 async function readGames() {
   const source = await readFile(gamesPath, 'utf8');
@@ -30,6 +31,7 @@ async function main() {
 
   await writeFile(offlinePath, buildOfflineModule(games));
   await writeFile(normalizedPath, JSON.stringify({ games: normalizedList }, null, 2) + '\n');
+  await writeFile(publicGamesPath, JSON.stringify(games, null, 2) + '\n');
 
   console.log('Game catalog artifacts updated.');
 }


### PR DESCRIPTION
## Summary
- update the catalog sync tool to also write games.json into the public directory
- generate public/games.json so bundlers can serve the catalog from /

## Testing
- node tools/sync-game-catalog.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d43d149b888327b03ed0a05d1740e0