### PR TITLE
Fix script paths for subdirectory hosting

### DIFF
--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -32,8 +32,8 @@
       if(el && !window.__Chess3DBooted){ el.textContent = 'Initializing renderer… if this persists, check network or open console (F12) for errors.'; }
     }, 1800);
   </script>
-  <script src="/js/sfx.js"></script>
-  <script src="/js/hud.js"></script>
+  <script src="../../js/sfx.js"></script>
+  <script src="../../js/hud.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess3d"></script>
 
 <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/gameshells/IMPORTMAP_SNIPPET.html
+++ b/gameshells/IMPORTMAP_SNIPPET.html
@@ -1,7 +1,7 @@
 <script type="importmap">
 {
   "imports": {
-    "console-signature": "/js/vendor/console-signature.mjs",
+    "console-signature": "../js/vendor/console-signature.mjs",
     "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
   }
 }

--- a/gameshells/asteroids/index.html
+++ b/gameshells/asteroids/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/asteroids/main.js"></script>
+    <script type="module" src="../../games/asteroids/main.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/breakout/index.html
+++ b/gameshells/breakout/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -15,13 +15,13 @@
   </head>
   <body>
     <canvas id="b" width="1000" height="800" aria-label="Breakout canvas"></canvas>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script src="/js/resizeCanvas.global.js"></script>
-    <script src="/js/gameUtil.js"></script>
-    <script src="/js/sfx.js"></script>
-    <script src="/shared/leaderboard.js"></script>
-    <script type="module" src="/games/breakout/breakout.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script src="../../js/resizeCanvas.global.js"></script>
+    <script src="../../js/gameUtil.js"></script>
+    <script src="../../js/sfx.js"></script>
+    <script src="../../shared/leaderboard.js"></script>
+    <script type="module" src="../../games/breakout/breakout.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/chess/index.html
+++ b/gameshells/chess/index.html
@@ -8,7 +8,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -58,11 +58,11 @@
         </section>
       </aside>
     </main>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("board");
         ensureCanvas("fx");
@@ -75,14 +75,14 @@
         ensureElement("#find-match");
       });
     </script>
-    <script src="/games/chess/ai.js?v=5.3"></script>
-    <script src="/games/chess/puzzles.js?v=5.3"></script>
-    <script src="/games/chess/ratings.js?v=5.3"></script>
-    <script src="/games/chess/net.js?v=5.3"></script>
-    <script type="module" src="/games/chess/chess.js?v=5.3"></script>
-    <script src="/js/input.js?v=5.3"></script>
-    <script src="/js/remapUI.js?v=5.3"></script>
-    <script src="/js/perfHud.js?v=5.3"></script>
+    <script src="../../games/chess/ai.js?v=5.3"></script>
+    <script src="../../games/chess/puzzles.js?v=5.3"></script>
+    <script src="../../games/chess/ratings.js?v=5.3"></script>
+    <script src="../../games/chess/net.js?v=5.3"></script>
+    <script type="module" src="../../games/chess/chess.js?v=5.3"></script>
+    <script src="../../js/input.js?v=5.3"></script>
+    <script src="../../js/remapUI.js?v=5.3"></script>
+    <script src="../../js/perfHud.js?v=5.3"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/chess3d/index.html
+++ b/gameshells/chess3d/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/chess3d/main.js"></script>
+    <script type="module" src="../../games/chess3d/main.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/g2048/index.html
+++ b/gameshells/g2048/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/2048/2048.js"></script>
+    <script type="module" src="../../games/2048/2048.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/maze3d/index.html
+++ b/gameshells/maze3d/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/maze3d/main.js"></script>
+    <script type="module" src="../../games/maze3d/main.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/platformer/index.html
+++ b/gameshells/platformer/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/platformer/main.js"></script>
+    <script type="module" src="../../games/platformer/main.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/pong/index.html
+++ b/gameshells/pong/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/pong/main.js"></script>
+    <script type="module" src="../../games/pong/main.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/runner/index.html
+++ b/gameshells/runner/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/runner/main.js"></script>
+    <script type="module" src="../../games/runner/main.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/shooter/index.html
+++ b/gameshells/shooter/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/shooter/main.js"></script>
+    <script type="module" src="../../games/shooter/main.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/snake/index.html
+++ b/gameshells/snake/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -19,17 +19,17 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/snake/snake.js"></script>
+    <script type="module" src="../../games/snake/snake.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/gameshells/tetris/index.html
+++ b/gameshells/tetris/index.html
@@ -7,7 +7,7 @@
     <script type="importmap">
     {
       "imports": {
-        "console-signature": "/js/vendor/console-signature.js",
+        "console-signature": "../../js/vendor/console-signature.js",
         "three": "https://unpkg.com/three@0.161.0/build/three.module.js"
       }
     }
@@ -26,16 +26,16 @@
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
-    <script src="/js/preflight.js"></script>
-    <script src="/js/resizeCanvas.global.js"></script>
-    <script src="/js/gameUtil.js"></script>
-    <script src="/js/sfx.js"></script>
-    <script src="/games/tetris/engine.js"></script>
-    <script src="/games/tetris/replay.js"></script>
-    <script type="module" src="/js/three-global-shim.js"></script>
+    <script src="../../js/bootstrap/gg.js"></script>
+    <script src="../../js/preflight.js"></script>
+    <script src="../../js/resizeCanvas.global.js"></script>
+    <script src="../../js/gameUtil.js"></script>
+    <script src="../../js/sfx.js"></script>
+    <script src="../../games/tetris/engine.js"></script>
+    <script src="../../games/tetris/replay.js"></script>
+    <script type="module" src="../../js/three-global-shim.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         const { canvas } = ensureCanvas("t");
         const extraCanvas = document.getElementById("gameCanvas");
@@ -43,7 +43,7 @@
         ensureElement("#score");
       });
     </script>
-    <script type="module" src="/games/tetris/tetris.js"></script>
+    <script type="module" src="../../games/tetris/tetris.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->
 <script>

--- a/health/entry-suggest.html
+++ b/health/entry-suggest.html
@@ -27,6 +27,6 @@
   <main>
     <div id="out"></div>
   </main>
-  <script src="/js/entry-suggest.js"></script>
+  <script src="../js/entry-suggest.js"></script>
 </body>
 </html>

--- a/health/index.html
+++ b/health/index.html
@@ -69,6 +69,6 @@
     <footer>
       Built for fast triage. Place this folder at <code>/health</code> and open <code>/health/</code>.
     </footer>
-    <script src="/js/health-scan.js"></script>
+    <script src="../js/health-scan.js"></script>
   </body>
 </html>

--- a/play.html
+++ b/play.html
@@ -18,10 +18,10 @@
   <div id="game-root" aria-live="polite" style="display:block;min-height:100vh"></div>
 
   <!-- Shim first (creates #game / <canvas> and a tiny window.GG if missing) -->
-  <script src="/js/compat-shim.js"></script>
+  <script src="js/compat-shim.js"></script>
 
   <!-- Universal loader (reads games.json and boots ?id=<slug>) -->
-  <script src="/js/game-loader.js"></script>
-  <script src="/shared/force-unpause.js"></script>
+  <script src="js/game-loader.js"></script>
+  <script src="shared/force-unpause.js"></script>
 </body>
 </html>

--- a/templates/game.html
+++ b/templates/game.html
@@ -12,9 +12,9 @@
       <div id="score" aria-live="polite"></div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
     </div>
-    <script src="/js/bootstrap/gg.js"></script>
+    <script src="../js/bootstrap/gg.js"></script>
     <script type="module">
-      import { ensureCanvas, ensureElement } from "/js/bootstrap/dom.js";
+      import { ensureCanvas, ensureElement } from "../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
         ensureCanvas("game-canvas");
         ensureElement("#score");


### PR DESCRIPTION
## Summary
- convert game shell import maps and script tags to relative paths so games load when hosted from a subdirectory
- update direct game pages, shared templates, and health tools to use the same relative paths

## Testing
- npm run health

------
https://chatgpt.com/codex/tasks/task_e_68d43d213a408327bdabb9bf0e0a0220