### PR TITLE
Add diagnostics autowire to game pages

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -419,7 +419,8 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="2048"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="g2048" data-apply-theme="false" data-focus-target="#board"></script>
 
-<!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script src="../common/diag-autowire.js" data-game="2048"></script>
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
 <script>
 (function(){
   if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;

--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -34,6 +34,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="asteroids"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="asteroids"></script>
 
+  <script src="../common/diag-autowire.js" data-game="asteroids"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -33,6 +33,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="breakout"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="breakout"></script>
 
+  <script src="../common/diag-autowire.js" data-game="breakout"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -89,6 +89,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="chess" data-apply-theme="false"></script>
 
+  <script src="../common/diag-autowire.js" data-game="chess"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -62,6 +62,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess3d"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="chess3d" data-apply-theme="false"></script>
 
+  <script src="../common/diag-autowire.js" data-game="chess3d"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -101,6 +101,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="maze3d"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="maze3d" data-apply-theme="false"></script>
 
+  <script src="../common/diag-autowire.js" data-game="maze3d"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -122,6 +122,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="platformer"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="platformer"></script>
 
+  <script src="../common/diag-autowire.js" data-game="platformer"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -16,7 +16,8 @@
     <script src="./pong.js" defer></script>
     <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="pong" data-apply-theme="false" data-focus-target="#app"></script>
 
-    <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
+  <script src="../common/diag-autowire.js" data-game="pong"></script>
+  <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
     <script>
     (function(){
       if (window.__gg_autoSignalInstalled) return; window.__gg_autoSignalInstalled = true;

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -138,6 +138,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="runner"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="runner" data-apply-theme="false"></script>
 
+  <script src="../common/diag-autowire.js" data-game="runner"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -167,6 +167,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="shooter"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="shooter"></script>
 
+  <script src="../common/diag-autowire.js" data-game="shooter"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -112,6 +112,7 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="snake"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="snake"></script>
 
+  <script src="../common/diag-autowire.js" data-game="snake"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -75,6 +75,7 @@
   </script>
   <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="tetris"></script>
 
+  <script src="../common/diag-autowire.js" data-game="tetris"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){


### PR DESCRIPTION
## Summary
- load the diag-autowire helper on every individual game page so diagnostics are automatically enabled when the page loads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5b080e9d483278afa63b4e37c483f