### PR TITLE
Guard missing helpers in canvas games

### DIFF
--- a/games/breakout/breakout.js
+++ b/games/breakout/breakout.js
@@ -5,6 +5,8 @@ import { installErrorReporter } from '../../shared/debug/error-reporter.js';
 import { showToast, showModal, clearHud } from '../../shared/ui/hud.js';
 import { createParticleSystem } from '../../shared/fx/canvasFx.js';
 
+window.fitCanvasToParent = window.fitCanvasToParent || function(){ /* no-op fallback */ };
+
 const GAME_ID='breakout';GG.incPlays();
 const BASE_W=1000;
 const BASE_H=800;

--- a/games/snake/snake.js
+++ b/games/snake/snake.js
@@ -3,6 +3,8 @@ import { createParticleSystem } from '../../shared/fx/canvasFx.js';
 import getThemeTokens from '../../shared/skins/index.js';
 import '../../shared/ui/hud.js';
 
+window.fitCanvasToParent = window.fitCanvasToParent || function(){ /* no-op fallback */ };
+
 const hud = document.querySelector('.hud');
 hud.innerHTML = `Arrows/WASD or swipe • R restart • P pause
   <label><input type="checkbox" id="dailyToggle"/> Daily</label>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -2,6 +2,8 @@ import '../../shared/fx/canvasFx.js';
 import '../../shared/skins/index.js';
 import { installErrorReporter } from '../../shared/debug/error-reporter.js';
 
+window.fitCanvasToParent = window.fitCanvasToParent || function(){ /* no-op fallback */ };
+
 installErrorReporter();
 
 const GAME_ID='tetris';GG.incPlays();


### PR DESCRIPTION
## Summary
- add a defensive no-op for window.fitCanvasToParent in Breakout, Snake, and Tetris so missing helpers no longer crash

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4658d28108327ae49901c8c7afe7d