### PR TITLE
Add diagnostics modal UI, core runtime, and capture hooks

### DIFF
--- a/games/common/diag-capture.js
+++ b/games/common/diag-capture.js
@@ -1,0 +1,394 @@
+/* Gurjot's Games — diag-capture.js
+   Instrumentation layer that forwards diagnostics to __GG_DIAG.
+*/
+(function(){
+  const global = typeof window !== "undefined" ? window : globalThis;
+  if (!global) return;
+
+  const queue = global.__GG_DIAG_QUEUE || (global.__GG_DIAG_QUEUE = []);
+
+  function emit(entry){
+    try {
+      if (global.__GG_DIAG && typeof global.__GG_DIAG.log === "function") {
+        global.__GG_DIAG.log(entry);
+      } else {
+        queue.push(entry);
+      }
+    } catch (err) {
+      queue.push({ category: "capture", level: "error", message: "emit failure", details: safeSerialize(err) });
+    }
+  }
+
+  function safeSerialize(value, seen = new WeakSet(), depth = 0){
+    const MAX_DEPTH = 4;
+    if (value === null || value === undefined) return value;
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: value.message,
+        stack: value.stack,
+      };
+    }
+    if (typeof value === "function") {
+      return `[Function${value.name ? ` ${value.name}` : ""}]`;
+    }
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value === "bigint") return `${value.toString()}n`;
+    if (typeof value === "symbol") return value.toString();
+    if (depth >= MAX_DEPTH) {
+      return `[Truncated depth ${depth}]`;
+    }
+    if (typeof value === "object") {
+      if (seen.has(value)) return "[Circular]";
+      seen.add(value);
+      if (Array.isArray(value)) {
+        return value.slice(0, 25).map((item) => safeSerialize(item, seen, depth + 1));
+      }
+      if (value instanceof HTMLElement) {
+        const tag = value.tagName?.toLowerCase() || "element";
+        const id = value.id ? `#${value.id}` : "";
+        const cls = value.className ? `.${String(value.className).replace(/\s+/g, ".")}` : "";
+        return `<${tag}${id}${cls}>`;
+      }
+      const output = {};
+      const keys = Object.keys(value).slice(0, 40);
+      for (const key of keys) {
+        try {
+          output[key] = safeSerialize(value[key], seen, depth + 1);
+        } catch (err) {
+          output[key] = `[Unserializable: ${err?.message || err}]`;
+        }
+      }
+      return output;
+    }
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (_) {
+      return String(value);
+    }
+  }
+
+  function coerceMessage(parts){
+    return parts.map((part) => {
+      if (typeof part === "string") return part;
+      try {
+        return JSON.stringify(safeSerialize(part));
+      } catch (_) {
+        return String(part);
+      }
+    }).join(" ");
+  }
+
+  function logConsole(level, args){
+    emit({
+      category: "console",
+      level,
+      message: coerceMessage(args),
+      details: { args: args.map((item) => safeSerialize(item)) },
+      timestamp: Date.now(),
+    });
+  }
+
+  function installConsoleHooks(){
+    const levels = ["log", "info", "warn", "error", "debug"];
+    for (const level of levels){
+      const original = global.console?.[level];
+      if (typeof original !== "function") continue;
+      global.console[level] = function(...args){
+        try {
+          logConsole(level === "log" ? "info" : level, args);
+        } catch (_){}
+        return original.apply(this, args);
+      };
+    }
+  }
+
+  function installErrorHooks(){
+    global.addEventListener("error", (event) => {
+      if (event.target && event.target !== global && !(event.error instanceof Error)) {
+        const target = event.target;
+        const url = target?.src || target?.href || target?.currentSrc;
+        const tag = target?.tagName || "resource";
+        emit({
+          category: "resource",
+          level: "error",
+          message: `${tag} failed to load`,
+          details: { url, node: safeSerialize(target) },
+          timestamp: Date.now(),
+        });
+        return;
+      }
+      emit({
+        category: "error",
+        level: "error",
+        message: event.message || String(event.error || "Unknown error"),
+        details: {
+          filename: event.filename,
+          lineno: event.lineno,
+          colno: event.colno,
+          error: safeSerialize(event.error || event.message),
+        },
+        timestamp: Date.now(),
+      });
+    }, { capture: true });
+
+    global.addEventListener("unhandledrejection", (event) => {
+      emit({
+        category: "promise",
+        level: "error",
+        message: "Unhandled promise rejection",
+        details: { reason: safeSerialize(event.reason) },
+        timestamp: Date.now(),
+      });
+    });
+
+    global.addEventListener("rejectionhandled", (event) => {
+      emit({
+        category: "promise",
+        level: "warn",
+        message: "Promise rejection handled late",
+        details: { reason: safeSerialize(event.reason) },
+        timestamp: Date.now(),
+      });
+    });
+  }
+
+  function wrapFetch(){
+    if (typeof global.fetch !== "function") return;
+    const original = global.fetch;
+    global.fetch = function(input, init){
+      const start = performance.now();
+      return original.apply(this, arguments).then((response) => {
+        emit({
+          category: "network",
+          level: response.ok ? "info" : "warn",
+          message: `fetch ${serializeRequestInfo(input)} -> ${response.status}`,
+          details: {
+            statusText: response.statusText,
+            url: response.url,
+            ok: response.ok,
+            duration: Math.round(performance.now() - start),
+          },
+          timestamp: Date.now(),
+        });
+        return response;
+      }).catch((error) => {
+        emit({
+          category: "network",
+          level: "error",
+          message: `fetch ${serializeRequestInfo(input)} failed`,
+          details: {
+            duration: Math.round(performance.now() - start),
+            error: safeSerialize(error),
+          },
+          timestamp: Date.now(),
+        });
+        throw error;
+      });
+    };
+  }
+
+  function wrapXHR(){
+    if (!global.XMLHttpRequest) return;
+    const proto = global.XMLHttpRequest.prototype;
+    const open = proto.open;
+    const send = proto.send;
+    proto.open = function(method, url){
+      this.__ggDiag = { method, url: typeof url === "string" ? url : safeSerialize(url) };
+      return open.apply(this, arguments);
+    };
+    proto.send = function(){
+      const started = performance.now();
+      const context = this.__ggDiag || { method: "GET", url: this.responseURL };
+      const done = (status, statusText, level, extra) => {
+        emit({
+          category: "network",
+          level,
+          message: `xhr ${context.method} ${context.url} -> ${status}`,
+          details: Object.assign({
+            status,
+            statusText,
+            duration: Math.round(performance.now() - started),
+          }, extra || {}),
+          timestamp: Date.now(),
+        });
+      };
+      this.addEventListener("load", () => done(this.status, this.statusText, this.status >= 200 && this.status < 400 ? "info" : "warn"));
+      this.addEventListener("error", () => done("ERR", "Network error", "error"));
+      this.addEventListener("timeout", () => done("TIMEOUT", "Request timed out", "warn"));
+      this.addEventListener("abort", () => done("ABORT", "Request aborted", "warn"));
+      return send.apply(this, arguments);
+    };
+  }
+
+  function serializeRequestInfo(input){
+    try {
+      if (typeof input === "string") return input;
+      if (input instanceof Request) return input.url;
+      if (input && typeof input === "object" && "url" in input) return String(input.url);
+      return JSON.stringify(safeSerialize(input));
+    } catch (_) {
+      return "[request]";
+    }
+  }
+
+  function reportCapabilities(){
+    emit({
+      category: "environment",
+      level: "info",
+      message: "Environment snapshot",
+      details: {
+        userAgent: navigator.userAgent,
+        language: navigator.language,
+        platform: navigator.platform,
+        hardwareConcurrency: navigator.hardwareConcurrency,
+        deviceMemory: navigator.deviceMemory,
+        colorScheme: matchMediaSafe("(prefers-color-scheme: dark)") ? "dark" : "light",
+        onLine: navigator.onLine,
+        viewport: { width: global.innerWidth, height: global.innerHeight },
+        timezone: tryResolveTimeZone(),
+      },
+      timestamp: Date.now(),
+    });
+  }
+
+  function reportPerformance(){
+    try {
+      const navEntries = performance.getEntriesByType?.("navigation") || [];
+      const nav = navEntries[0];
+      const timing = performance.timing || {};
+      const memory = performance.memory || null;
+      emit({
+        category: "performance",
+        level: "info",
+        message: "Performance snapshot",
+        details: {
+          navigation: nav ? pick(nav, [
+            "type",
+            "domContentLoadedEventEnd",
+            "loadEventEnd",
+            "responseEnd",
+            "startTime",
+            "duration",
+          ]) : null,
+          timing: timing ? pick(timing, [
+            "navigationStart",
+            "domInteractive",
+            "domComplete",
+            "responseStart",
+            "responseEnd",
+          ]) : null,
+          memory: memory ? pick(memory, ["jsHeapSizeLimit", "totalJSHeapSize", "usedJSHeapSize"]) : null,
+        },
+        timestamp: Date.now(),
+      });
+    } catch (err) {
+      emit({ category: "performance", level: "warn", message: "Unable to gather performance metrics", details: safeSerialize(err), timestamp: Date.now() });
+    }
+  }
+
+  function reportServiceWorker(){
+    if (!navigator.serviceWorker) {
+      emit({ category: "service-worker", level: "warn", message: "Service workers unsupported", timestamp: Date.now() });
+      return;
+    }
+    navigator.serviceWorker.ready.then((registration) => {
+      emit({
+        category: "service-worker",
+        level: "info",
+        message: "Service worker ready",
+        details: {
+          scope: registration.scope,
+          active: registration.active ? registration.active.state : null,
+        },
+        timestamp: Date.now(),
+      });
+    }).catch((err) => {
+      emit({ category: "service-worker", level: "warn", message: "Service worker ready() rejected", details: safeSerialize(err), timestamp: Date.now() });
+    });
+
+    navigator.serviceWorker.getRegistrations?.().then((regs) => {
+      emit({
+        category: "service-worker",
+        level: "info",
+        message: `Service worker registrations (${regs.length})`,
+        details: regs.map((reg) => ({ scope: reg.scope, active: reg.active?.state, installing: reg.installing?.state, waiting: reg.waiting?.state })),
+        timestamp: Date.now(),
+      });
+    }).catch((err) => {
+      emit({ category: "service-worker", level: "warn", message: "Unable to enumerate service workers", details: safeSerialize(err), timestamp: Date.now() });
+    });
+
+    if (navigator.serviceWorker.controller) {
+      emit({
+        category: "service-worker",
+        level: "info",
+        message: "Service worker controller detected",
+        details: { state: navigator.serviceWorker.controller.state },
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  function matchMediaSafe(query){
+    try {
+      return global.matchMedia?.(query)?.matches || false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function tryResolveTimeZone(){
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (_) {
+      return "unknown";
+    }
+  }
+
+  function pick(source, keys){
+    if (!source) return null;
+    const out = {};
+    for (const key of keys){
+      if (key in source) out[key] = source[key];
+    }
+    return out;
+  }
+
+  function heartbeat(){
+    const origin = Date.now();
+    emit({
+      category: "heartbeat",
+      level: "debug",
+      message: "diagnostics heartbeat",
+      details: {
+        ts: origin,
+        uptime: Math.round(performance.now()),
+        memory: safeSerialize(performance.memory || null),
+        visibilityState: document.visibilityState,
+      },
+      timestamp: origin,
+    });
+  }
+
+  function installHeartbeat(){
+    heartbeat();
+    setInterval(heartbeat, 5000);
+  }
+
+  function installNetworkListeners(){
+    global.addEventListener("online", () => emit({ category: "network", level: "info", message: "navigator.online = true", timestamp: Date.now() }));
+    global.addEventListener("offline", () => emit({ category: "network", level: "warn", message: "navigator.online = false", timestamp: Date.now() }));
+  }
+
+  installConsoleHooks();
+  installErrorHooks();
+  wrapFetch();
+  wrapXHR();
+  reportCapabilities();
+  reportPerformance();
+  reportServiceWorker();
+  installHeartbeat();
+  installNetworkListeners();
+})();

--- a/games/common/diag-core.js
+++ b/games/common/diag-core.js
@@ -1,0 +1,440 @@
+/* Gurjot's Games — diag-core.js
+   Modern diagnostics console UI and runtime helpers.
+*/
+(function(){
+  const global = typeof window !== "undefined" ? window : globalThis;
+  if (!global) return;
+  if (global.__GG_DIAG && typeof global.__GG_DIAG.log === "function") {
+    return;
+  }
+
+  const existingQueue = Array.isArray(global.__GG_DIAG_QUEUE) ? global.__GG_DIAG_QUEUE.splice(0) : [];
+  global.__GG_DIAG_OPTS = Object.assign({}, { suppressButton: true }, global.__GG_DIAG_OPTS || {});
+
+  const state = {
+    logs: [],
+    maxLogs: 500,
+    injected: false,
+    root: null,
+    fab: null,
+    backdrop: null,
+    modal: null,
+    logList: null,
+    metaEl: null,
+    autoScroll: true,
+    isOpen: false,
+    lastFocus: null,
+    styleInjected: false,
+    cssHref: null,
+  };
+
+  const LEVEL_ORDER = ["debug", "info", "warn", "error"];
+  const LEGACY_SELECTORS = [
+    "[data-gg-diag-root]",
+    "#gg-diag-overlay",
+    "#gg-diag-floating",
+    "[data-diag-legacy]",
+  ];
+
+  const diag = {
+    open,
+    close,
+    toggle,
+    log,
+    exportJSON,
+    exportText,
+    copyToClipboard,
+    download,
+  };
+
+  Object.defineProperty(global, "__GG_DIAG", {
+    configurable: true,
+    enumerable: false,
+    writable: false,
+    value: diag,
+  });
+
+  if (existingQueue.length){
+    for (const entry of existingQueue){
+      try { log(entry); } catch(_){}
+    }
+  }
+
+  function open(){
+    ensureUI();
+    if (state.isOpen) return;
+    state.lastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    state.backdrop?.setAttribute("data-open", "true");
+    state.fab?.setAttribute("aria-expanded", "true");
+    state.isOpen = true;
+    document.body.classList.add("gg-diag-scroll-locked");
+    requestAnimationFrame(() => {
+      const first = firstFocusable();
+      (first || state.modal)?.focus({ preventScroll: true });
+    });
+    document.addEventListener("keydown", trapKeydown, true);
+  }
+
+  function close(){
+    if (!state.isOpen) return;
+    state.isOpen = false;
+    state.backdrop?.setAttribute("data-open", "false");
+    state.fab?.setAttribute("aria-expanded", "false");
+    document.body.classList.remove("gg-diag-scroll-locked");
+    document.removeEventListener("keydown", trapKeydown, true);
+    if (state.lastFocus && document.contains(state.lastFocus)) {
+      try { state.lastFocus.focus({ preventScroll: true }); } catch(_){}
+    } else {
+      state.fab?.focus({ preventScroll: true });
+    }
+  }
+
+  function toggle(){
+    if (state.isOpen) close(); else open();
+  }
+
+  function log(entry){
+    if (!entry) return;
+    ensureUI();
+    const normalized = normalizeEntry(entry);
+    state.logs.push(normalized);
+    if (state.logs.length > state.maxLogs) state.logs.splice(0, state.logs.length - state.maxLogs);
+    renderLog(normalized);
+  }
+
+  function exportJSON(){
+    return JSON.stringify(state.logs, null, 2);
+  }
+
+  function exportText(){
+    return state.logs.map((item) => {
+      return `[${new Date(item.timestamp).toISOString()}] ${item.category}/${item.level} ${item.message}`;
+    }).join("\n");
+  }
+
+  async function copyToClipboard(format = "text"){
+    try {
+      const text = format === "json" ? exportJSON() : exportText();
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "true");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        textarea.remove();
+      }
+      announce("Copied diagnostics to clipboard");
+    } catch (err) {
+      announce("Unable to copy diagnostics");
+      console.warn("__GG_DIAG copy failed", err);
+    }
+  }
+
+  function download(){
+    try {
+      const blob = new Blob([exportJSON()], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `gg-diag-${Date.now()}.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      announce("Diagnostics exported");
+    } catch (err) {
+      announce("Unable to export diagnostics");
+      console.warn("__GG_DIAG export failed", err);
+    }
+  }
+
+  function ensureUI(){
+    if (state.injected) return;
+    state.injected = true;
+    ensureStyle();
+    removeLegacy();
+
+    const doc = document;
+    const root = doc.createElement("div");
+    root.dataset.ggDiagRoot = "modern";
+
+    const fab = doc.createElement("button");
+    fab.type = "button";
+    fab.className = "gg-diag-fab";
+    fab.setAttribute("aria-label", "Open diagnostics console");
+    fab.setAttribute("aria-haspopup", "dialog");
+    fab.setAttribute("aria-expanded", "false");
+    fab.innerHTML = "&#9881;";
+    fab.addEventListener("click", () => open());
+
+    const backdrop = doc.createElement("div");
+    backdrop.className = "gg-diag-backdrop";
+    backdrop.setAttribute("role", "presentation");
+    backdrop.setAttribute("data-open", "false");
+    backdrop.addEventListener("pointerdown", (event) => {
+      if (event.target === backdrop) {
+        close();
+      }
+    });
+
+    const modal = doc.createElement("div");
+    modal.className = "gg-diag-modal";
+    modal.setAttribute("role", "dialog");
+    modal.setAttribute("aria-modal", "true");
+    modal.setAttribute("tabindex", "-1");
+    modal.setAttribute("aria-labelledby", "gg-diag-modal-title");
+
+    const header = doc.createElement("header");
+    header.className = "gg-diag-modal-header";
+
+    const title = doc.createElement("h2");
+    title.className = "gg-diag-modal-title";
+    title.id = "gg-diag-modal-title";
+    title.textContent = "Diagnostics";
+
+    const meta = doc.createElement("div");
+    meta.className = "gg-diag-modal-meta";
+    meta.innerHTML = `<span>Logs: <strong>0</strong></span>`;
+    state.metaEl = meta.querySelector("strong");
+
+    const closeBtn = doc.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "gg-diag-close";
+    closeBtn.textContent = "Close";
+    closeBtn.setAttribute("aria-label", "Close diagnostics console");
+    closeBtn.addEventListener("click", () => close());
+
+    header.append(title, meta, closeBtn);
+
+    const body = doc.createElement("div");
+    body.className = "gg-diag-modal-body";
+
+    const logList = doc.createElement("ul");
+    logList.className = "gg-diag-loglist";
+    logList.setAttribute("role", "log");
+    logList.setAttribute("aria-live", "polite");
+    logList.setAttribute("aria-relevant", "additions");
+    state.logList = logList;
+
+    body.append(logList);
+
+    const actions = doc.createElement("div");
+    actions.className = "gg-diag-modal-actions";
+
+    const btnCopy = doc.createElement("button");
+    btnCopy.type = "button";
+    btnCopy.className = "gg-diag-action";
+    btnCopy.textContent = "Copy summary";
+    btnCopy.addEventListener("click", () => copyToClipboard("text"));
+
+    const btnCopyJSON = doc.createElement("button");
+    btnCopyJSON.type = "button";
+    btnCopyJSON.className = "gg-diag-action";
+    btnCopyJSON.textContent = "Copy JSON";
+    btnCopyJSON.addEventListener("click", () => copyToClipboard("json"));
+
+    const btnDownload = doc.createElement("button");
+    btnDownload.type = "button";
+    btnDownload.className = "gg-diag-action";
+    btnDownload.textContent = "Download JSON";
+    btnDownload.addEventListener("click", () => download());
+
+    actions.append(btnCopy, btnCopyJSON, btnDownload);
+
+    modal.append(header, body, actions);
+    backdrop.append(modal);
+    root.append(backdrop, fab);
+    doc.body.appendChild(root);
+
+    state.root = root;
+    state.fab = fab;
+    state.backdrop = backdrop;
+    state.modal = modal;
+
+    state.logList.addEventListener("scroll", handleScroll);
+  }
+
+  function ensureStyle(){
+    if (state.styleInjected) return;
+    state.styleInjected = true;
+    try {
+      const scriptEl = document.currentScript || Array.from(document.scripts || []).find((s) => /diag-core\.js/.test(s.src));
+      if (scriptEl?.src) {
+        state.cssHref = new URL("./diag-modal.css", scriptEl.src).href;
+      } else {
+        state.cssHref = "/games/common/diag-modal.css";
+      }
+    } catch (_) {
+      state.cssHref = "/games/common/diag-modal.css";
+    }
+    if (!state.cssHref) return;
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = state.cssHref;
+    link.setAttribute("data-gg-diag-style", "modern");
+    document.head.appendChild(link);
+  }
+
+  function removeLegacy(){
+    for (const selector of LEGACY_SELECTORS){
+      document.querySelectorAll(selector).forEach((node) => {
+        if (!node || node.dataset.ggDiagRoot === "modern") return;
+        node.remove();
+      });
+    }
+  }
+
+  function normalizeEntry(entry){
+    const now = Date.now();
+    if (typeof entry === "string" || typeof entry === "number") {
+      return { timestamp: now, level: "info", category: "general", message: String(entry), details: null };
+    }
+    const objectEntry = typeof entry === "object" && entry ? entry : { message: String(entry) };
+    const level = normalizeLevel(objectEntry.level);
+    const category = String(objectEntry.category || objectEntry.type || "general");
+    const message = normalizeMessage(objectEntry.message, objectEntry.args);
+    const details = objectEntry.details ?? objectEntry.data ?? null;
+    return {
+      timestamp: typeof objectEntry.timestamp === "number" ? objectEntry.timestamp : now,
+      level,
+      category,
+      message,
+      details,
+    };
+  }
+
+  function normalizeLevel(value){
+    const lvl = String(value || "info").toLowerCase();
+    return LEVEL_ORDER.includes(lvl) ? lvl : "info";
+  }
+
+  function normalizeMessage(message, args){
+    if (typeof message === "string") return message;
+    if (Array.isArray(args)) {
+      return args.map((item) => stringify(item)).join(" ");
+    }
+    return stringify(message);
+  }
+
+  function stringify(value){
+    if (value === null || value === undefined) return String(value);
+    if (typeof value === "string") return value;
+    if (typeof value === "number" || typeof value === "boolean") return String(value);
+    if (value instanceof Error) return value.stack || `${value.name}: ${value.message}`;
+    try {
+      return JSON.stringify(value);
+    } catch (_) {
+      return Object.prototype.toString.call(value);
+    }
+  }
+
+  function renderLog(entry){
+    if (!state.logList) return;
+    const item = document.createElement("li");
+    item.className = "gg-diag-logitem";
+    item.setAttribute("data-level", entry.level);
+
+    const header = document.createElement("div");
+    header.className = "gg-diag-logitem-header";
+    const label = document.createElement("span");
+    label.textContent = `${entry.category} / ${entry.level}`;
+    const time = document.createElement("time");
+    time.className = "gg-diag-logitem-time";
+    time.dateTime = new Date(entry.timestamp).toISOString();
+    time.textContent = new Date(entry.timestamp).toLocaleTimeString();
+    header.append(label, time);
+
+    const body = document.createElement("div");
+    body.className = "gg-diag-logitem-body";
+    body.textContent = entry.message;
+
+    item.append(header, body);
+
+    if (entry.details) {
+      const meta = document.createElement("div");
+      meta.className = "gg-diag-logitem-meta";
+      meta.textContent = stringify(entry.details);
+      item.append(meta);
+    }
+
+    const shouldStick = state.autoScroll && isScrolledToBottom();
+    state.logList.appendChild(item);
+    state.metaEl && (state.metaEl.textContent = String(state.logs.length));
+    if (shouldStick) {
+      requestAnimationFrame(() => {
+        state.logList.scrollTop = state.logList.scrollHeight;
+      });
+    }
+  }
+
+  function handleScroll(){
+    const nearBottom = isScrolledToBottom();
+    state.autoScroll = nearBottom;
+  }
+
+  function isScrolledToBottom(){
+    if (!state.logList) return true;
+    const { scrollTop, scrollHeight, clientHeight } = state.logList;
+    return scrollHeight - (scrollTop + clientHeight) < 24;
+  }
+
+  function firstFocusable(){
+    if (!state.modal) return null;
+    const selectors = [
+      "button:not([disabled])",
+      "a[href]",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "[tabindex]:not([tabindex='-1'])"
+    ];
+    const nodes = state.modal.querySelectorAll(selectors.join(","));
+    return nodes.length ? nodes[0] : null;
+  }
+
+  function trapKeydown(event){
+    if (!state.isOpen) return;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    if (!state.modal) return;
+    const focusable = Array.from(state.modal.querySelectorAll("button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])"));
+    if (!focusable.length) {
+      event.preventDefault();
+      state.modal.focus({ preventScroll: true });
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const current = document.activeElement;
+    if (event.shiftKey && current === first) {
+      event.preventDefault();
+      last.focus({ preventScroll: true });
+    } else if (!event.shiftKey && current === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  }
+
+  function announce(message){
+    if (!state.root) return;
+    let region = state.root.querySelector("[data-gg-diag-live]");
+    if (!region){
+      region = document.createElement("div");
+      region.className = "gg-diag-hidden";
+      region.setAttribute("role", "status");
+      region.setAttribute("aria-live", "polite");
+      region.dataset.ggDiagLive = "";
+      state.root.appendChild(region);
+    }
+    region.textContent = message;
+  }
+})();

--- a/games/common/diag-modal.css
+++ b/games/common/diag-modal.css
@@ -1,0 +1,272 @@
+:root {
+  color-scheme: dark;
+}
+
+body.gg-diag-scroll-locked {
+  overflow: hidden;
+}
+
+.gg-diag-hidden {
+  display: none !important;
+}
+
+.gg-diag-fab {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(138, 180, 255, 0.35);
+  background: radial-gradient(circle at 30% 30%, #3b82f6, #1d4ed8 65%, #0f172a);
+  color: #f8fbff;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.6), 0 2px 12px rgba(30, 64, 175, 0.6);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 1.125rem;
+  line-height: 1;
+  z-index: 2147483600;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 200ms ease;
+}
+
+.gg-diag-fab:hover,
+.gg-diag-fab:focus-visible {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.72);
+  background: radial-gradient(circle at 35% 25%, #60a5fa, #2563eb 60%, #111b2f);
+}
+
+.gg-diag-fab:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.6);
+  outline-offset: 2px;
+}
+
+.gg-diag-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(0.75rem, 3vw, 2rem);
+  background: rgba(4, 11, 22, 0.82);
+  backdrop-filter: blur(6px) saturate(120%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+  z-index: 2147483599;
+}
+
+.gg-diag-backdrop[data-open="true"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.gg-diag-modal {
+  width: min(720px, 100%);
+  max-height: min(90vh, 680px);
+  display: flex;
+  flex-direction: column;
+  border-radius: 18px;
+  border: 1px solid rgba(96, 165, 250, 0.28);
+  background: linear-gradient(165deg, rgba(12, 20, 31, 0.98), rgba(8, 13, 23, 0.98));
+  box-shadow: 0 28px 76px rgba(2, 6, 14, 0.82), 0 4px 24px rgba(30, 64, 175, 0.45);
+  color: #e6efff;
+  overflow: hidden;
+}
+
+.gg-diag-modal-header {
+  padding: 1.25rem clamp(1rem, 4vw, 1.75rem);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(96, 165, 250, 0.18);
+  background: linear-gradient(180deg, rgba(17, 27, 42, 0.95), rgba(11, 19, 32, 0.95));
+}
+
+.gg-diag-modal-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: 0.01em;
+}
+
+.gg-diag-modal-meta {
+  margin-left: auto;
+  font-size: 0.8125rem;
+  color: rgba(191, 219, 254, 0.72);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.gg-diag-close {
+  background: none;
+  border: 1px solid transparent;
+  color: inherit;
+  border-radius: 10px;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.gg-diag-close:hover,
+.gg-diag-close:focus-visible {
+  background: rgba(96, 165, 250, 0.16);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.gg-diag-close:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.45);
+  outline-offset: 2px;
+}
+
+.gg-diag-modal-body {
+  padding: clamp(0.75rem, 3vw, 1.5rem);
+  flex: 1;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(9, 15, 24, 0.96);
+}
+
+.gg-diag-loglist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.8125rem;
+}
+
+.gg-diag-logitem {
+  border-radius: 12px;
+  padding: 0.75rem 0.85rem;
+  background: rgba(17, 27, 42, 0.74);
+  border: 1px solid rgba(96, 165, 250, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.45rem;
+  word-break: break-word;
+}
+
+.gg-diag-logitem[data-level="error"] {
+  border-color: rgba(248, 113, 113, 0.38);
+  background: rgba(45, 17, 26, 0.84);
+}
+
+.gg-diag-logitem[data-level="warn"] {
+  border-color: rgba(251, 191, 36, 0.38);
+  background: rgba(40, 28, 6, 0.84);
+}
+
+.gg-diag-logitem-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+  color: rgba(226, 232, 240, 0.86);
+  font-weight: 500;
+}
+
+.gg-diag-logitem-time {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+  margin-left: auto;
+}
+
+.gg-diag-logitem-body {
+  color: rgba(226, 232, 240, 0.84);
+  white-space: pre-wrap;
+}
+
+.gg-diag-logitem-meta {
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.75rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.gg-diag-modal-actions {
+  padding: 0.9rem clamp(1rem, 4vw, 1.75rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  background: rgba(10, 17, 28, 0.92);
+  border-top: 1px solid rgba(96, 165, 250, 0.14);
+}
+
+.gg-diag-action {
+  border-radius: 12px;
+  border: 1px solid rgba(96, 165, 250, 0.4);
+  background: rgba(37, 99, 235, 0.3);
+  color: #e0f2ff;
+  padding: 0.55rem 1.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.gg-diag-action:hover,
+.gg-diag-action:focus-visible {
+  background: rgba(59, 130, 246, 0.45);
+  border-color: rgba(147, 197, 253, 0.7);
+  transform: translateY(-1px);
+}
+
+.gg-diag-action:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.45);
+  outline-offset: 2px;
+}
+
+@media (max-width: 720px) {
+  .gg-diag-fab {
+    bottom: 1.1rem;
+    right: 1.1rem;
+    width: 3.15rem;
+    height: 3.15rem;
+    font-size: 1rem;
+  }
+
+  .gg-diag-modal {
+    border-radius: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .gg-diag-modal {
+    width: 100%;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .gg-diag-backdrop {
+    padding: 0;
+    align-items: stretch;
+  }
+
+  .gg-diag-modal-header,
+  .gg-diag-modal-actions {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gg-diag-fab,
+  .gg-diag-backdrop,
+  .gg-diag-action {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive dark diagnostics modal and floating action button styles
- implement the diagnostics core that manages UI, logging, exports, and accessibility behaviors
- capture console, network, error, performance, and heartbeat diagnostics with resilient serialization

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6cb7d454c8327bd80a839fb173acb