### PR TITLE
Add consistent auto-pause handling across games

### DIFF
--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -11,6 +11,30 @@ import { log, warn } from '../../tools/reporters/console-signature.js';
 import { injectHelpButton } from '../../shared/ui.js';
 const games = await fetch('/public/games.json').then(r => r.json());
 
+let renderLoopId = 0;
+let renderLoopPaused = false;
+let shellLoopAutoPaused = false;
+let shellClockAutoPaused = false;
+let handleShellPause = () => {};
+let handleShellResume = () => {};
+
+(function installShellAutoPause(){
+  const onPause = () => handleShellPause();
+  const onResume = () => handleShellResume();
+  window.addEventListener('ggshell:pause', onPause);
+  window.addEventListener('ggshell:resume', onResume);
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) handleShellPause();
+    else handleShellResume();
+  });
+  window.addEventListener('message', (event) => {
+    const data = event && typeof event.data === 'object' ? event.data : null;
+    const type = data?.type;
+    if (type === 'GAME_PAUSE' || type === 'GG_PAUSE') handleShellPause();
+    if (type === 'GAME_RESUME' || type === 'GG_RESUME') handleShellResume();
+  }, { passive: true });
+})();
+
 log('chess3d', '[Chess3D] booting');
 
 const help = games.find(g => g.id === 'chess3d')?.help || {};
@@ -322,12 +346,58 @@ async function boot(){
   updateStatus();
   maybeAIMove();
 
-  function animate() {
-    requestAnimationFrame(animate);
+  const renderFrame = () => {
+    if (renderLoopPaused) {
+      renderLoopId = 0;
+      return;
+    }
     controls.update();
     renderer.render(scene, camera);
-  }
-  animate();
+    renderLoopId = requestAnimationFrame(renderFrame);
+  };
+  const startRenderLoop = () => {
+    if (renderLoopId) return;
+    renderLoopPaused = false;
+    renderLoopId = requestAnimationFrame(renderFrame);
+  };
+  const stopRenderLoop = () => {
+    renderLoopPaused = true;
+    if (renderLoopId) {
+      cancelAnimationFrame(renderLoopId);
+      renderLoopId = 0;
+    }
+  };
+  startRenderLoop();
+
+  handleShellPause = () => {
+    const wasRunning = !!renderLoopId && !renderLoopPaused;
+    stopRenderLoop();
+    shellLoopAutoPaused = wasRunning;
+    if (!gameOver && clocks && typeof clocks.pause === 'function') {
+      try {
+        clocks.pause();
+        shellClockAutoPaused = true;
+      } catch (_) {
+        shellClockAutoPaused = false;
+      }
+    } else {
+      shellClockAutoPaused = false;
+    }
+  };
+  handleShellResume = () => {
+    if (document.hidden) return;
+    if (shellClockAutoPaused && !gameOver && clocks && typeof clocks.resume === 'function') {
+      try { clocks.resume(); } catch (_) {}
+      shellClockAutoPaused = false;
+    }
+    if (shellLoopAutoPaused && !renderLoopId) {
+      shellLoopAutoPaused = false;
+      startRenderLoop();
+    } else if (!renderLoopId && !renderLoopPaused) {
+      startRenderLoop();
+    }
+  };
+
   try{ window.__Chess3DBooted = true; }catch(_){}
 }
 

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -88,6 +88,9 @@ let rematchBtn = document.getElementById('rematchBtn');
 
 let running = false;
 let paused = true;
+let pausedByShell = false;
+let shellRenderPaused = false;
+let loopRaf = 0;
 let startTime = 0;
 let best = Number(localStorage.getItem('besttime:maze3d') || 0);
 let net = null;
@@ -831,7 +834,10 @@ function update(dt) {
 }
 
 function loop() {
-  requestAnimationFrame(loop);
+  if (shellRenderPaused) {
+    loopRaf = 0;
+    return;
+  }
   const dt = 0.016; // fixed timestep
   if (running && !paused) {
     const now = performance.now();
@@ -878,7 +884,57 @@ function loop() {
     ctx2.fillStyle = '#eab308';
     ctx2.fillRect(u-2, v-2, 4, 4);
   }
+  if (!shellRenderPaused) {
+    loopRaf = requestAnimationFrame(loop);
+  } else {
+    loopRaf = 0;
+  }
 }
+
+function startRenderLoop() {
+  if (!loopRaf) {
+    shellRenderPaused = false;
+    loopRaf = requestAnimationFrame(loop);
+  }
+}
+
+function stopRenderLoop() {
+  shellRenderPaused = true;
+  if (loopRaf) {
+    cancelAnimationFrame(loopRaf);
+    loopRaf = 0;
+  }
+}
+
+function pauseForShell() {
+  stopRenderLoop();
+  if (!running || paused) { pausedByShell = false; return; }
+  pausedByShell = true;
+  pause();
+}
+
+function resumeFromShell() {
+  if (document.hidden) return;
+  startRenderLoop();
+  if (!pausedByShell) return;
+  pausedByShell = false;
+  if (running && paused) start();
+}
+
+const onShellPause = () => pauseForShell();
+const onShellResume = () => resumeFromShell();
+const onVisibilityChange = () => { if (document.hidden) pauseForShell(); else resumeFromShell(); };
+const onShellMessage = (event) => {
+  const data = event && typeof event.data === 'object' ? event.data : null;
+  const type = data?.type;
+  if (type === 'GAME_PAUSE' || type === 'GG_PAUSE') pauseForShell();
+  if (type === 'GAME_RESUME' || type === 'GG_RESUME') resumeFromShell();
+};
+
+window.addEventListener('ggshell:pause', onShellPause);
+window.addEventListener('ggshell:resume', onShellResume);
+document.addEventListener('visibilitychange', onVisibilityChange);
+window.addEventListener('message', onShellMessage, { passive: true });
 
 window.addEventListener('resize', () => {
   camera.aspect = window.innerWidth / window.innerHeight;
@@ -887,4 +943,4 @@ window.addEventListener('resize', () => {
 });
 
 restart(currentSeed);
-loop();
+startRenderLoop();

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -111,6 +111,7 @@ export function boot() {
   };
 
   let paused = false;
+  let pausedByShell = false;
   let gameOver = false;
   let finalTime = null;
   let rafId = 0;
@@ -537,6 +538,10 @@ export function boot() {
     window.removeEventListener('keyup', handleKeyUp);
     clearTimeout(shareResetTimer);
     clearTimeout(coopRetryTimer);
+    window.removeEventListener('ggshell:pause', onShellPause);
+    window.removeEventListener('ggshell:resume', onShellResume);
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+    window.removeEventListener('message', onShellMessage);
   }
 
   window.addEventListener('keydown', handleKeyDown);
@@ -544,6 +549,34 @@ export function boot() {
   restartBtn?.addEventListener('click', restartGame);
   shareBtn?.addEventListener('click', shareRun);
   if (netHud) initNet();
+
+  function pauseForShell() {
+    if (gameOver) return;
+    if (paused) { pausedByShell = false; return; }
+    pausedByShell = true;
+    togglePause(true);
+  }
+
+  function resumeFromShell() {
+    if (!pausedByShell || document.hidden) return;
+    pausedByShell = false;
+    if (paused && !gameOver) togglePause(false);
+  }
+
+  const onShellPause = () => pauseForShell();
+  const onShellResume = () => resumeFromShell();
+  const onVisibilityChange = () => { if (document.hidden) pauseForShell(); else resumeFromShell(); };
+  const onShellMessage = (event) => {
+    const data = event && typeof event.data === 'object' ? event.data : null;
+    const type = data?.type;
+    if (type === 'GAME_PAUSE' || type === 'GG_PAUSE') pauseForShell();
+    if (type === 'GAME_RESUME' || type === 'GG_RESUME') resumeFromShell();
+  };
+
+  window.addEventListener('ggshell:pause', onShellPause);
+  window.addEventListener('ggshell:resume', onShellResume);
+  document.addEventListener('visibilitychange', onVisibilityChange);
+  window.addEventListener('message', onShellMessage, { passive: true });
 
   resetState();
   lastFrame = performance.now();

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -88,7 +88,59 @@ export function boot() {
     ctx.fillText('Move: WASD/Arrows • Shoot: Space/Enter', 16, 70);
   }
 
-  let raf; function loop(){ update(); draw(); if (player.hp>0) raf=requestAnimationFrame(loop); else gameOver(); } loop();
+  let raf = 0;
+  let shellPaused = false;
+  let pausedByShell = false;
+
+  function frame(){
+    if(shellPaused){ raf = 0; return; }
+    update();
+    draw();
+    if (player.hp>0) {
+      raf=requestAnimationFrame(frame);
+    } else {
+      gameOver();
+      shellPaused = false;
+      pausedByShell = false;
+      raf = 0;
+    }
+  }
+
+  function startLoop(){ if(!raf && player.hp>0){ raf=requestAnimationFrame(frame); } }
+
+  function stopLoop(){ if(raf){ cancelAnimationFrame(raf); raf=0; } }
+
+  function pauseForShell(){
+    if(shellPaused) return;
+    if(player.hp<=0){ shellPaused=false; pausedByShell=false; return; }
+    shellPaused=true;
+    pausedByShell=true;
+    stopLoop();
+  }
+
+  function resumeFromShell(){
+    if(!shellPaused || document.hidden) return;
+    shellPaused=false;
+    if(pausedByShell && player.hp>0){ pausedByShell=false; startLoop(); }
+  }
+
+  const onShellPause=()=>pauseForShell();
+  const onShellResume=()=>resumeFromShell();
+  const onVisibility=()=>{ if(document.hidden) pauseForShell(); else resumeFromShell(); };
+  const onShellMessage=(event)=>{
+    const data=event && typeof event.data==='object' ? event.data : null;
+    const type=data?.type;
+    if(type==='GAME_PAUSE' || type==='GG_PAUSE') pauseForShell();
+    if(type==='GAME_RESUME' || type==='GG_RESUME') resumeFromShell();
+  };
+
+  window.addEventListener('ggshell:pause', onShellPause);
+  window.addEventListener('ggshell:resume', onShellResume);
+  document.addEventListener('visibilitychange', onVisibility);
+  window.addEventListener('message', onShellMessage, { passive:true });
+
+  startLoop();
+
   function gameOver(){
     ctx.fillStyle = 'rgba(0,0,0,0.5)'; ctx.fillRect(0,0,W,H);
     ctx.fillStyle = '#fff'; ctx.font='bold 48px system-ui'; ctx.textAlign='center';
@@ -96,5 +148,5 @@ export function boot() {
     ctx.font='24px system-ui';
     ctx.fillText(`Score: ${score}`, W/2, H/2 + 26);
   }
-  addEventListener('beforeunload', ()=>cancelAnimationFrame(raf));
+  addEventListener('beforeunload', ()=>stopLoop());
 }

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -97,6 +97,9 @@ let ghost;
 let showGhost=localStorage.getItem('tetris:ghost')!=='0';
 let score=0, level=1, lines=0, over=false, dropMs=700, last=0, paused=false;
 let lockTimer=0; const LOCK_DELAY=0.5; let lastFrame=0;
+let shellPaused=false;
+let pausedByShell=false;
+let rafId=0;
 let clearAnim=0, clearRows=[];
 let bgShift=0;
 let combo=-1;
@@ -422,6 +425,7 @@ c.addEventListener('pointerup',e=>{
 
 
 function loop(ts){
+  if(shellPaused){ rafId=0; return; }
   if(!last) last=ts;
   if(!lastFrame) lastFrame=ts;
   const dt=Math.min((ts-lastFrame)/1000,0.05);
@@ -459,14 +463,51 @@ function loop(ts){
   ctx.clearRect(0,0,c.width,c.height);
   draw();
   if(bc && mode==='play') bc.postMessage({grid,cur,nextM,holdM,score,level,lines,over,paused,started,showGhost});
-  requestAnimationFrame(loop);
+  rafId=requestAnimationFrame(loop);
 }
 
+function startLoop(){ if(!rafId) rafId=requestAnimationFrame(loop); }
+
+function pauseForShell(){
+  if(shellPaused) return;
+  if(!over && !paused){ paused=true; pausedByShell=true; }
+  shellPaused=true;
+  if(rafId){ cancelAnimationFrame(rafId); rafId=0; }
+}
+
+function resumeFromShell(){
+  if(!shellPaused || document.hidden) return;
+  shellPaused=false;
+  if(pausedByShell && !over){
+    paused=false;
+    pausedByShell=false;
+    last=performance.now();
+    lastFrame=0;
+  } else {
+    pausedByShell=false;
+  }
+  startLoop();
+}
+
+const onShellPause=()=>pauseForShell();
+const onShellResume=()=>resumeFromShell();
+const onVisibility=()=>{ if(document.hidden) pauseForShell(); else resumeFromShell(); };
+const onShellMessage=(event)=>{
+  const data=event && typeof event.data==='object' ? event.data : null;
+  const type=data?.type;
+  if(type==='GAME_PAUSE' || type==='GG_PAUSE') pauseForShell();
+  if(type==='GAME_RESUME' || type==='GG_RESUME') resumeFromShell();
+};
+window.addEventListener('ggshell:pause', onShellPause);
+window.addEventListener('ggshell:resume', onShellResume);
+document.addEventListener('visibilitychange', onVisibility);
+window.addEventListener('message', onShellMessage, {passive:true});
+
 if(mode==='replay'){
-  Replay.load(`./replays/${replayFile}`).then(()=>{initGame();started=true;requestAnimationFrame(loop);if(typeof reportReady==='function') reportReady('tetris');});
+  Replay.load(`./replays/${replayFile}`).then(()=>{initGame();started=true;startLoop();if(typeof reportReady==='function') reportReady('tetris');});
 }else{
   initGame();
   if(mode==='spectate') started=true;
-  requestAnimationFrame(loop);
+  startLoop();
   if(typeof reportReady==='function') reportReady('tetris');
 }

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -1,16 +1,46 @@
 export class GameEngine {
-  constructor({ fps = 60 } = {}) {
+  constructor({ fps = 60, autoPause = true } = {}) {
     this.fps = fps;
     this.dt = 1000 / fps;
     this.acc = 0;
     this.last = 0;
     this.rafId = null;
     this.running = false;
+    this._autoPauseEnabled = autoPause !== false;
+    this._autoPauseActive = false;
+    this._autoPauseWasRunning = false;
+
+    if (this._autoPauseEnabled) {
+      this._handleShellPause = () => { this._pauseForShell(); };
+      this._handleShellResume = () => { this._resumeForShell(); };
+      this._handleVisibility = () => {
+        if (document?.hidden) {
+          this._pauseForShell();
+        } else {
+          this._resumeForShell();
+        }
+      };
+      this._handleMessage = (event) => {
+        const data = event && typeof event.data === 'object' ? event.data : null;
+        const type = data?.type;
+        if (type === 'GAME_PAUSE' || type === 'GG_PAUSE') {
+          this._pauseForShell();
+        } else if (type === 'GAME_RESUME' || type === 'GG_RESUME') {
+          this._resumeForShell();
+        }
+      };
+      window.addEventListener('ggshell:pause', this._handleShellPause);
+      window.addEventListener('ggshell:resume', this._handleShellResume);
+      document.addEventListener('visibilitychange', this._handleVisibility, { passive: true });
+      window.addEventListener('message', this._handleMessage, { passive: true });
+    }
   }
 
   start() {
     if (this.running) return;
     this.running = true;
+    this._autoPauseActive = false;
+    this._autoPauseWasRunning = false;
     this.last = performance.now();
     const loop = (t) => {
       if (!this.running) return;
@@ -31,6 +61,27 @@ export class GameEngine {
     if (this.rafId !== null) {
       cancelAnimationFrame(this.rafId);
       this.rafId = null;
+    }
+  }
+
+  _pauseForShell() {
+    if (!this._autoPauseEnabled) return;
+    if (!this.running) return;
+    this._autoPauseActive = true;
+    this._autoPauseWasRunning = true;
+    this.stop();
+  }
+
+  _resumeForShell() {
+    if (!this._autoPauseEnabled) return;
+    if (document?.hidden) return;
+    if (!this._autoPauseActive) return;
+    this._autoPauseActive = false;
+    if (this._autoPauseWasRunning && !this.running) {
+      this._autoPauseWasRunning = false;
+      this.start();
+    } else {
+      this._autoPauseWasRunning = false;
     }
   }
 


### PR DESCRIPTION
## Summary
- dispatch ggshell pause/resume events from the shared game shell and hook GameEngine into visibility messages
- add shell pause/resume handlers to the main loops for Pong, Runner, Platformer, Maze3D, Shooter, Tetris, and Chess3D
- keep shell overlays accurate by respecting visibility-driven pause state across game UIs

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d56789b60c8327a4ca4d38b6868134