### PR TITLE
Send GAME_READY from every game loop

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -43,6 +43,7 @@ diffSel?.addEventListener('change',()=>{
   hintDepth=parseInt(diffSel.value)||1;
 });
 const hud=HUD.create({title:'2048', onPauseToggle:()=>{}, onRestart:()=>reset()});
+let postedReady=false;
 
 // UI update functions
 function updateUI() {
@@ -474,6 +475,10 @@ c.addEventListener('touchend',e=>{
 });
 
 function draw(anim){
+  if(!postedReady){
+    postedReady=true;
+    try { window.parent?.postMessage({ type:'GAME_READY', slug:'g2048' }, '*'); } catch {}
+  }
   // Frame rate optimization - skip frames when performance is poor
   const now = performance.now();
   if (renderCache.skipFrames > 0) {

--- a/games/breakout/breakout.js
+++ b/games/breakout/breakout.js
@@ -44,6 +44,7 @@ c.height=BASE_H;
 fitCanvasToParent(c,BASE_W,BASE_H,24);addEventListener('resize',()=>fitCanvasToParent(c,BASE_W,BASE_H,24));
 const ctx=c.getContext('2d');
 installErrorReporter();
+let postedReady=false;
 
 const paddleBaseW=120;
 let paddle={w:paddleBaseW,h:14,x:c.width/2-paddleBaseW/2,y:c.height-40};
@@ -244,6 +245,10 @@ function step(dt){
 }
 
 function draw(){
+  if(!postedReady){
+    postedReady=true;
+    try { window.parent?.postMessage({ type:'GAME_READY', slug:'breakout' }, '*'); } catch {}
+  }
   ctx.shadowColor='rgba(0,200,255,0.6)';ctx.shadowBlur=12;
   bgT+=0.3;const bg=ctx.createLinearGradient(0,0,0,c.height);
   bg.addColorStop(0,`hsl(${bgT%360},40%,10%)`);

--- a/games/chess/chess.js
+++ b/games/chess/chess.js
@@ -51,6 +51,7 @@ let onlineMode=false;
 let localColor='w';
 let lastSentMove=null;
 const netMoveQueue=[];
+let postedReady=false;
 
 // piece sprites encoded as base64 data URIs to avoid external binary assets
 const pieceSrcs={
@@ -377,6 +378,10 @@ function enqueueNetMove(moveStr){
 }
 function highlightSquare(x,y,color){ drawGlow(fxCtx, x*S+S/2, y*S+S/2, S*0.6, color); }
 function draw(){
+  if(!postedReady){
+    postedReady=true;
+    try { window.parent?.postMessage({ type:'GAME_READY', slug:'chess' }, '*'); } catch {}
+  }
   ctx.clearRect(0,0,c.width,c.height);
   fxCtx.clearRect(0,0,fx.width,fx.height);
   ctx.drawImage(boardTex,0,0);

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -36,6 +36,7 @@ let searchToken = 0;
 let evalBar;
 let lastMoveHelper;
 let autoRotate = localStorage.getItem('chess3d.rotate') === '1';
+let postedReady=false;
 
 function handlePostMove(){
   try{ moveList?.refresh(); moveList?.setIndex(rules.historySAN().length); }catch(_){ }
@@ -325,6 +326,10 @@ async function boot(){
   function animate() {
     requestAnimationFrame(animate);
     controls.update();
+    if(!postedReady){
+      postedReady=true;
+      try { window.parent?.postMessage({ type:'GAME_READY', slug:'chess3d' }, '*'); } catch {}
+    }
     renderer.render(scene, camera);
   }
   animate();

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -97,6 +97,7 @@ let opponent = { mesh:null };
 let opponentFinish = null;
 let myFinish = null;
 let lastPosSent = 0;
+let postedReady=false;
 if (roomInput) roomInput.value = Math.random().toString(36).slice(2,7);
 if (best) bestEl.textContent = best.toFixed(2);
 
@@ -847,6 +848,10 @@ function loop() {
   playerLight.position.copy(controls.getObject().position);
   playerLight.position.y += 1.5;
   renderer.render(scene, camera);
+  if(!postedReady){
+    postedReady=true;
+    try { window.parent?.postMessage({ type:'GAME_READY', slug:'maze3d' }, '*'); } catch {}
+  }
   if (mapVisible) {
     // render minimap (orthographic top-down)
     const miniCam = new THREE.OrthographicCamera(-cellSize*MAZE_CELLS*1.2, cellSize*MAZE_CELLS*1.2, cellSize*MAZE_CELLS*1.2, -cellSize*MAZE_CELLS*1.2, 0.1, 1000);

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -58,6 +58,7 @@ export function boot() {
   const W = canvas.width;
   const H = canvas.height;
   const groundY = H - 60;
+  let postedReady = false;
 
   const overlay = document.getElementById('overlay');
   const overlayTitle = document.getElementById('over-title');
@@ -438,6 +439,10 @@ export function boot() {
   }
 
   function drawScene() {
+    if(!postedReady){
+      postedReady = true;
+      try { window.parent?.postMessage({ type:'GAME_READY', slug:'platformer' }, '*'); } catch {}
+    }
     ctx.clearRect(0, 0, W, H);
     const gradient = ctx.createLinearGradient(0, 0, 0, H);
     gradient.addColorStop(0, '#0d1a2b');

--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -24,6 +24,7 @@ const DEFAULT_LEVEL = {
 };
 
 const SKY_GRADIENT = ['#1e293b', '#0f172a'];
+let postedReady = false;
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
@@ -663,6 +664,10 @@ class RunnerGame {
   }
 
   draw() {
+    if(!postedReady){
+      postedReady = true;
+      try { window.parent?.postMessage({ type:'GAME_READY', slug:'runner' }, '*'); } catch {}
+    }
     const ctx = this.ctx;
     const canSave = typeof ctx.save === 'function';
     if (canSave) ctx.save();

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -6,6 +6,7 @@ export function boot() {
   canvas.width = canvas.width || 960;
   canvas.height = canvas.height || 540;
   const W = canvas.width, H = canvas.height;
+  let postedReady = false;
 
   const player = { x: W*0.2, y: H*0.5, r: 12, vx: 0, vy: 0, speed: 5, hp: 3, cd: 0 };
   const bullets = [];
@@ -68,6 +69,10 @@ export function boot() {
   }
 
   function draw(){
+    if(!postedReady){
+      postedReady = true;
+      try { window.parent?.postMessage({ type:'GAME_READY', slug:'shooter' }, '*'); } catch {}
+    }
     ctx.clearRect(0,0,W,H);
     // bg
     ctx.fillStyle = '#10151a';

--- a/games/snake/snake.js
+++ b/games/snake/snake.js
@@ -79,6 +79,7 @@ let deadHandled = false;
 const GAME_ID = 'snake';
 GG.incPlays();
 const tokens = getThemeTokens('snake');
+let postedReady=false;
 const SNAKE_SKINS = [
   { id: 'default', name: 'Purple', color: tokens['snake-purple'] || '#8b5cf6', unlock: p => true },
   { id: 'gold', name: 'Gold', color: tokens['snake-gold'] || '#fcd34d', unlock: p => p.best >= 10 },
@@ -284,6 +285,10 @@ function step() {
 }
 
 function render() {
+  if(!postedReady){
+    postedReady=true;
+    try { window.parent?.postMessage({ type:'GAME_READY', slug:'snake' }, '*'); } catch {}
+  }
   const time = performance.now();
   CELL = c.width / N;
 

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -43,6 +43,7 @@ if(c){
   throw error;
 }
 const ctx=c.getContext('2d');
+let postedReady=false;
 const COLS=10, ROWS=20;
 const COLORS=['#000','#8b5cf6','#22d3ee','#f59e0b','#ef4444','#10b981','#e879f9','#38bdf8'];
 const SHAPES={I:[[1,1,1,1]],O:[[2,2],[2,2]],T:[[0,3,0],[3,3,3]],S:[[0,4,4],[4,4,0]],Z:[[5,5,0],[0,5,5]],J:[[6,0,0],[6,6,6]],L:[[0,0,7],[7,7,7]]};
@@ -222,6 +223,10 @@ function drawGhost(cell){
       if(ghost.m[y][x]) drawPieceCell(ghost.x+x,ghost.y+y,ghost.m[y][x],cell,0.3);
 }
 function draw(){
+  if(!postedReady){
+    postedReady=true;
+    try { window.parent?.postMessage({ type:'GAME_READY', slug:'tetris' }, '*'); } catch {}
+  }
   const cell=getCellSize();
   bgShift=(bgShift+0.5)%c.height;
   const bg=ctx.createLinearGradient(0,bgShift,0,c.height+bgShift);


### PR DESCRIPTION
## Summary
- post a GAME_READY message after the first render in g2048, breakout, chess, chess3d, maze3d, platformer, runner, shooter, snake, and tetris

## Testing
- npm run test:smoke

------
https://chatgpt.com/codex/tasks/task_e_68d567834bec83279adbe2e70093bc5e