### PR TITLE
Make canvas layouts responsive across legacy games

### DIFF
--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -11,6 +11,10 @@
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: 16px;
       box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+      display: block;
+      width: min(100%, 800px);
+      height: auto;
+      margin: 0 auto;
     }
   </style>
 </head>

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -27,6 +27,9 @@
       border: 1px solid #243047;
       border-radius: 12px;
       background: #0f172a;
+      display: block;
+      width: min(100%, 480px);
+      height: auto;
     }
     .chess-info {
       max-width: 260px;

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -15,12 +15,17 @@
       display: grid;
       place-items: center;
       padding: 16px;
+      width: min(100%, 960px);
+      margin: 0 auto;
     }
     canvas {
       background: #0a0d13;
       border: 1px solid #1f2431;
       border-radius: 12px;
       box-shadow: 0 6px 22px rgba(0, 0, 0, .35);
+      display: block;
+      width: min(100%, 800px);
+      height: auto;
     }
     .hud {
       position: fixed;
@@ -31,10 +36,16 @@
       border-radius: 10px;
       padding: 8px 10px;
       font-size: 14px;
+      max-width: calc(100vw - 24px);
+      box-sizing: border-box;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 12px;
     }
     #netHud {
       left: auto;
       right: 12px;
+      max-width: calc(100vw - 24px);
     }
     .btn {
       display: inline-block;
@@ -69,6 +80,21 @@
     }
     .panel h2 {
       margin: 0 0 6px 0;
+    }
+    @media (max-width: 600px) {
+      .hud {
+        top: auto;
+        bottom: 12px;
+        left: 12px;
+        right: 12px;
+        justify-content: center;
+      }
+      #netHud {
+        top: auto;
+        bottom: 72px;
+        left: 12px;
+        right: 12px;
+      }
     }
   </style>
 </head>

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -15,12 +15,17 @@
       display: grid;
       place-items: center;
       padding: 16px;
+      width: min(100%, 960px);
+      margin: 0 auto;
     }
     canvas {
       background: #0a0d13;
       border: 1px solid #1f2431;
       border-radius: 12px;
       box-shadow: 0 6px 22px rgba(0, 0, 0, .35);
+      display: block;
+      width: min(100%, 800px);
+      height: auto;
     }
     .hud {
       position: fixed;
@@ -31,6 +36,11 @@
       border-radius: 10px;
       padding: 8px 10px;
       font-size: 14px;
+      max-width: calc(100vw - 24px);
+      box-sizing: border-box;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 12px;
     }
     .room-ui {
       position: fixed;
@@ -42,13 +52,15 @@
       padding: 8px 10px;
       font-size: 14px;
       display: flex;
+      flex-wrap: wrap;
       gap: 4px;
+      max-width: calc(100vw - 24px);
     }
     #chat {
       position: fixed;
       bottom: 12px;
       left: 12px;
-      width: 200px;
+      width: min(220px, calc(100vw - 24px));
       background: #1b1e24c0;
       border: 1px solid #27314b;
       border-radius: 10px;
@@ -102,6 +114,26 @@
       text-decoration: none;
       cursor: pointer;
       font-weight: 700;
+    }
+    @media (max-width: 640px) {
+      .hud {
+        top: auto;
+        bottom: 12px;
+        left: 12px;
+        right: 12px;
+        justify-content: center;
+      }
+      .room-ui {
+        top: auto;
+        bottom: 72px;
+        right: 12px;
+        left: 12px;
+        justify-content: flex-end;
+      }
+      #chat {
+        left: 12px;
+        right: 12px;
+      }
     }
   </style>
 </head>

--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -26,6 +26,8 @@
       display: grid;
       place-items: center;
       padding: 10px;
+      width: min(100%, 960px);
+      margin: 0 auto;
     }
     canvas {
       display: block;
@@ -36,6 +38,8 @@
       max-height: 100vh;
       image-rendering: pixelated;
       box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+      width: min(100%, 640px);
+      height: auto;
     }
     .hud {
       position: fixed;

--- a/games/tetris/play.html
+++ b/games/tetris/play.html
@@ -11,6 +11,10 @@
       border-radius: 16px;
       border: 1px solid rgba(255, 255, 255, 0.08);
       box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+      display: block;
+      width: min(100%, 420px);
+      height: auto;
+      margin: 0 auto;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- adjust legacy canvas-based game shells to scale canvas elements within the available viewport
- wrap HUD overlays so fixed-position toolbars no longer trigger horizontal scrolling on small screens
- add mobile breakpoints so platformer and shooter overlays reposition cleanly when space is constrained

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68d47578d178832787e8c299f2042b64