### PR TITLE
Enhance game shell helpers and add runtime tests

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -417,7 +417,7 @@
   <script src="../../js/remapUI.js"></script>
   <script src="../../js/perfHud.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="2048"></script>
-  <script type="module" src="../common/game-shell.js" data-game="g2048" data-apply-theme="false" data-focus-target="#board"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="g2048" data-apply-theme="false" data-focus-target="#board"></script>
 
 <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
 <script>

--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -32,7 +32,7 @@
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/game-boot.js" data-slug="asteroids"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="asteroids"></script>
-  <script type="module" src="../common/game-shell.js" data-game="asteroids"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="asteroids"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -31,7 +31,7 @@
   <script src="../../shared/leaderboard.js"></script>
   <script type="module" src="./breakout.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="breakout"></script>
-  <script type="module" src="../common/game-shell.js" data-game="breakout"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="breakout"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -87,7 +87,7 @@
   <script src="../../js/remapUI.js?v=5.3"></script>
   <script src="../../js/perfHud.js?v=5.3"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess"></script>
-  <script type="module" src="../common/game-shell.js" data-game="chess" data-apply-theme="false"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="chess" data-apply-theme="false"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -60,7 +60,7 @@
   <script src="../../js/sfx.js"></script>
   <script src="../../js/hud.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess3d"></script>
-  <script type="module" src="../common/game-shell.js" data-game="chess3d" data-apply-theme="false"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="chess3d" data-apply-theme="false"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/common/game-shell.css
+++ b/games/common/game-shell.css
@@ -47,11 +47,47 @@ body.game-shell::after {
   justify-self: stretch;
 }
 
-.game-shell__surface {
+.game-shell__surface { 
   display: grid;
   place-items: center;
   gap: 24px;
   width: min(100%, 960px);
+}
+
+.game-shell__controls {
+  width: min(100%, 720px);
+  background: rgba(15, 19, 32, 0.9);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 12px 18px;
+  color: #e4e6ed;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+}
+
+.game-shell__controls-details {
+  font-size: 0.95rem;
+}
+
+.game-shell__controls-details > summary {
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.game-shell__controls-list {
+  margin: 12px 0 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 4px;
+  font-size: 0.9rem;
+}
+
+.game-shell__controls-list kbd {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 2px 6px;
+  font-size: 0.85em;
 }
 
 .game-shell__surface > canvas,

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -99,7 +99,7 @@
   <script type="module" src="/js/three-global-shim.js" data-three-version="0.161.0"></script>
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="maze3d"></script>
-  <script type="module" src="../common/game-shell.js" data-game="maze3d" data-apply-theme="false"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="maze3d" data-apply-theme="false"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -120,7 +120,7 @@
 
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="platformer"></script>
-  <script type="module" src="../common/game-shell.js" data-game="platformer"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="platformer"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -14,7 +14,7 @@
       try { window.parent && window.parent.postMessage({type:'IFRAME_LOADED', slug:'pong'}, '*'); } catch(e){}
     </script>
     <script src="./pong.js" defer></script>
-    <script type="module" src="../common/game-shell.js" data-game="pong" data-apply-theme="false" data-focus-target="#app"></script>
+    <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="pong" data-apply-theme="false" data-focus-target="#app"></script>
 
     <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
     <script>

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -136,7 +136,7 @@
   <script type="module" src="./editor.js"></script>
   <script type="module" src="../../shared/game-boot.js" data-slug="runner"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="runner"></script>
-  <script type="module" src="../common/game-shell.js" data-game="runner" data-apply-theme="false"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="runner" data-apply-theme="false"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -165,7 +165,7 @@
 
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="shooter"></script>
-  <script type="module" src="../common/game-shell.js" data-game="shooter"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="shooter"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -110,7 +110,7 @@
   <script src="../../js/sfx.js"></script>
   <script type="module" src="./snake.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="snake"></script>
-  <script type="module" src="../common/game-shell.js" data-game="snake"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="snake"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -73,7 +73,7 @@
       document.getElementById('replayList').innerHTML = '<li>No replays</li>';
     });
   </script>
-  <script type="module" src="../common/game-shell.js" data-game="tetris"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="tetris"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/tests/game-shell.runtime.test.js
+++ b/tests/game-shell.runtime.test.js
@@ -1,0 +1,75 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const importShell = async (options = {}) => {
+  const { slug = 'pong', preload = '' } = options;
+  vi.resetModules();
+  document.body.className = 'game-shell';
+  document.body.innerHTML = `
+    <main class="game-shell__main">
+      <div class="game-shell__surface">
+        <canvas id="game"></canvas>
+        <div id="hud"><span id="score" data-game-score>0</span></div>
+      </div>
+    </main>
+  `;
+  Object.defineProperty(document, 'currentScript', {
+    value: {
+      dataset: {
+        game: slug,
+        preloadFirst: preload,
+        backHref: '/index.html',
+      },
+    },
+    configurable: true,
+  });
+  const postMessage = vi.fn();
+  Object.defineProperty(window, 'parent', {
+    value: { postMessage },
+    configurable: true,
+  });
+  window.fitCanvasToParent = vi.fn();
+  await import('../games/common/game-shell.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await Promise.resolve();
+  await Promise.resolve();
+  return { postMessage };
+};
+
+describe('game-shell runtime integration', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('injects a controls overlay when mounted', async () => {
+    await importShell();
+    const overlay = await vi.waitFor(() => {
+      const node = document.querySelector('[data-gg-controls-overlay]');
+      expect(node).toBeTruthy();
+      return node;
+    });
+    expect(overlay.querySelector('.game-shell__controls-list')).toBeTruthy();
+    expect(window.fitCanvasToParent).toHaveBeenCalled();
+  });
+
+  it('emits GAME_SCORE messages when the score node changes', async () => {
+    const { postMessage } = await importShell();
+    postMessage.mockClear();
+    window.GGShellEmitScore(42);
+    expect(postMessage).toHaveBeenLastCalledWith({ type: 'GAME_SCORE', slug: 'pong', score: 42 }, '*');
+  });
+
+  it('exposes a visibility helper that binds pause/resume listeners', async () => {
+    await importShell();
+    const pause = vi.fn();
+    const resume = vi.fn();
+    const dispose = window.GGShellVisibility.bind({ onPause: pause, onResume: resume });
+    window.dispatchEvent(new CustomEvent('ggshell:pause'));
+    window.dispatchEvent(new CustomEvent('ggshell:resume'));
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(resume).toHaveBeenCalledTimes(1);
+    dispose();
+    window.dispatchEvent(new CustomEvent('ggshell:pause'));
+    expect(pause).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- enhance the shared game shell to post pause/resume signals, emit score updates, auto-fit canvases, inject a reusable Controls overlay, expose a visibility helper, and preload flagged assets
- add styling for the new controls overlay and attach the shell script with a default back link across game pages
- add jsdom runtime tests covering overlay injection, score emission helper, and visibility helper bindings

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d57590e3a483278e83292c78026a11