### PR TITLE
Route runtime catalog reads to public copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 ## How to add a new game
 
 1. Create a new folder under `games/<slug>` containing your HTML entry point and game scripts.
-2. Register the game in `games.json` so it appears in the library.
+2. Register the game in `games.json` so it appears in the library, then run `npm run sync:games` to regenerate the read-only `public/games.json` copy.
 3. Export `init()` and `dispose()` functions from your main module. `init()` should boot the game, while `dispose()` must remove event listeners, timers, and DOM nodes.
 4. Use helpers in `shared/` for consistent controls and UI. Most games import `shared/controls.js` to wire keyboard, touch, and gamepad input.
 
@@ -29,3 +29,4 @@ npm test             # runs the test suite
 - **Game never cleans up resources** – Ensure `dispose()` removes listeners and stops loops.
 - **Controls behave differently across games** – Import and use `shared/controls.js` instead of implementing custom input handlers.
 - **Health check fails** – Confirm the game is listed in `games.json` and all referenced files exist.
+- **Catalog drift** – Never edit `public/games.json` directly; update the root `games.json` and run `npm run sync:games` instead.

--- a/README-FORCE-REFRESH.md
+++ b/README-FORCE-REFRESH.md
@@ -2,16 +2,16 @@
 
 Upload these files to your repo:
 - `health/cache-reset.html` — visit once to unregister SW, clear caches, and hard-reload.
-- `js/game-loader.js` — smarter loader that tries `/games.json`, `/public/games.json`, and `./games.json` (same folder) with cache-busting.
-- `js/health-scan.js` — health page uses the same multi-path strategy.
+- `js/game-loader.js` — loader that fetches `/public/games.json` with cache-busting.
+- `js/health-scan.js` — health page points at the same `/public/games.json` catalog.
 - `games.json` — reference copy filled with entries.
 
 ## Steps (no IDE)
 
 1) **Upload** files to the same paths in GitHub (create folders if missing).
 2) Visit `https://<yoursite>/health/cache-reset.html` and click **Do it now**.
-3) Open `https://<yoursite>/games.json?t=123` — ensure you see the updated JSON with `entry` fields.
+3) Open `https://<yoursite>/public/games.json?t=123` — ensure you see the updated JSON with `entry` fields.
 4) Open `https://<yoursite>/health/?t=123` — rows should flip from SCHEMA failures.
 5) Click a row to open `/game.html?id=<slug>`; if the loader shows a red box, follow the message (404 path or missing boot function).
 
-If Netlify deploy path differs, the loader will also try `/public/games.json` and a local `./games.json` next to the page.
+If Netlify deploy path differs, ensure `/public/games.json` is deployed alongside your pages or update the loader paths accordingly.

--- a/cabinet.html
+++ b/cabinet.html
@@ -43,7 +43,7 @@
 
     async function loadGames(){
       try {
-        const res = await fetch('./games.json', { cache: 'no-store' });
+        const res = await fetch('./public/games.json', { cache: 'no-store' });
         const data = await res.json();
         games = Array.isArray(data.games) ? data.games : (Array.isArray(data) ? data : []);
       } catch { games = []; }

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -13,7 +13,9 @@ The client-side interface communicates with modular game logic. State is saved l
 
 ## Updating Game Data
 
-Game metadata displayed on the landing page lives in `/games.json`.
+Game metadata displayed on the landing page lives in the repository root `games.json` file.
+At build time the sync script copies that source file to `/public/games.json`, which is what the deployed site loads. Treat `/public/games.json` as read-only—update the root catalog and re-run the sync script instead of editing the public copy by hand.
+
 To add a new entry:
 
 1. Open `games.json`.
@@ -26,5 +28,6 @@ To add a new entry:
    - `released` – release date in `YYYY-MM-DD`
    - `playUrl` – path to the game's root
 3. Ensure the JSON remains valid and each object is comma-separated.
-4. Run `npm run health` to verify the metadata.
+4. Run `npm run sync:games` to refresh `/public/games.json`.
+5. Run `npm run health` to verify the metadata.
 

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -9,7 +9,7 @@ import { mountCameraPresets } from "./ui/cameraPresets.js";
 import { envDataUrl } from "./textures/env.js";
 import { log, warn } from '../../tools/reporters/console-signature.js';
 import { injectHelpButton } from '../../shared/ui.js';
-const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
+const games = await fetch('/public/games.json').then(r => r.json());
 
 log('chess3d', '[Chess3D] booting');
 

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -4,7 +4,7 @@ import { injectHelpButton, recordLastPlayed, shareScore } from '../../shared/ui.
 import { emitEvent } from '../../shared/achievements.js';
 import { connect } from './net.js';
 import { generateMaze, seedRandom } from './generator.js';
-const games = await fetch(new URL('../../games.json', import.meta.url)).then(r => r.json());
+const games = await fetch('/public/games.json').then(r => r.json());
 
 const help = games.find(g => g.id === 'maze3d')?.help || {};
 injectHelpButton({ gameId: 'maze3d', ...help });

--- a/health/index.html
+++ b/health/index.html
@@ -33,7 +33,7 @@
   <body>
     <header>
       <h1>Gurjot’s Games — Health Check</h1>
-      <div class="small">Scans <code>/games.json</code>, probes each game's <code>entry</code>, and checks common pitfalls.</div>
+      <div class="small">Scans <code>/public/games.json</code>, probes each game's <code>entry</code>, and checks common pitfalls.</div>
     </header>
     <main>
       <div id="summary" class="panel">Loading…</div>
@@ -62,7 +62,7 @@
         </div>
         <div class="panel">
           <h3>Legend</h3>
-          <p><span class="pill">OK</span> Loadable | <span class="pill">FETCH</span> network issue | <span class="pill">BOOT</span> boot/export missing | <span class="pill">SCHEMA</span> bad <code>games.json</code></p>
+          <p><span class="pill">OK</span> Loadable | <span class="pill">FETCH</span> network issue | <span class="pill">BOOT</span> boot/export missing | <span class="pill">SCHEMA</span> bad catalog data</p>
         </div>
       </div>
     </main>

--- a/health/runtime-diagnose.html
+++ b/health/runtime-diagnose.html
@@ -50,7 +50,7 @@ const tbody = document.querySelector('#report tbody');
 const mk = (t, props={}) => Object.assign(document.createElement(t), props);
 
 async function loadCatalog() {
-  const res = await fetch('/games.json?cb=' + t);
+  const res = await fetch('/public/games.json?cb=' + t);
   if (!res.ok) throw new Error('Failed to fetch games.json');
   return res.json();
 }

--- a/js/bolt-landing.js
+++ b/js/bolt-landing.js
@@ -108,7 +108,7 @@ function buildFilterChips(tags){
 
 async function boot(){
   try {
-    const res = await fetch('./games.json?v=20250911175011', { cache:'no-cache' });
+    const res = await fetch('./public/games.json?v=20250911175011', { cache:'no-cache' });
     if (!res.ok) throw new Error('Failed to load games.json');
     const data = await res.json();
     const list = Array.isArray(data) ? data : (Array.isArray(data.games) ? data.games : []);

--- a/js/entry-suggest.js
+++ b/js/entry-suggest.js
@@ -31,7 +31,7 @@
   function esc(s){ return (s+'').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 
   async function run(){
-    const list = await fetchJSON('/games.json?t=' + now);
+    const list = await fetchJSON('/public/games.json?t=' + now);
     const games = Array.isArray(list) ? list : Object.keys(list).map(k => ({ slug:k, ...list[k] }));
     const missing = [];
     for (const g of games){

--- a/js/game-shell.js
+++ b/js/game-shell.js
@@ -149,7 +149,7 @@ async function boot(){
   if(!slug){ return render404("Missing ?slug= parameter"); }
   var catalog;
   try{
-    var res = await fetch('/games.json', {cache:'no-cache'});
+    var res = await fetch('/public/games.json', {cache:'no-cache'});
     catalog = await res.json();
   }catch(e){ return renderError("Could not load games.json", e); }
   var list = Array.isArray(catalog) ? catalog : (catalog.games || []);

--- a/js/health-scan.js
+++ b/js/health-scan.js
@@ -14,16 +14,8 @@
   }
 
   async function getList(){
-    const bases = ['/games.json','/public/games.json', (location.pathname.replace(/[^\/]+$/, '') + 'games.json')];
-    const tried = [];
-    for (const b of bases){
-      const url = b + (b.includes('?')?'&':'?') + 't=' + now;
-      try {
-        const j = await fetchJSON(url);
-        return { j, src:b };
-      } catch(e){ tried.push(`${b} → ${e.message}`); }
-    }
-    throw new Error('Could not fetch games.json from any known location:\n' + tried.join('\n'));
+    const url = `/public/games.json?t=${now}`;
+    return { j: await fetchJSON(url), src: '/public/games.json' };
   }
 
   async function scan(){

--- a/js/runtime-diagnose.js
+++ b/js/runtime-diagnose.js
@@ -51,11 +51,8 @@
 
   async function scan(){
     const { list, src } = await (async ()=>{
-      const bases=['/games.json','/public/games.json',(location.pathname.replace(/[^\\/]+$/,'')+'games.json')];
-      for (const b of bases){
-        try{ const j=await fetchJSON(b+'?t='+now); return {list:j, src:b}; }catch(e){}
-      }
-      throw new Error('Unable to fetch games.json');
+      const url = `/public/games.json?t=${now}`;
+      return { list: await fetchJSON(url), src: '/public/games.json' };
     })();
 
     const arr = Array.isArray(list) ? list : Object.keys(list).map(k => ({ slug:k, ...list[k] }));

--- a/shared/game-boot.js
+++ b/shared/game-boot.js
@@ -17,7 +17,7 @@ recordLastPlayed(slug);
 async function track(){
   let tags = [];
   try {
-    const res = await fetch('/games.json');
+    const res = await fetch('/public/games.json');
     const data = await res.json();
     const games = Array.isArray(data.games) ? data.games : (Array.isArray(data) ? data : []);
     const g = games.find(g => g.slug === slug);

--- a/shared/game-catalog.js
+++ b/shared/game-catalog.js
@@ -1,6 +1,6 @@
 import { normalizeCatalogEntries, toNormalizedList } from './game-catalog-core.js';
 
-const CATALOG_URL = '/games.json';
+const CATALOG_URL = '/public/games.json';
 let catalogPromise = null;
 
 async function fetchCatalogSource() {

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -267,7 +267,7 @@ export async function shareScore(slug, score) {
   let text = `I scored ${score} in ${slug}!`;
   try {
     // Attempt to grab a nicer title from games.json
-    const res = await fetch(new URL('../games.json', import.meta.url));
+    const res = await fetch(new URL('../public/games.json', import.meta.url));
     const data = await res.json();
     const game = (data.games || data).find?.(g => g.slug === slug);
     if (game?.title) text = `I scored ${score} in ${game.title}!`;


### PR DESCRIPTION
## Summary
- point frontend loaders and diagnostics at `/public/games.json` as the runtime catalog source
- refresh cabinet mode, game modules, and tooling to use the generated catalog copy
- document the root `games.json` -> `/public/games.json` workflow and mark the public file read-only

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d46d11cde08327bd1bf27be4b92992