### PR TITLE
Normalize game shells

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>2048</title>
+  <link rel="preload" href="../../assets/audio/click.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <link rel="stylesheet" href="../../css/styles.css">
   <style>
@@ -417,7 +418,7 @@
   <script src="../../js/remapUI.js"></script>
   <script src="../../js/perfHud.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="2048"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="g2048" data-apply-theme="false" data-focus-target="#board"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="g2048" data-apply-theme="false" data-focus-target="#board"></script>
 
   <script src="../common/diag-autowire.js" data-game="2048"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Asteroids Pro</title>
+  <link rel="preload" href="../../assets/sprites/ship.png" as="image" />
+  <link rel="preload" href="../../assets/audio/hit.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/explode.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     :root {
@@ -32,7 +36,7 @@
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/game-boot.js" data-slug="asteroids"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="asteroids"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="asteroids"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="asteroids"></script>
 
   <script src="../common/diag-autowire.js" data-game="asteroids"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -4,6 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Breakout</title>
+  <link rel="preload" href="../../assets/sprites/paddle.png" as="image" />
+  <link rel="preload" href="../../assets/sprites/brick.png" as="image" />
+  <link rel="preload" href="../../assets/sprites/ball.png" as="image" />
+  <link rel="preload" href="../../assets/audio/hit.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/click.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     canvas {
@@ -31,7 +37,7 @@
   <script src="../../shared/leaderboard.js"></script>
   <script type="module" src="./breakout.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="breakout"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="breakout"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="breakout"></script>
 
   <script src="../common/diag-autowire.js" data-game="breakout"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Chess</title>
+  <link rel="preload" href="../../assets/audio/click.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <link rel="stylesheet" href="../../css/styles.css?v=5.3" />
   <style>
@@ -87,7 +88,7 @@
   <script src="../../js/remapUI.js?v=5.3"></script>
   <script src="../../js/perfHud.js?v=5.3"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="chess" data-apply-theme="false"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="chess" data-apply-theme="false"></script>
 
   <script src="../common/diag-autowire.js" data-game="chess"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Chess 3D</title>
+  <link rel="preload" href="../../assets/audio/click.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
-  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="stylesheet" href="../../css/styles.css" />
   <style>
     body {
       margin: 0;
@@ -60,7 +61,7 @@
   <script src="../../js/sfx.js"></script>
   <script src="../../js/hud.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess3d"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="chess3d" data-apply-theme="false"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="chess3d" data-apply-theme="false"></script>
 
   <script src="../common/diag-autowire.js" data-game="chess3d"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3D Maze</title>
+  <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     body {
@@ -96,10 +97,10 @@
     </div>
   </div>
 
-  <script type="module" src="/js/three-global-shim.js" data-three-version="0.161.0"></script>
+  <script type="module" src="../../js/three-global-shim.js" data-three-version="0.161.0"></script>
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="maze3d"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="maze3d" data-apply-theme="false"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="maze3d" data-apply-theme="false"></script>
 
   <script src="../common/diag-autowire.js" data-game="maze3d"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Retro Platformer</title>
+  <link rel="preload" href="../../assets/sprites/coin.png" as="image" />
+  <link rel="preload" href="../../assets/audio/hit.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     body {
@@ -120,7 +123,7 @@
 
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="platformer"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="platformer"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="platformer"></script>
 
   <script src="../common/diag-autowire.js" data-game="platformer"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Pong • Gurjot’s Games</title>
     <link rel="preload" href="./pong.css" as="style" />
+    <link rel="preload" href="../../assets/sprites/paddle.png" as="image" />
+    <link rel="preload" href="../../assets/sprites/ball.png" as="image" />
+    <link rel="preload" href="../../assets/audio/hit.wav" as="audio" />
+    <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
+    <link rel="preload" href="../../assets/audio/click.wav" as="audio" />
     <link rel="stylesheet" href="../common/game-shell.css" />
     <link rel="stylesheet" href="./pong.css" />
   </head>
@@ -14,7 +19,7 @@
       try { window.parent && window.parent.postMessage({type:'IFRAME_LOADED', slug:'pong'}, '*'); } catch(e){}
     </script>
     <script src="./pong.js" defer></script>
-    <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="pong" data-apply-theme="false" data-focus-target="#app"></script>
+    <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="pong" data-apply-theme="false" data-focus-target="#app"></script>
 
   <script src="../common/diag-autowire.js" data-game="pong"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Runner Pro</title>
+  <link rel="preload" href="../../assets/sprites/coin.png" as="image" />
+  <link rel="preload" href="../../assets/audio/hit.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/click.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     :root { --fg:#eaeaf2; --bg:#0b0b0f; --accent:#6ee7b7; }
@@ -136,7 +140,7 @@
   <script type="module" src="./editor.js"></script>
   <script type="module" src="../../shared/game-boot.js" data-slug="runner"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="runner"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="runner" data-apply-theme="false"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="runner" data-apply-theme="false"></script>
 
   <script src="../common/diag-autowire.js" data-game="runner"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Space Shooter</title>
+  <link rel="preload" href="../../assets/sprites/ship.png" as="image" />
+  <link rel="preload" href="../../assets/audio/explode.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     body {
@@ -165,7 +168,7 @@
 
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="shooter"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="shooter"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="shooter"></script>
 
   <script src="../common/diag-autowire.js" data-game="shooter"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Snake+</title>
+  <link rel="preload" href="../../assets/sprites/coin.png" as="image" />
+  <link rel="preload" href="../../assets/audio/hit.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/click.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     :root {
@@ -110,7 +114,7 @@
   <script src="../../js/sfx.js"></script>
   <script type="module" src="./snake.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="snake"></script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="snake"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="snake"></script>
 
   <script src="../common/diag-autowire.js" data-game="snake"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Tetris Lobby</title>
+  <link rel="preload" href="../../assets/audio/hit.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/click.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     body {
@@ -73,7 +76,7 @@
       document.getElementById('replayList').innerHTML = '<li>No replays</li>';
     });
   </script>
-  <script type="module" src="../common/game-shell.js" data-back-href="/index.html" data-game="tetris"></script>
+  <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="tetris"></script>
 
   <script src="../common/diag-autowire.js" data-game="tetris"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->


### PR DESCRIPTION
## Summary
- add first-frame preload tags to each game entry so critical art and audio arrive with the shell
- switch game-shell includes and back links to relative paths for subdirectory hosting
- keep diagnostics auto-wiring consistent across games

## Testing
- npm run test:smoke


------
https://chatgpt.com/codex/tasks/task_e_68d5b4cbf1888327a421ae25353df635