### PR TITLE
Remove 2048 cache-buster query params

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>2048</title>
   <link rel="stylesheet" href="../common/game-shell.css" />
-  <link rel="stylesheet" href="../../css/styles.css?v=5.3">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
     /* Reset and base styles */
     * { box-sizing: border-box; }
@@ -410,12 +410,12 @@
       </div>
     </div>
   </div>
-  <script src="../../js/hud.js?v=5.3"></script>
-  <script src="net.js?v=5.3"></script>
-  <script type="module" src="g2048.js?v=5.3"></script>
-  <script src="../../js/input.js?v=5.3"></script>
-  <script src="../../js/remapUI.js?v=5.3"></script>
-  <script src="../../js/perfHud.js?v=5.3"></script>
+  <script src="../../js/hud.js"></script>
+  <script src="net.js"></script>
+  <script type="module" src="g2048.js"></script>
+  <script src="../../js/input.js"></script>
+  <script src="../../js/remapUI.js"></script>
+  <script src="../../js/perfHud.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="2048"></script>
   <script type="module" src="../common/game-shell.js" data-game="g2048" data-apply-theme="false" data-focus-target="#board"></script>
 


### PR DESCRIPTION
## Summary
- remove hard-coded ?v=5.3 cache-buster query parameters from the 2048 game HTML
- rely on shared asset paths so all clients load the same versions after deploys

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d46d00d8b08327830a95c952f28acc