### PR TITLE
Improve shared game shell layout scaling

### DIFF
--- a/games/common/game-shell.css
+++ b/games/common/game-shell.css
@@ -2,14 +2,26 @@
   color-scheme: dark;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 body.game-shell {
   margin: 0;
   min-height: 100svh;
   background: #0b0d12;
   color: #e6e7ea;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  place-items: center;
+}
+
+canvas {
+  max-width: 100vw;
+  max-height: 100vh;
+  height: auto;
+  image-rendering: pixelated;
 }
 
 body.game-shell::after {
@@ -32,6 +44,7 @@ body.game-shell::after {
   position: relative;
   z-index: 1;
   min-height: 0;
+  justify-self: stretch;
 }
 
 .game-shell__surface {
@@ -45,8 +58,8 @@ body.game-shell::after {
 .game-shell__surface > .game-shell__canvas,
 .game-shell__surface > .game-shell__frame {
   display: block;
-  max-width: min(100%, 960px);
-  max-height: calc(100svh - 160px);
+  max-width: min(100vw, 960px);
+  max-height: min(100vh, calc(100svh - 160px));
   background: #0f1320;
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -55,6 +68,7 @@ body.game-shell::after {
 
 .game-shell__surface > canvas {
   height: auto;
+  image-rendering: pixelated;
 }
 
 .game-shell__surface--plain {


### PR DESCRIPTION
## Summary
- ensure the shared game shell grid fills the viewport and centers its contents to eliminate stray scrollbars
- add global canvas sizing defaults so fixed-dimension games scale down to the viewport while keeping pixel art crisp
- tighten shell surface sizing to respect viewport height limits when centering games

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d46d23e5148327ad96acd95f2d737e