### PR TITLE
Add drawParticles fallback for Pong

### DIFF
--- a/games/pong/pong.js
+++ b/games/pong/pong.js
@@ -1,4 +1,6 @@
 
+window.drawParticles = window.drawParticles || function(){ /* no-op fallback */ };
+
 (function(){
   "use strict";
 


### PR DESCRIPTION
## Summary
- add a no-op fallback for window.drawParticles in the Pong shell to avoid runtime reference errors before GAME_READY can be posted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d462a9feb08327bcfe86025a5f3da4