### PR TITLE
Add shared pause overlay utilities and unify clearing logic

### DIFF
--- a/games/pong/pauseOverlay.js
+++ b/games/pong/pauseOverlay.js
@@ -1,6 +1,20 @@
 (function (global) {
   if (typeof document === 'undefined') return;
-  function createPauseOverlay(opts = {}) {
+
+  const gameUI = global.gameUI = global.gameUI || {};
+
+  function localCreatePauseOverlay(opts = {}) {
+    const overlay = (global.pauseOverlay && typeof global.pauseOverlay.createPauseOverlay === 'function')
+      ? global.pauseOverlay.createPauseOverlay({
+          ...opts,
+          gameId: 'pong',
+          hint: opts.hint || 'Press Esc or P to resume'
+        })
+      : createFallbackOverlay(opts);
+    return overlay;
+  }
+
+  function createFallbackOverlay(opts = {}) {
     const { onResume, onRestart } = opts;
     const existing = document.querySelector('.pause-overlay[data-game="pong"]');
     if (existing) existing.remove();
@@ -12,9 +26,7 @@
     overlay.innerHTML = `
       <div class="panel" role="document">
         <h3 style="margin:0 0 12px 0; font: 700 18px Inter,system-ui">Paused</h3>
-        <p class="hint" style="margin:0 0 16px 0; font:500 14px/1.4 Inter,system-ui; color:var(--muted,#9aa0a6);">
-          Press Esc or P to resume
-        </p>
+        <p class="hint" style="margin:0 0 16px 0; font:500 14px/1.4 Inter,system-ui; color:var(--muted,#9aa0a6);">Press Esc or P to resume</p>
         <div style="display:flex; gap:10px; justify-content:center">
           <button type="button" class="btn" data-action="resume">Resume</button>
           <button type="button" class="btn" data-action="restart">Restart</button>
@@ -50,5 +62,6 @@
       }
     };
   }
-  global.PongPauseOverlay = { create: createPauseOverlay };
+
+  global.PongPauseOverlay = { create: localCreatePauseOverlay };
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/play.html
+++ b/play.html
@@ -22,6 +22,7 @@
 
   <!-- Universal loader (reads games.json and boots ?id=<slug>) -->
   <script src="js/game-loader.js"></script>
+  <script src="shared/pauseOverlay.js"></script>
   <script src="shared/force-unpause.js"></script>
 </body>
 </html>

--- a/shared/force-unpause.js
+++ b/shared/force-unpause.js
@@ -1,14 +1,37 @@
 
 // shared/force-unpause.js — runs inside iframe (play.html) to guarantee unpaused start
 (function(){
-  function clear(){
-    try{
-      document.querySelectorAll('.pause-overlay, #gg-pause-overlay, .gg-overlay.gg-pause, .modal-paused, #hud .paused, .hud-paused').forEach(el=>{
-        el.style.display='none'; el.classList.add('hidden'); el.setAttribute('aria-hidden','true');
+  const global = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : this;
+
+  function fallbackForceClear(){
+    try {
+      const nodes = document.querySelectorAll('.pause-overlay, #gg-pause-overlay, .gg-overlay.gg-pause, .modal-paused, #hud .paused, .hud-paused');
+      nodes.forEach(el => {
+        el.style.display = 'none';
+        el.classList.add('hidden');
+        el.setAttribute('aria-hidden', 'true');
       });
-      if (window.GG_HUD && typeof GG_HUD.hidePause==='function') GG_HUD.hidePause();
-    }catch{}
+      if (global.GG_HUD && typeof global.GG_HUD.hidePause === 'function') global.GG_HUD.hidePause();
+    } catch (err) {
+      // ignore errors in the fallback implementation
+    }
   }
-  clear(); setTimeout(clear, 100); setTimeout(clear, 350);
-  window.addEventListener('message', (e)=>{ const d=e.data||{}; if (d.type==='GAME_RESUME') clear(); });
+
+  const gameUI = global.gameUI = global.gameUI || {};
+  if (typeof gameUI.forceClearPause !== 'function') {
+    gameUI.forceClearPause = fallbackForceClear;
+  }
+
+  function clear(){
+    try {
+      gameUI.forceClearPause();
+    } catch (err) {
+      fallbackForceClear();
+    }
+  }
+
+  clear();
+  setTimeout(clear, 100);
+  setTimeout(clear, 350);
+  global.addEventListener('message', (e)=>{ const d=e.data||{}; if (d.type==='GAME_RESUME') clear(); });
 })();

--- a/shared/game-ui.js
+++ b/shared/game-ui.js
@@ -138,6 +138,16 @@ import { resolveGamePaths } from './game-paths.js';
   };
 
   function clearAnyPause(){
+    const gameUI = window.gameUI = window.gameUI || {};
+    if (typeof gameUI.forceClearPause === 'function') {
+      try {
+        gameUI.forceClearPause({ pausedEl: $paused, pauseButton: $pauseButton, document });
+        return;
+      } catch (err) {
+        // fall back to legacy logic below
+      }
+    }
+
     try {
       if (!document.getElementById('gg-pause-kill-style')){
         const style = document.createElement('style');

--- a/shared/pauseOverlay.js
+++ b/shared/pauseOverlay.js
@@ -1,0 +1,169 @@
+(function (global) {
+  const g = global || (typeof globalThis !== 'undefined' ? globalThis : {});
+  const doc = g.document;
+  const SELECTORS = [
+    '.pause-overlay',
+    '#gg-pause-overlay',
+    '.gg-overlay.gg-pause',
+    '.modal-paused',
+    '#hud .paused',
+    '.hud-paused'
+  ];
+  const joinedSelectors = SELECTORS.join(',');
+
+  function ensureKillStyle(targetDoc) {
+    const d = targetDoc || doc;
+    if (!d || !d.head) return null;
+    const existing = d.getElementById('gg-pause-kill-style');
+    if (existing) return existing;
+    const style = d.createElement('style');
+    style.id = 'gg-pause-kill-style';
+    style.textContent = `
+      ${SELECTORS.join(',\n      ')} {
+        display: none !important;
+        visibility: hidden !important;
+        opacity: 0 !important;
+      }
+    `;
+    d.head.appendChild(style);
+    return style;
+  }
+
+  function hideElement(el) {
+    if (!el) return;
+    el.style.display = 'none';
+    el.classList.add('hidden');
+    if (typeof el.setAttribute === 'function') {
+      el.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  function forceClearPause(options) {
+    const opts = options || {};
+    const d = opts.document || doc;
+    if (!d) return;
+    const root = opts.root || d;
+    const selectors = opts.selectors || joinedSelectors;
+    ensureKillStyle(d);
+    try {
+      const nodes = typeof selectors === 'string'
+        ? root.querySelectorAll(selectors)
+        : root.querySelectorAll((selectors || []).join(','));
+      nodes.forEach(hideElement);
+    } catch (err) {
+      // ignore selector issues
+    }
+
+    const pausedEl = opts.pausedEl || (typeof d.getElementById === 'function' ? d.getElementById('gg-paused') : null);
+    if (pausedEl) {
+      pausedEl.setAttribute('hidden', '');
+      hideElement(pausedEl);
+    }
+
+    const pauseBtn = opts.pauseButton || (typeof d.getElementById === 'function' ? d.getElementById('gg-pause') : null);
+    if (pauseBtn && typeof pauseBtn.setAttribute === 'function') {
+      pauseBtn.setAttribute('aria-pressed', 'false');
+    }
+
+    try {
+      const hud = g.GG_HUD;
+      if (hud && typeof hud.hidePause === 'function') {
+        hud.hidePause();
+      }
+    } catch (err) {
+      // ignore hud errors
+    }
+
+    if (typeof opts.onClear === 'function') {
+      try { opts.onClear(); } catch (err) {}
+    }
+  }
+
+  function createPauseOverlay(opts) {
+    if (!doc) return null;
+    const options = opts || {};
+    const existingSelector = options.selector || '.pause-overlay';
+    try {
+      const previous = doc.querySelector(existingSelector + (options.gameId ? `[data-game="${options.gameId}"]` : ''));
+      if (previous && typeof previous.remove === 'function') previous.remove();
+    } catch (err) {}
+
+    const overlay = doc.createElement('div');
+    overlay.className = 'pause-overlay hidden';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    if (options.gameId) overlay.setAttribute('data-game', String(options.gameId));
+
+    const heading = options.heading || 'Paused';
+    const hint = options.hint || 'Press Esc or P to resume';
+    const resumeLabel = options.resumeLabel || 'Resume';
+    const restartLabel = options.restartLabel || 'Restart';
+
+    overlay.innerHTML = `
+      <div class="panel" role="document">
+        <h3 style="margin:0 0 12px 0; font: 700 18px Inter,system-ui">${heading}</h3>
+        <p class="hint" style="margin:0 0 16px 0; font:500 14px/1.4 Inter,system-ui; color:var(--muted,#9aa0a6);">${hint}</p>
+        <div style="display:flex; gap:10px; justify-content:center">
+          <button type="button" class="btn" data-action="resume">${resumeLabel}</button>
+          <button type="button" class="btn" data-action="restart">${restartLabel}</button>
+        </div>
+      </div>`;
+
+    const attach = () => {
+      (doc.body || doc.documentElement).appendChild(overlay);
+    };
+    if (doc.body) attach();
+    else doc.addEventListener('DOMContentLoaded', attach, { once: true });
+
+    const resumeBtn = overlay.querySelector('[data-action="resume"]');
+    const restartBtn = overlay.querySelector('[data-action="restart"]');
+    const hintEl = overlay.querySelector('.hint');
+
+    function hide() { overlay.classList.add('hidden'); }
+    function show() {
+      overlay.classList.remove('hidden');
+      if (resumeBtn && typeof resumeBtn.focus === 'function') resumeBtn.focus();
+    }
+
+    resumeBtn?.addEventListener('click', () => {
+      hide();
+      if (typeof options.onResume === 'function') options.onResume();
+    });
+
+    restartBtn?.addEventListener('click', () => {
+      hide();
+      if (typeof options.onRestart === 'function') options.onRestart();
+    });
+
+    return {
+      show,
+      hide,
+      element: overlay,
+      setHint(text) {
+        if (hintEl && typeof text === 'string') hintEl.textContent = text;
+      }
+    };
+  }
+
+  const api = {
+    createPauseOverlay,
+    forceClearPause,
+    ensurePauseOverlayStyle: ensureKillStyle,
+    selectors: SELECTORS.slice()
+  };
+
+  const gameUI = g.gameUI = g.gameUI || {};
+  gameUI.forceClearPause = forceClearPause;
+  gameUI.createPauseOverlay = createPauseOverlay;
+  gameUI.ensurePauseOverlayStyle = ensureKillStyle;
+
+  g.pauseOverlay = Object.assign(g.pauseOverlay || {}, api);
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  if (typeof define === 'function' && define.amd) {
+    define(() => api);
+  }
+})(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- add a shared pauseOverlay.js helper that exposes gameUI.forceClearPause and createPauseOverlay
- update the force-unpause shim and shell UI to call the shared helper while keeping fallbacks
- load the shared script in play.html and route the Pong pause overlay wrapper through it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5b095a71c83278901ca468f219d8b