### PR TITLE
feat: introduce shared game shell and align embeds

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>2048</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
   <link rel="stylesheet" href="../../css/styles.css?v=5.3">
   <style>
     /* Reset and base styles */
@@ -415,8 +416,8 @@
   <script src="../../js/input.js?v=5.3"></script>
   <script src="../../js/remapUI.js?v=5.3"></script>
   <script src="../../js/perfHud.js?v=5.3"></script>
-  <script src="../common/diag-upgrades.js" defer data-slug="g2048"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="2048"></script>
+  <script type="module" src="../common/game-shell.js" data-game="g2048" data-apply-theme="false" data-focus-target="#board"></script>
 
 <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
 <script>

--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -4,47 +4,63 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Asteroids Pro</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
-    :root{ --fg:#eaeaf2; --bg:#0b0b0f; --muted:#9aa0a6; --accent:#6ee7b7; }
-    html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;overflow:hidden}
-    canvas{width:100%;height:100%;display:block;background:radial-gradient(50% 50% at 50% 50%, rgba(110,231,183,0.06), transparent 60%)}
+    :root {
+      --fg: #eaeaf2;
+      --bg: #05070f;
+      --muted: #9aa0a6;
+      --accent: #6ee7b7;
+    }
+
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+      background: radial-gradient(50% 50% at 50% 50%, rgba(110, 231, 183, 0.08), transparent 70%);
+    }
   </style>
 </head>
-<body>
-  <canvas id="game"></canvas>
+<body class="game-shell">
+  <main class="game-shell__main">
+    <div class="game-shell__surface">
+      <canvas id="game" class="game-shell__canvas"></canvas>
+    </div>
+  </main>
+
   <script src="../../js/hud.js"></script>
   <script type="module" src="./main.js"></script>
-  <script src="../common/diag-upgrades.js" defer data-slug="asteroids"></script>
   <script type="module" src="../../shared/game-boot.js" data-slug="asteroids"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="asteroids"></script>
+  <script type="module" src="../common/game-shell.js" data-game="asteroids"></script>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
 </body>
 </html>

--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -1,53 +1,61 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Breakout</title>
-<style>
-html,body{height:100%;margin:0;background:#0b0d12;color:#e6e7ea;font-family:Inter,system-ui,sans-serif}
-.wrap{display:grid;place-items:center;height:100%}
-canvas{background:#0f1320;border:1px solid rgba(255,255,255,.08);border-radius:16px;box-shadow:0 20px 40px rgba(0,0,0,.4)}
-</style>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Breakout</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
+  <style>
+    canvas {
+      background: #0f1320;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+    }
+  </style>
 </head>
-<body>
-<div class="wrap"><canvas id="b" width="800" height="600" data-basew="800" data-baseh="600"></canvas></div>
-<script src="../../js/injectBackButton.js"></script>
-<script src="../../js/resizeCanvas.global.js"></script>
-<script src="../../js/gameUtil.js"></script>
-<script src="../../js/sfx.js"></script>
-<script src="../../shared/leaderboard.js"></script>
-<script type="module" src="./breakout.js"></script>
-<script src="../common/diag-upgrades.js" defer data-slug="breakout"></script>
-  <script type="module" src="../../shared/juice/overlay.js" data-game="breakout"></script>
+<body class="game-shell">
+  <main class="game-shell__main">
+    <div class="game-shell__surface">
+      <canvas id="b" width="800" height="600" data-basew="800" data-baseh="600"></canvas>
+    </div>
+  </main>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
+  <script src="../../js/resizeCanvas.global.js"></script>
+  <script src="../../js/gameUtil.js"></script>
+  <script src="../../js/sfx.js"></script>
+  <script src="../../shared/leaderboard.js"></script>
+  <script type="module" src="./breakout.js"></script>
+  <script type="module" src="../../shared/juice/overlay.js" data-game="breakout"></script>
+  <script type="module" src="../common/game-shell.js" data-game="breakout"></script>
+
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
 </body>
 </html>

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -1,69 +1,118 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Chess</title>
-<link rel="stylesheet" href="../../css/styles.css?v=5.3">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Chess</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
+  <link rel="stylesheet" href="../../css/styles.css?v=5.3" />
+  <style>
+    body {
+      margin: 0;
+      background: #0b1220;
+      color: #e6e7ea;
+    }
+    .chess-shell {
+      display: flex;
+      gap: 16px;
+      justify-content: center;
+      align-items: flex-start;
+      padding: 16px 16px 80px;
+      flex-wrap: wrap;
+    }
+    .chess-board {
+      position: relative;
+    }
+    .chess-board canvas {
+      border: 1px solid #243047;
+      border-radius: 12px;
+      background: #0f172a;
+    }
+    .chess-info {
+      max-width: 260px;
+    }
+    .chess-info h3 {
+      margin: 0 0 8px 0;
+    }
+    .chess-info label {
+      display: block;
+      margin: 8px 0;
+    }
+  </style>
 </head>
-<body style="margin:0;background:#0b1220;color:#e6e7ea;">
-<div style="display:flex;gap:16px;justify-content:center;align-items:flex-start;padding:16px 16px 80px;">
-  <div style="position:relative;">
-    <canvas id="board" width="480" height="480" style="border:1px solid #243047;border-radius:12px;background:#0f172a;"></canvas>
-    <canvas id="fx" width="480" height="480" style="position:absolute;left:0;top:0;pointer-events:none;"></canvas>
-  </div>
-  <div style="max-width:260px;">
-    <h3 style="margin:0 0 8px 0;">Chess</h3>
-    <p>Click a piece, then a target square. <br/>Press <b>R</b> to restart. <br/>Press <b>F1</b> for control remap.</p>
-    <label>Difficulty: <select id="difficulty"><option value="1">Easy</option><option value="2" selected>Medium</option><option value="3">Hard</option><option value="4">Expert</option></select></label>
-    <br/>
-    <label>Puzzles: <select id="puzzle-select"><option value="-1">Free Play</option></select></label>
-    <div id="status"></div>
-    <div id="lobby" style="margin-top:16px;">
-      <button id="find-match">Find Match</button>
-      <div id="lobby-status"></div>
-      <ol id="rankings"></ol>
+<body class="game-shell">
+  <main class="game-shell__main">
+    <div class="game-shell__surface game-shell__surface--plain">
+      <div class="chess-shell">
+        <div class="chess-board">
+          <canvas id="board" width="480" height="480" aria-label="Chess board"></canvas>
+          <canvas id="fx" width="480" height="480" aria-hidden="true"></canvas>
+        </div>
+        <aside class="chess-info">
+          <h3>Chess</h3>
+          <p>Click a piece, then a target square. <br />Press <b>R</b> to restart. <br />Press <b>F1</b> for control remap.</p>
+          <label>Difficulty:
+            <select id="difficulty">
+              <option value="1">Easy</option>
+              <option value="2" selected>Medium</option>
+              <option value="3">Hard</option>
+              <option value="4">Expert</option>
+            </select>
+          </label>
+          <label>Puzzles:
+            <select id="puzzle-select">
+              <option value="-1">Free Play</option>
+            </select>
+          </label>
+          <div id="status"></div>
+          <div id="lobby" style="margin-top:16px;">
+            <button id="find-match">Find Match</button>
+            <div id="lobby-status"></div>
+            <ol id="rankings"></ol>
+          </div>
+        </aside>
+      </div>
     </div>
-  </div>
-</div>
-<script src="ai.js?v=5.3"></script>
-<script src="puzzles.js?v=5.3"></script>
-<script src="ratings.js?v=5.3"></script>
-<script src="net.js?v=5.3"></script>
-<script type="module" src="chess.js?v=5.3"></script>
-<script src="../../js/input.js?v=5.3"></script>
-<script src="../../js/remapUI.js?v=5.3"></script>
-<script src="../../js/perfHud.js?v=5.3"></script>
-<script src="../common/diag-upgrades.js" defer data-slug="chess"></script>
-  <script type="module" src="../../shared/juice/overlay.js" data-game="chess"></script>
+  </main>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
+  <script src="ai.js?v=5.3"></script>
+  <script src="puzzles.js?v=5.3"></script>
+  <script src="ratings.js?v=5.3"></script>
+  <script src="net.js?v=5.3"></script>
+  <script type="module" src="chess.js?v=5.3"></script>
+  <script src="../../js/input.js?v=5.3"></script>
+  <script src="../../js/remapUI.js?v=5.3"></script>
+  <script src="../../js/perfHud.js?v=5.3"></script>
+  <script type="module" src="../../shared/juice/overlay.js" data-game="chess"></script>
+  <script type="module" src="../common/game-shell.js" data-game="chess" data-apply-theme="false"></script>
+
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
 </body>
 </html>

--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -4,65 +4,91 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Chess 3D</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
   <link rel="stylesheet" href="/css/styles.css" />
   <style>
-    #stage{width:100%;height:70vh;}
-    #stage canvas{display:block}
+    body {
+      margin: 0;
+      background: #060b16;
+      color: #e6e7ea;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    }
+    #stage {
+      width: 100%;
+      height: 70vh;
+    }
+    #stage canvas {
+      display: block;
+    }
+    .chess3d-panel {
+      display: grid;
+      gap: 12px;
+      padding-bottom: 48px;
+    }
   </style>
 </head>
-<body>
-  <div id="stage"></div>
-  <div id="hud"></div>
-  <div id="coords" hidden></div>
-  <div id="thinking" hidden>Engine thinking…</div>
-  <div>
-    <label for="difficulty">Difficulty:</label>
-    <select id="difficulty">
-      <option value="1">Easy</option>
-      <option value="2" selected>Medium</option>
-      <option value="3">Hard</option>
-    </select>
-  </div>
-  <div id="status"></div>
+<body class="game-shell">
+  <main class="game-shell__main">
+    <div class="game-shell__surface game-shell__surface--plain">
+      <div class="chess3d-panel">
+        <div id="stage" aria-label="3D chess board"></div>
+        <div id="hud"></div>
+        <div id="coords" hidden></div>
+        <div id="thinking" hidden>Engine thinking…</div>
+        <div>
+          <label for="difficulty">Difficulty:</label>
+          <select id="difficulty">
+            <option value="1">Easy</option>
+            <option value="2" selected>Medium</option>
+            <option value="3">Hard</option>
+          </select>
+        </div>
+        <div id="status"></div>
+      </div>
+    </div>
+  </main>
+
   <script type="module" src="./main.js"></script>
-  <script src="../common/diag-upgrades.js" defer data-slug="chess3d"></script>
   <script>
-    setTimeout(()=>{
-      const el=document.getElementById('status');
-      if(el && !window.__Chess3DBooted){ el.textContent = 'Initializing renderer… if this persists, check network or open console (F12) for errors.'; }
+    setTimeout(() => {
+      const el = document.getElementById('status');
+      if (el && !window.__Chess3DBooted) {
+        el.textContent = 'Initializing renderer… if this persists, check network or open console (F12) for errors.';
+      }
     }, 1800);
   </script>
   <script src="../../js/sfx.js"></script>
   <script src="../../js/hud.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess3d"></script>
+  <script type="module" src="../common/game-shell.js" data-game="chess3d" data-apply-theme="false"></script>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
 </body>
 </html>

--- a/games/common/game-shell.css
+++ b/games/common/game-shell.css
@@ -1,0 +1,112 @@
+:root {
+  color-scheme: dark;
+}
+
+body.game-shell {
+  margin: 0;
+  min-height: 100svh;
+  background: #0b0d12;
+  color: #e6e7ea;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  display: flex;
+  flex-direction: column;
+}
+
+body.game-shell::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(236, 72, 153, 0.12), transparent 55%);
+  opacity: 0.55;
+  mix-blend-mode: screen;
+  z-index: 0;
+}
+
+.game-shell__main {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  padding: clamp(16px, 4vw, 64px);
+  position: relative;
+  z-index: 1;
+  min-height: 0;
+}
+
+.game-shell__surface {
+  display: grid;
+  place-items: center;
+  gap: 24px;
+  width: min(100%, 960px);
+}
+
+.game-shell__surface > canvas,
+.game-shell__surface > .game-shell__canvas,
+.game-shell__surface > .game-shell__frame {
+  display: block;
+  max-width: min(100%, 960px);
+  max-height: calc(100svh - 160px);
+  background: #0f1320;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+}
+
+.game-shell__surface > canvas {
+  height: auto;
+}
+
+.game-shell__surface--plain {
+  place-items: stretch;
+  justify-items: stretch;
+  text-align: left;
+}
+
+.game-shell__surface--plain > * {
+  max-width: none;
+  background: none;
+  border: 0;
+  box-shadow: none;
+  border-radius: 0;
+}
+
+.game-shell__back {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 10;
+  filter: drop-shadow(0 12px 24px rgba(0, 0, 0, 0.4));
+}
+
+.game-shell__back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  font-weight: 700;
+  text-decoration: none;
+  background: linear-gradient(135deg, #22d3ee, #8b5cf6);
+  color: #020617;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.game-shell__back-link:focus-visible,
+.game-shell__back-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(34, 211, 238, 0.35);
+}
+
+.game-shell__diagnostics-anchor {
+  display: contents;
+}
+
+@media (max-width: 600px) {
+  .game-shell__surface > canvas,
+  .game-shell__surface > .game-shell__canvas,
+  .game-shell__surface > .game-shell__frame {
+    max-height: calc(100svh - 120px);
+  }
+}

--- a/games/common/game-shell.js
+++ b/games/common/game-shell.js
@@ -1,0 +1,58 @@
+const current = document.currentScript;
+const dataset = current ? current.dataset : {};
+const applyTheme = dataset.applyTheme !== 'false';
+const slug = dataset.game || dataset.slug || '';
+const diagSrc = dataset.diagSrc || '../common/diag-upgrades.js';
+
+if (applyTheme) {
+  document.body.classList.add('game-shell');
+}
+
+document.body.dataset.gameSlug = slug;
+
+if (!document.querySelector('.game-shell__back')) {
+  const backHost = document.createElement('div');
+  backHost.className = 'game-shell__back';
+  const anchor = document.createElement('a');
+  anchor.className = 'game-shell__back-link';
+  const baseParts = window.location.pathname.split('/games/');
+  const base = (baseParts[0] || '/').replace(/\/+$/, '/');
+  const target = dataset.backHref || `${base}index.html`;
+  anchor.href = target;
+  anchor.setAttribute('data-shell-back-link', '');
+  anchor.setAttribute('aria-label', 'Back to games hub');
+  anchor.innerHTML = '<span aria-hidden="true">⟵</span><span>Back</span>';
+  backHost.append(anchor);
+  document.body.append(backHost);
+}
+
+if (slug && !document.querySelector(`script[data-slug="${slug}"][data-shell-diag]`)) {
+  const attach = () => {
+    const diag = document.createElement('script');
+    diag.src = diagSrc;
+    diag.defer = true;
+    diag.dataset.slug = slug;
+    diag.dataset.shellDiag = 'true';
+    diag.className = 'game-shell__diagnostics-anchor';
+    document.head.append(diag);
+  };
+  if (document.readyState === 'complete') {
+    setTimeout(attach, 0);
+  } else {
+    window.addEventListener('load', attach, { once: true });
+  }
+}
+
+if (dataset.focusTarget) {
+  const tryFocus = () => {
+    const el = document.querySelector(dataset.focusTarget);
+    if (el && typeof el.focus === 'function') {
+      el.focus({ preventScroll: true });
+    }
+  };
+  if (document.readyState === 'complete') {
+    setTimeout(tryFocus, 0);
+  } else {
+    window.addEventListener('load', tryFocus, { once: true });
+  }
+}

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -4,21 +4,65 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3D Maze</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
-    html, body { margin:0; height:100%; overflow:hidden; background:#0e0f12; }
-    canvas { display:block; }
-    #hud { position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; color:#e6e6e6; font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; font-size:14px; }
-    a.back { position:fixed; left:12px; bottom:12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none; }
-    #overlay { position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,0.4); font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
-    #overlay.hidden { display:none; }
-    #overlay .panel { background:#111522; border:1px solid #27314b; padding:18px 22px; border-radius:16px; text-align:center; color:#e6e6e6; }
-    #overlay .btn { margin:4px; padding:8px 12px; border:1px solid #27314b; background:#0e1422; color:#cfe6ff; border-radius:10px; cursor:pointer; font-weight:700; }
+    body {
+      margin: 0;
+      height: 100%;
+      overflow: hidden;
+      background: #0e0f12;
+      color: #e6e6e6;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+    }
+    canvas {
+      display: block;
+    }
+    #hud {
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      background: #1b1e24c0;
+      border: 1px solid #27314b;
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 14px;
+      z-index: 5;
+    }
+    #overlay {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.4);
+      z-index: 6;
+    }
+    #overlay.hidden {
+      display: none;
+    }
+    #overlay .panel {
+      background: #111522;
+      border: 1px solid #27314b;
+      padding: 18px 22px;
+      border-radius: 16px;
+      text-align: center;
+      color: #e6e6e6;
+    }
+    #overlay .btn {
+      margin: 4px;
+      padding: 8px 12px;
+      border: 1px solid #27314b;
+      background: #0e1422;
+      color: #cfe6ff;
+      border-radius: 10px;
+      cursor: pointer;
+      font-weight: 700;
+    }
   </style>
 </head>
-<body>
+<body class="game-shell">
   <div id="hud">Time: <span id="time">0.00</span> • Opp: <span id="oppTime">--</span> • Best: <span id="best">--</span></div>
-  <a class="back" href="../../">← Back to Hub</a>
-  <div id="overlay" class="">
+  <div id="overlay">
     <div class="panel">
       <div id="message">Click Start to play.<br/>WASD to move • Mouse to look<br/>P to pause • R to restart<br/>Esc to release pointer lock.</div>
       <div style="margin-top:10px">
@@ -51,39 +95,40 @@
       </div>
     </div>
   </div>
+
   <script src="https://unpkg.com/three@0.161.0/build/three.min.js"></script>
   <script src="https://unpkg.com/three@0.161.0/examples/js/controls/PointerLockControls.js"></script>
   <script type="module" src="./main.js"></script>
-  <script src="../common/diag-upgrades.js" defer data-slug="maze3d"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="maze3d"></script>
+  <script type="module" src="../common/game-shell.js" data-game="maze3d" data-apply-theme="false"></script>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
 </body>
 </html>

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -4,67 +4,125 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Retro Platformer</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
-    html, body{height:100%; margin:0; background:#0e0f12; color:#e6e6e6; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;}
-    .wrap{display:grid; place-items:center; height:100%; padding:16px}
-    canvas{background:#0a0d13; border:1px solid #1f2431; border-radius:12px; box-shadow:0 6px 22px rgba(0,0,0,.35)}
-    .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
-    .back{position: fixed; left: 12px; bottom: 12px; color:#cfe6ff; background:#0e1422; border:1px solid #27314b; padding:8px 10px; border-radius:10px; font-weight:700; text-decoration:none}
-    kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
-    .overlay{position:fixed; inset:0; display:none; place-items:center; background:rgba(0,0,0,.35); font-weight:800; letter-spacing:.4px; text-align:center;}
-    .overlay.show{display:grid}
-    .panel{background:#111522; border:1px solid #27314b; padding:18px 22px; border-radius:16px; box-shadow:0 10px 40px rgba(0,0,0,.5)}
-    .panel h2{margin:0 0 6px 0}
-    .btn{display:inline-block; padding:8px 12px; border:1px solid #27314b; background:#0e1422; color:#cfe6ff; border-radius:10px; text-decoration:none; cursor:pointer; font-weight:700}
+    body {
+      background: #0e0f12;
+      color: #e6e6e6;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+    }
+    .wrap {
+      display: grid;
+      place-items: center;
+      padding: 16px;
+    }
+    canvas {
+      background: #0a0d13;
+      border: 1px solid #1f2431;
+      border-radius: 12px;
+      box-shadow: 0 6px 22px rgba(0, 0, 0, .35);
+    }
+    .hud {
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      background: #1b1e24c0;
+      border: 1px solid #27314b;
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 14px;
+    }
+    #netHud {
+      left: auto;
+      right: 12px;
+    }
+    .btn {
+      display: inline-block;
+      padding: 8px 12px;
+      border: 1px solid #27314b;
+      background: #0e1422;
+      color: #cfe6ff;
+      border-radius: 10px;
+      text-decoration: none;
+      cursor: pointer;
+      font-weight: 700;
+    }
+    .overlay {
+      position: fixed;
+      inset: 0;
+      display: none;
+      place-items: center;
+      background: rgba(0, 0, 0, .35);
+      font-weight: 800;
+      letter-spacing: .4px;
+      text-align: center;
+    }
+    .overlay.show {
+      display: grid;
+    }
+    .panel {
+      background: #111522;
+      border: 1px solid #27314b;
+      padding: 18px 22px;
+      border-radius: 16px;
+      box-shadow: 0 10px 40px rgba(0, 0, 0, .5);
+    }
+    .panel h2 {
+      margin: 0 0 6px 0;
+    }
   </style>
 </head>
-<body>
+<body class="game-shell">
   <div class="hud">Move: <kbd>←</kbd>/<kbd>→</kbd> • Jump: <kbd>Space</kbd> or <kbd>↑</kbd> • Pause: <kbd>P</kbd> • Restart: <kbd>R</kbd></div>
-  <div class="hud" id="netHud" style="left:auto; right:12px; top:12px">
+  <div class="hud" id="netHud">
     <span id="connStatus">Offline</span>
     <div class="btn" id="startCoop" style="display:inline-block; margin-left:6px; font-size:12px">Start Co-op</div>
   </div>
-  <a class="back" href="../../">← Back to Hub</a>
-  <div class="wrap">
-    <canvas id="game" width="800" height="450" aria-label="Platformer game"></canvas>
-  </div>
+  <main class="game-shell__main">
+    <div class="game-shell__surface">
+      <div class="wrap">
+        <canvas id="game" width="800" height="450" aria-label="Platformer game"></canvas>
+      </div>
+    </div>
+  </main>
   <div id="overlay" class="overlay"><div class="panel">
     <h2 id="over-title">Game Over</h2>
     <div id="over-info" style="margin-bottom:10px"></div>
     <div class="btn" id="restartBtn">Restart</div>
     <div class="btn" id="shareBtn" style="margin-top:8px">Share</div>
   </div></div>
-  <script type="module" src="./main.js"></script>
-  <script src="../common/diag-upgrades.js" defer data-slug="platformer"></script>
-  <script type="module" src="../../shared/juice/overlay.js" data-game="platformer"></script>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
+  <script type="module" src="./main.js"></script>
+  <script type="module" src="../../shared/juice/overlay.js" data-game="platformer"></script>
+  <script type="module" src="../common/game-shell.js" data-game="platformer"></script>
+
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
 </body>
 </html>

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -4,8 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Pong • Gurjot’s Games</title>
-    <link rel="preload" href="./pong.css" as="style">
-    <link rel="stylesheet" href="./pong.css">
+    <link rel="preload" href="./pong.css" as="style" />
+    <link rel="stylesheet" href="../common/game-shell.css" />
+    <link rel="stylesheet" href="./pong.css" />
   </head>
   <body class="pong-root">
     <div id="app" class="pong-app" aria-live="polite"></div>
@@ -13,35 +14,35 @@
       try { window.parent && window.parent.postMessage({type:'IFRAME_LOADED', slug:'pong'}, '*'); } catch(e){}
     </script>
     <script src="./pong.js" defer></script>
-    <script src="../common/diag-upgrades.js" defer data-slug="pong"></script>
-  
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
-</body>
-  </html>
+    <script type="module" src="../common/game-shell.js" data-game="pong" data-apply-theme="false" data-focus-target="#app"></script>
+
+    <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+    <script>
+    (function(){
+      if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+      function send(type, payload){
+        try {
+          if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+        } catch(e){ /* noop */ }
+      }
+      // Bubble uncaught errors to shell
+      window.addEventListener("error", function(e){
+        send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+      });
+      window.addEventListener("unhandledrejection", function(e){
+        var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+        send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+      });
+      // If the game hasn't sent a signal by load, emit READY as a fallback
+      var signalled = false;
+      window.addEventListener("message", function(ev){
+        if (!ev || !ev.data) return;
+        if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+      });
+      function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+      if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+      else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+    })();
+    </script>
+  </body>
+</html>

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -4,24 +4,105 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Runner Pro</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
-    :root{--fg:#eaeaf2;--bg:#0b0b0f;--accent:#6ee7b7}
-    html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;overflow:hidden}
-    canvas{width:100%;height:100%;display:block;background:linear-gradient(#222,#111)}
-    .hud{position:absolute;top:8px;left:50%;transform:translateX(-50%);display:flex;gap:12px;padding:6px 12px;background:rgba(0,0,0,0.35);border-radius:12px;align-items:center}
-    .hud span{font-weight:700}
-    .hud select,.hud button{background:rgba(255,255,255,0.08);color:var(--fg);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:4px 8px}
-    footer{position:absolute;bottom:6px;left:50%;transform:translateX(-50%);font-size:12px;opacity:0.7}
-    .touch{position:absolute;inset:0;pointer-events:none}
-    .touch .zone{position:absolute;width:50%;height:100%;top:0;pointer-events:auto}
-    .touch .left{left:0}.touch .right{right:0}
-    .editor{position:absolute;top:8px;right:8px;display:flex;flex-direction:column;gap:6px;}
-    .palette{display:flex;gap:4px;}
-    .palette .item{width:24px;height:24px;background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:4px;display:flex;align-items:center;justify-content:center;cursor:grab;}
-    .editor button,.editor select{background:rgba(255,255,255,0.08);color:var(--fg);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:4px 8px;}
+    :root { --fg:#eaeaf2; --bg:#0b0b0f; --accent:#6ee7b7; }
+    body {
+      margin: 0;
+      height: 100%;
+      background: var(--bg);
+      color: var(--fg);
+      font-family: system-ui, Segoe UI, Roboto, Arial, sans-serif;
+      overflow: hidden;
+    }
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+      background: linear-gradient(#222, #111);
+    }
+    .hud {
+      position: absolute;
+      top: 8px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      gap: 12px;
+      padding: 6px 12px;
+      background: rgba(0, 0, 0, 0.35);
+      border-radius: 12px;
+      align-items: center;
+      z-index: 5;
+    }
+    .hud span {
+      font-weight: 700;
+    }
+    .hud select,
+    .hud button {
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--fg);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 8px;
+      padding: 4px 8px;
+    }
+    footer {
+      position: absolute;
+      bottom: 6px;
+      left: 50%;
+      transform: translateX(-50%);
+      font-size: 12px;
+      opacity: 0.7;
+      z-index: 5;
+    }
+    .touch {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+    .touch .zone {
+      position: absolute;
+      width: 50%;
+      height: 100%;
+      top: 0;
+      pointer-events: auto;
+    }
+    .touch .left { left: 0; }
+    .touch .right { right: 0; }
+    .editor {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      z-index: 5;
+    }
+    .palette {
+      display: flex;
+      gap: 4px;
+    }
+    .palette .item {
+      width: 24px;
+      height: 24px;
+      background: rgba(255, 255, 255, 0.1);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 4px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: grab;
+    }
+    .editor button,
+    .editor select {
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--fg);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 8px;
+      padding: 4px 8px;
+    }
   </style>
 </head>
-<body>
+<body class="game-shell">
   <canvas id="game"></canvas>
   <div class="hud">
     <span id="score">0</span> m
@@ -53,37 +134,37 @@
 
   <script type="module" src="./main.js"></script>
   <script type="module" src="./editor.js"></script>
-  <script src="../common/diag-upgrades.js" defer data-slug="runner"></script>
   <script type="module" src="../../shared/game-boot.js" data-slug="runner"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="runner"></script>
+  <script type="module" src="../common/game-shell.js" data-game="runner" data-apply-theme="false"></script>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
 </body>
 </html>

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -4,27 +4,116 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Space Shooter</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
-    html, body{height:100%; margin:0; background:#0e0f12; color:#e6e6e6; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;}
-    .wrap{display:grid; place-items:center; height:100%; padding:16px}
-    canvas{background:#0a0d13; border:1px solid #1f2431; border-radius:12px; box-shadow:0 6px 22px rgba(0,0,0,.35)}
-    .hud{position:fixed; top:12px; left:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px}
-    .room-ui{position:fixed; top:12px; right:12px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:8px 10px; font-size:14px; display:flex; gap:4px}
-    #chat{position:fixed; bottom:12px; left:12px; width:200px; background:#1b1e24c0; border:1px solid #27314b; border-radius:10px; padding:6px; font-size:12px}
-    #chatLog{max-height:100px; overflow-y:auto; margin-bottom:4px}
-    kbd{padding:1px 6px; border-radius:6px; border:1px solid #2f3542; background:#111319; color:#d3d7de; font-weight:600; font-size:12px;}
-    .overlay{position:fixed; inset:0; display:none; place-items:center; background:rgba(0,0,0,.35); font-weight:800; letter-spacing:.4px; text-align:center;}
-    .overlay.show{display:grid}
-    .panel{background:#111522; border:1px solid #27314b; padding:18px 22px; border-radius:16px; box-shadow:0 10px 40px rgba(0,0,0,.5)}
-    .panel h2{margin:0 0 6px 0}
-    .btn{display:inline-block; padding:8px 12px; border:1px solid #27314b; background:#0e1422; color:#cfe6ff; border-radius:10px; text-decoration:none; cursor:pointer; font-weight:700}
+    body {
+      background: #0e0f12;
+      color: #e6e6e6;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+    }
+    .wrap {
+      display: grid;
+      place-items: center;
+      padding: 16px;
+    }
+    canvas {
+      background: #0a0d13;
+      border: 1px solid #1f2431;
+      border-radius: 12px;
+      box-shadow: 0 6px 22px rgba(0, 0, 0, .35);
+    }
+    .hud {
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      background: #1b1e24c0;
+      border: 1px solid #27314b;
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 14px;
+    }
+    .room-ui {
+      position: fixed;
+      top: 12px;
+      right: 12px;
+      background: #1b1e24c0;
+      border: 1px solid #27314b;
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 14px;
+      display: flex;
+      gap: 4px;
+    }
+    #chat {
+      position: fixed;
+      bottom: 12px;
+      left: 12px;
+      width: 200px;
+      background: #1b1e24c0;
+      border: 1px solid #27314b;
+      border-radius: 10px;
+      padding: 6px;
+      font-size: 12px;
+    }
+    #chatLog {
+      max-height: 100px;
+      overflow-y: auto;
+      margin-bottom: 4px;
+    }
+    kbd {
+      padding: 1px 6px;
+      border-radius: 6px;
+      border: 1px solid #2f3542;
+      background: #111319;
+      color: #d3d7de;
+      font-weight: 600;
+      font-size: 12px;
+    }
+    .overlay {
+      position: fixed;
+      inset: 0;
+      display: none;
+      place-items: center;
+      background: rgba(0, 0, 0, .35);
+      font-weight: 800;
+      letter-spacing: .4px;
+      text-align: center;
+    }
+    .overlay.show {
+      display: grid;
+    }
+    .panel {
+      background: #111522;
+      border: 1px solid #27314b;
+      padding: 18px 22px;
+      border-radius: 16px;
+      box-shadow: 0 10px 40px rgba(0, 0, 0, .5);
+    }
+    .panel h2 {
+      margin: 0 0 6px 0;
+    }
+    .btn {
+      display: inline-block;
+      padding: 8px 12px;
+      border: 1px solid #27314b;
+      background: #0e1422;
+      color: #cfe6ff;
+      border-radius: 10px;
+      text-decoration: none;
+      cursor: pointer;
+      font-weight: 700;
+    }
   </style>
 </head>
-<body>
+<body class="game-shell">
   <div class="hud">Score: <span id="score">0</span> • Best: <span id="best">0</span> • Power: <span id="power">None</span> • Shield: <span id="shield">0</span> • Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Shoot: <kbd>Space</kbd> • Turret: <kbd>T</kbd> • Wall: <kbd>F</kbd> • Pause: <kbd>P</kbd> • Restart: <kbd>R</kbd></div>
-  <div class="wrap">
-    <canvas id="game" width="800" height="450" aria-label="Space Shooter game"></canvas>
-  </div>
+  <main class="game-shell__main">
+    <div class="game-shell__surface">
+      <div class="wrap">
+        <canvas id="game" width="800" height="450" aria-label="Space Shooter game"></canvas>
+      </div>
+    </div>
+  </main>
   <div class="room-ui">
     <input id="roomName" placeholder="room" />
     <button id="joinRoom">Join</button>
@@ -41,37 +130,38 @@
     <div class="btn" id="restartBtn">Restart</div>
     <div class="btn" id="shareBtn" style="margin-top:8px">Share</div>
   </div></div>
-  <script type="module" src="./main.js"></script>
-  <script src="../common/diag-upgrades.js" defer data-slug="shooter"></script>
-  <script type="module" src="../../shared/juice/overlay.js" data-game="shooter"></script>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
+  <script type="module" src="./main.js"></script>
+  <script type="module" src="../../shared/juice/overlay.js" data-game="shooter"></script>
+  <script type="module" src="../common/game-shell.js" data-game="shooter"></script>
+
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
 </body>
 </html>

--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Snake+</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     :root {
       --bg: #0b1020;
@@ -14,7 +15,7 @@
       --border: #25305a;
     }
     * { box-sizing: border-box; }
-    html, body {
+    body {
       height: 100%;
       margin: 0;
       background: var(--bg);
@@ -22,8 +23,6 @@
       font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
     }
     .wrap {
-      position: fixed;
-      inset: 0;
       display: grid;
       place-items: center;
       padding: 10px;
@@ -78,22 +77,36 @@
       .hud {
         top: auto;
         bottom: 12px;
-        transform: translateX(-50%);
+        left: 12px;
+        transform: none;
+        right: 12px;
         justify-content: center;
       }
     }
   </style>
 </head>
-<body>
-  <div class="wrap">
-    <canvas id="c" width="640" height="640" aria-label="Snake game"></canvas>
+<body class="game-shell">
+  <main class="game-shell__main">
+    <div class="game-shell__surface">
+      <div class="wrap">
+        <canvas id="game" width="640" height="480"></canvas>
+      </div>
+    </div>
+  </main>
+  <div class="hud" role="group" aria-label="Snake controls">
+    <label><input type="checkbox" id="wrapToggle" /> Wrap walls</label>
+    <label><input type="checkbox" id="warpToggle" /> Warp speed</label>
+    <button id="restartBtn">Restart</button>
+    <button id="autoBtn" aria-pressed="false">Autoplay</button>
+    <label>Theme <select id="themeSelect"></select></label>
   </div>
-  <div class="hud" aria-live="polite"></div>
 
+  <script src="../../js/resizeCanvas.global.js"></script>
+  <script src="../../js/gameUtil.js"></script>
+  <script src="../../js/sfx.js"></script>
   <script type="module" src="./snake.js"></script>
-  <script src="../common/diag-upgrades.js" defer data-slug="snake"></script>
-  <script type="module" src="../../shared/game-boot.js" data-slug="snake"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="snake"></script>
+  <script type="module" src="../common/game-shell.js" data-game="snake"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -1,31 +1,107 @@
-<!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Tetris Lobby</title><style>body{margin:0;background:#0b0d12;color:#e6e7ea;font-family:Inter,system-ui,sans-serif;padding:20px}a{color:#38bdf8;text-decoration:none;margin-right:12px}.list{margin-top:10px}ul{list-style:none;padding:0}li{margin:4px 0}</style></head><body><h1>Tetris Tournament</h1><p><a href="play.html">Play</a><a href="play.html?spectate=1">Spectate</a></p><h2>Replays</h2><ul id="replayList" class="list"><li>Loading...</li></ul><script src="../../js/injectBackButton.js"></script><script>fetch('./replays/list.json').then(r=>r.json()).then(list=>{const ul=document.getElementById('replayList');ul.innerHTML='';if(!list.length){ul.innerHTML='<li>No replays</li>';return;}list.forEach(n=>{const li=document.createElement('li');const a=document.createElement('a');a.href='play.html?replay='+encodeURIComponent(n);a.textContent=n;li.appendChild(a);ul.appendChild(li);});}).catch(()=>{document.getElementById('replayList').innerHTML='<li>No replays</li>';});</script>  <script src="../common/diag-upgrades.js" defer data-slug="tetris"></script>  <script type="module" src="../../shared/juice/overlay.js" data-game="tetris"></script>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tetris Lobby</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
+  <style>
+    body {
+      font-size: 16px;
+      line-height: 1.6;
+    }
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
-<script>
-(function(){
-  if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
-  function send(type, payload){
-    try {
-      if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
-    } catch(e){ /* noop */ }
-  }
-  // Bubble uncaught errors to shell
-  window.addEventListener("error", function(e){
-    send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
-  });
-  window.addEventListener("unhandledrejection", function(e){
-    var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
-    send("GAME_ERROR", { error: String(reason).slice(0, 500) });
-  });
-  // If the game hasn't sent a signal by load, emit READY as a fallback
-  var signalled = false;
-  window.addEventListener("message", function(ev){
-    if (!ev || !ev.data) return;
-    if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
-  });
-  function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
-  if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
-  else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
-})();
-</script>
-</body></html>
+    a {
+      color: #38bdf8;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    a:hover,
+    a:focus-visible {
+      text-decoration: underline;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    li + li {
+      margin-top: 6px;
+    }
+  </style>
+</head>
+<body class="game-shell">
+  <main class="game-shell__main">
+    <div class="game-shell__surface game-shell__surface--plain">
+      <section>
+        <h1>Tetris Tournament</h1>
+        <p>
+          <a href="play.html">Play</a>
+          <a href="play.html?spectate=1">Spectate</a>
+        </p>
+        <h2>Replays</h2>
+        <ul id="replayList">
+          <li>Loading...</li>
+        </ul>
+      </section>
+    </div>
+  </main>
+
+  <script>
+  fetch('./replays/list.json')
+    .then(r => r.json())
+    .then(list => {
+      const ul = document.getElementById('replayList');
+      ul.innerHTML = '';
+      if (!list.length) {
+        ul.innerHTML = '<li>No replays</li>';
+        return;
+      }
+      list.forEach(n => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = 'play.html?replay=' + encodeURIComponent(n);
+        a.textContent = n;
+        li.appendChild(a);
+        ul.appendChild(li);
+      });
+    })
+    .catch(() => {
+      document.getElementById('replayList').innerHTML = '<li>No replays</li>';
+    });
+  </script>
+  <script type="module" src="../common/game-shell.js" data-game="tetris"></script>
+
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script>
+  (function(){
+    if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;
+    function send(type, payload){
+      try {
+        if (window.parent) window.parent.postMessage(Object.assign({ type }, payload || {}), "*");
+      } catch(e){ /* noop */ }
+    }
+    // Bubble uncaught errors to shell
+    window.addEventListener("error", function(e){
+      send("GAME_ERROR", { error: (e.message || String(e.error || e)).slice(0, 500) });
+    });
+    window.addEventListener("unhandledrejection", function(e){
+      var reason = e && e.reason ? (e.reason.message || String(e.reason)) : "unhandled rejection";
+      send("GAME_ERROR", { error: String(reason).slice(0, 500) });
+    });
+    // If the game hasn't sent a signal by load, emit READY as a fallback
+    var signalled = false;
+    window.addEventListener("message", function(ev){
+      if (!ev || !ev.data) return;
+      if (ev.data.type === "GAME_READY" || ev.data.type === "GAME_ERROR") signalled = true;
+    });
+    function emitReadyOnce(){ if (!signalled) { send("GAME_READY"); signalled = true; } }
+    if (document.readyState === "complete") { setTimeout(emitReadyOnce, 0); }
+    else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
+  })();
+  </script>
+</body>
+</html>

--- a/games/tetris/play.html
+++ b/games/tetris/play.html
@@ -1,1 +1,33 @@
-<!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Tetris</title><style>html,body{height:100%;margin:0;background:#0b0d12;color:#e6e7ea;font-family:Inter,system-ui,sans-serif}.wrap{display:grid;place-items:center;height:100%;position:relative}canvas{background:#0f1320;border:1px solid rgba(255,255,255,.08);border-radius:16px;box-shadow:0 20px 40px rgba(0,0,0,.4)}</style></head><body><div class="wrap"><canvas id="t" width="300" height="600" data-basew="300" data-baseh="600"></canvas></div><script src="../../js/injectBackButton.js"></script><script src="../../js/resizeCanvas.global.js"></script><script src="../../js/gameUtil.js"></script><script src="../../js/sfx.js"></script><script type="module" src="../../shared/ui/hud.js"></script><script src="./engine.js"></script><script src="./replay.js"></script><script type="module" src="./tetris.js"></script></body></html>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tetris</title>
+  <link rel="stylesheet" href="../common/game-shell.css" />
+  <style>
+    canvas {
+      background: #0f1320;
+      border-radius: 16px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+    }
+  </style>
+</head>
+<body class="game-shell">
+  <main class="game-shell__main">
+    <div class="game-shell__surface">
+      <canvas id="t" width="300" height="600" data-basew="300" data-baseh="600"></canvas>
+    </div>
+  </main>
+
+  <script src="../../js/resizeCanvas.global.js"></script>
+  <script src="../../js/gameUtil.js"></script>
+  <script src="../../js/sfx.js"></script>
+  <script src="./engine.js"></script>
+  <script src="./replay.js"></script>
+  <script type="module" src="../../shared/ui/hud.js"></script>
+  <script type="module" src="./tetris.js"></script>
+  <script type="module" src="../common/game-shell.js" data-game="tetris"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a reusable game shell stylesheet and script that apply the shared layout, gradient chrome, back button, and deferred diagnostics injection
- adopt the new shell wrapper across canvas-heavy games (Breakout, Snake, Tetris, etc.) and reorder scripts so diagnostics always follow module bundles
- wire shell support into UI-heavy titles like the Tetris lobby, chess variants, runner, maze3d, and 2048 while preserving their bespoke styling hooks

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68d4696d7cd48327ac3e688803b5e904