### PR TITLE
Preload critical assets and surface load failures

### DIFF
--- a/data/games-offline.js
+++ b/data/games-offline.js
@@ -10,7 +10,18 @@ export const games = [
     ],
     "difficulty": "easy",
     "released": "2025-08-20",
-    "playUrl": "/games/pong/"
+    "playUrl": "/games/pong/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/paddle.png",
+        "/assets/sprites/ball.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "snake",
@@ -22,7 +33,17 @@ export const games = [
     ],
     "difficulty": "easy",
     "released": "2025-08-25",
-    "playUrl": "/games/snake/"
+    "playUrl": "/games/snake/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "tetris",
@@ -34,7 +55,14 @@ export const games = [
     ],
     "difficulty": "medium",
     "released": "2025-08-26",
-    "playUrl": "/games/tetris/"
+    "playUrl": "/games/tetris/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "breakout",
@@ -46,7 +74,19 @@ export const games = [
     ],
     "difficulty": "medium",
     "released": "2025-08-26",
-    "playUrl": "/games/breakout/"
+    "playUrl": "/games/breakout/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/paddle.png",
+        "/assets/sprites/brick.png",
+        "/assets/sprites/ball.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "chess",
@@ -58,7 +98,12 @@ export const games = [
     ],
     "difficulty": "hard",
     "released": "2025-08-20",
-    "playUrl": "/games/chess/"
+    "playUrl": "/games/chess/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "chess3d",
@@ -70,7 +115,12 @@ export const games = [
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/chess3d/"
+    "playUrl": "/games/chess3d/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "g2048",
@@ -82,7 +132,12 @@ export const games = [
     ],
     "difficulty": "medium",
     "released": "2025-08-20",
-    "playUrl": "/games/2048/"
+    "playUrl": "/games/2048/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "asteroids",
@@ -94,7 +149,17 @@ export const games = [
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/asteroids/"
+    "playUrl": "/games/asteroids/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/ship.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/explode.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "maze3d",
@@ -105,7 +170,12 @@ export const games = [
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/maze3d/"
+    "playUrl": "/games/maze3d/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "platformer",
@@ -116,7 +186,16 @@ export const games = [
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/platformer/"
+    "playUrl": "/games/platformer/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "runner",
@@ -127,7 +206,17 @@ export const games = [
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/runner/"
+    "playUrl": "/games/runner/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "shooter",
@@ -138,7 +227,16 @@ export const games = [
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/shooter/"
+    "playUrl": "/games/shooter/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/ship.png"
+      ],
+      "audio": [
+        "/assets/audio/explode.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   }
 ];
 export default games;

--- a/games.json
+++ b/games.json
@@ -9,7 +9,18 @@
     ],
     "difficulty": "easy",
     "released": "2025-08-20",
-    "playUrl": "/games/pong/"
+    "playUrl": "/games/pong/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/paddle.png",
+        "/assets/sprites/ball.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "snake",
@@ -21,7 +32,17 @@
     ],
     "difficulty": "easy",
     "released": "2025-08-25",
-    "playUrl": "/games/snake/"
+    "playUrl": "/games/snake/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "tetris",
@@ -33,7 +54,14 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-26",
-    "playUrl": "/games/tetris/"
+    "playUrl": "/games/tetris/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "breakout",
@@ -45,7 +73,19 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-26",
-    "playUrl": "/games/breakout/"
+    "playUrl": "/games/breakout/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/paddle.png",
+        "/assets/sprites/brick.png",
+        "/assets/sprites/ball.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "chess",
@@ -57,7 +97,12 @@
     ],
     "difficulty": "hard",
     "released": "2025-08-20",
-    "playUrl": "/games/chess/"
+    "playUrl": "/games/chess/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "chess3d",
@@ -69,7 +114,12 @@
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/chess3d/"
+    "playUrl": "/games/chess3d/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "g2048",
@@ -81,7 +131,12 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-20",
-    "playUrl": "/games/2048/"
+    "playUrl": "/games/2048/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "asteroids",
@@ -93,7 +148,17 @@
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/asteroids/"
+    "playUrl": "/games/asteroids/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/ship.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/explode.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "maze3d",
@@ -104,7 +169,12 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/maze3d/"
+    "playUrl": "/games/maze3d/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "platformer",
@@ -115,7 +185,16 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/platformer/"
+    "playUrl": "/games/platformer/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "runner",
@@ -126,7 +205,17 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/runner/"
+    "playUrl": "/games/runner/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "shooter",
@@ -137,6 +226,15 @@
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/shooter/"
+    "playUrl": "/games/shooter/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/ship.png"
+      ],
+      "audio": [
+        "/assets/audio/explode.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   }
 ]

--- a/public/games.json
+++ b/public/games.json
@@ -9,7 +9,18 @@
     ],
     "difficulty": "easy",
     "released": "2025-08-20",
-    "playUrl": "/games/pong/"
+    "playUrl": "/games/pong/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/paddle.png",
+        "/assets/sprites/ball.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "snake",
@@ -21,7 +32,17 @@
     ],
     "difficulty": "easy",
     "released": "2025-08-25",
-    "playUrl": "/games/snake/"
+    "playUrl": "/games/snake/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "tetris",
@@ -33,7 +54,14 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-26",
-    "playUrl": "/games/tetris/"
+    "playUrl": "/games/tetris/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "breakout",
@@ -45,7 +73,19 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-26",
-    "playUrl": "/games/breakout/"
+    "playUrl": "/games/breakout/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/paddle.png",
+        "/assets/sprites/brick.png",
+        "/assets/sprites/ball.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "chess",
@@ -57,7 +97,12 @@
     ],
     "difficulty": "hard",
     "released": "2025-08-20",
-    "playUrl": "/games/chess/"
+    "playUrl": "/games/chess/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "chess3d",
@@ -69,7 +114,12 @@
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/chess3d/"
+    "playUrl": "/games/chess3d/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "g2048",
@@ -81,7 +131,12 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-20",
-    "playUrl": "/games/2048/"
+    "playUrl": "/games/2048/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "asteroids",
@@ -93,7 +148,17 @@
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/asteroids/"
+    "playUrl": "/games/asteroids/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/ship.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/explode.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "maze3d",
@@ -104,7 +169,12 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/maze3d/"
+    "playUrl": "/games/maze3d/",
+    "firstFrame": {
+      "audio": [
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "platformer",
@@ -115,7 +185,16 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/platformer/"
+    "playUrl": "/games/platformer/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   },
   {
     "id": "runner",
@@ -126,7 +205,17 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-27",
-    "playUrl": "/games/runner/"
+    "playUrl": "/games/runner/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/coin.png"
+      ],
+      "audio": [
+        "/assets/audio/hit.wav",
+        "/assets/audio/powerup.wav",
+        "/assets/audio/click.wav"
+      ]
+    }
   },
   {
     "id": "shooter",
@@ -137,6 +226,15 @@
     ],
     "difficulty": "hard",
     "released": "2025-08-27",
-    "playUrl": "/games/shooter/"
+    "playUrl": "/games/shooter/",
+    "firstFrame": {
+      "sprites": [
+        "/assets/sprites/ship.png"
+      ],
+      "audio": [
+        "/assets/audio/explode.wav",
+        "/assets/audio/powerup.wav"
+      ]
+    }
   }
 ]

--- a/shared/game-asset-preloader.js
+++ b/shared/game-asset-preloader.js
@@ -1,0 +1,148 @@
+import { getGameById } from './game-catalog.js';
+
+const reportedFailures = new Set();
+
+function normalizeList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') return value.split(/[,\s]+/).filter(Boolean);
+  return [];
+}
+
+function ensureLink(href, as) {
+  if (!href || !as || typeof document === 'undefined') return;
+  const existing = document.head.querySelector(`link[rel="preload"][href="${href}"]`);
+  if (existing) return;
+  const link = document.createElement('link');
+  link.rel = 'preload';
+  link.as = as;
+  link.href = href;
+  if (as === 'audio') link.crossOrigin = 'anonymous';
+  document.head.appendChild(link);
+}
+
+function toAbsoluteUrl(url) {
+  try {
+    return new URL(url, document.baseURI).href;
+  } catch (_) {
+    return url;
+  }
+}
+
+function reportAssetError(slug, url, err) {
+  const key = `${slug}|${url}`;
+  if (reportedFailures.has(key)) return;
+  reportedFailures.add(key);
+  const message = `[assets] failed to load ${url}: ${err?.message || err || 'unknown error'}`;
+  console.error(message);
+  try {
+    window.parent?.postMessage?.({
+      type: 'GAME_ERROR',
+      slug,
+      message: `First-frame asset failed to load: ${url}`
+    }, '*');
+  } catch (_) {}
+}
+
+function loadImage(url, slug) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.decoding = 'async';
+    img.referrerPolicy = 'no-referrer';
+    const done = () => {
+      cleanup();
+      resolve();
+    };
+    const fail = (event) => {
+      cleanup();
+      const err = event?.error || new Error('image load error');
+      reportAssetError(slug, url, err);
+      reject(err);
+    };
+    function cleanup() {
+      img.removeEventListener('load', done);
+      img.removeEventListener('error', fail);
+    }
+    img.addEventListener('load', done, { once: true });
+    img.addEventListener('error', fail, { once: true });
+    img.src = url;
+  });
+}
+
+function loadAudio(url, slug) {
+  return new Promise((resolve, reject) => {
+    try {
+      const audio = new Audio();
+      audio.preload = 'auto';
+      const done = () => {
+        cleanup();
+        resolve();
+      };
+      const fail = () => {
+        const err = new Error('audio load error');
+        cleanup();
+        reportAssetError(slug, url, err);
+        reject(err);
+      };
+      function cleanup() {
+        audio.removeEventListener('canplaythrough', done);
+        audio.removeEventListener('loadeddata', done);
+        audio.removeEventListener('error', fail);
+      }
+      audio.addEventListener('canplaythrough', done, { once: true });
+      audio.addEventListener('loadeddata', done, { once: true });
+      audio.addEventListener('error', fail, { once: true });
+      audio.src = url;
+      audio.load();
+    } catch (err) {
+      reportAssetError(slug, url, err);
+      reject(err);
+    }
+  });
+}
+
+function classifyAsset(url, hint) {
+  if (hint === 'audio' || /\.(mp3|ogg|wav|m4a)(\?.*)?$/i.test(url)) return 'audio';
+  if (hint === 'image' || /\.(png|jpg|jpeg|gif|webp|svg)(\?.*)?$/i.test(url)) return 'image';
+  return null;
+}
+
+export async function preloadFirstFrameAssets(slug) {
+  if (!slug) return;
+  let game = null;
+  try {
+    game = await getGameById(slug);
+  } catch (err) {
+    console.warn('[assets] unable to read catalog for slug', slug, err);
+  }
+  const meta = game?.firstFrame || game?.firstFrameAssets || null;
+  if (!meta) return;
+  const sprites = normalizeList(meta.sprites || meta.images);
+  const audio = normalizeList(meta.audio || meta.sounds);
+  const misc = normalizeList(meta.assets);
+  const pending = [];
+  const seen = new Set();
+  for (const raw of [...sprites, ...audio, ...misc]) {
+    const href = toAbsoluteUrl(raw);
+    const type = classifyAsset(href, sprites.includes(raw) ? 'image' : (audio.includes(raw) ? 'audio' : null));
+    if (!type) continue;
+    const key = `${type}|${href}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    ensureLink(href, type);
+    if (type === 'image') {
+      pending.push(loadImage(href, slug).catch(() => {}));
+    } else if (type === 'audio') {
+      pending.push(loadAudio(href, slug).catch(() => {}));
+    }
+  }
+  if (pending.length) {
+    try {
+      await Promise.allSettled(pending);
+    } catch (_) {
+      // handled per-asset
+    }
+  }
+}
+
+export default preloadFirstFrameAssets;

--- a/shared/game-boot.js
+++ b/shared/game-boot.js
@@ -3,6 +3,7 @@
 import { injectBackButton, injectHelpButton, recordLastPlayed } from './ui.js';
 import { recordPlay } from './quests.js';
 import { renderFallbackPanel } from './fallback.js';
+import { preloadFirstFrameAssets } from './game-asset-preloader.js';
 
 const currentScript = document.currentScript;
 const pathSegments = (new URL(location.href)).pathname.split('/').filter(Boolean);
@@ -13,6 +14,7 @@ const slug = currentScript?.dataset?.slug || urlSlug || 'unknown';
 injectBackButton('/');
 injectHelpButton({ gameId: slug, ...(window.helpData || { steps: window.helpSteps || [] }) });
 recordLastPlayed(slug);
+preloadFirstFrameAssets(slug);
 
 async function track(){
   let tags = [];


### PR DESCRIPTION
## Summary
- add a shared first-frame asset preloader that injects `<link rel="preload">` tags and reports friendly `GAME_ERROR`s when a preload fails
- wire the game boot helper to invoke the preloader and extend both online/offline game catalogs with first-frame audio/sprite metadata so every shell has the same hints

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d5757e05a48327988169bcb499d454