### PR TITLE
Guard Pong particle rendering when helper missing

### DIFF
--- a/games/pong/pong.js
+++ b/games/pong/pong.js
@@ -395,7 +395,9 @@
     // balls
     for(const b of state.balls){ circle(b.x,b.y,b.r, getCSS("--pong-fg")); }
 
-    drawParticles();
+    if(typeof drawParticles === "function"){
+      drawParticles();
+    }
     endShake();
     ctx.restore();
 


### PR DESCRIPTION
## Summary
- add a defensive check before invoking `drawParticles` in the Pong renderer so missing particle helpers do not crash the game

## Testing
- npx vitest run tests/pong.match.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d43d2ad0fc8327bb5d36f3abed232b