### PR TITLE
Refine diagnostics autowire shim

### DIFF
--- a/games/common/diag-autowire.js
+++ b/games/common/diag-autowire.js
@@ -1,37 +1,117 @@
-
-/* diag-autowire.js (dup-suppress) */
+/* diag-autowire.js (lightweight loader) */
 (function(){
-  const onReady=(fn)=>document.readyState==='loading'?document.addEventListener('DOMContentLoaded',fn,{once:true}):fn();
-  const removeDup=()=>{try{
-    const preferred=document.getElementById('gg-diag-btn');
-    const q='[data-diag-copy],.gg-diag-copy,.diagnostics-btn,#diagnostics,button[data-gg-diag],button.gg-diagnostics,a.gg-diagnostics';
-    const cand=[...document.querySelectorAll(q)];
-    const labelled=[...document.querySelectorAll('button,a')].filter(el=>{
-      const t=(el.textContent||'').trim().toLowerCase(); if(!t) return false;
-      if(el.id==='gg-diag-btn') return false; return t==='diagnostics'||t==='open diagnostics';
-    });
-    const toRemove=new Set([...cand,...labelled]);
-    if(preferred){ toRemove.forEach(el=>{ if(el!==preferred) el.remove(); });}
-  }catch(_){}}; 
-  const guard=()=>{ const opts=window.__GG_DIAG_OPTS||{}; const has=document.getElementById('gg-diag-btn'); window.__GG_DIAG_OPTS=Object.assign(opts,{suppressButton:!!has});};
-  const wire=()=>{ const g=(window.__GG_DIAG=window.__GG_DIAG||{}); if(typeof g.open==='function') return;
-    g.open=function(){ try{ const ov=document.querySelector('#gg-diagnostics-overlay,.gg-diagnostics-overlay'); if(ov){ ov.style.display='block'; ov.removeAttribute('hidden'); return; } }catch(_){}
-      let p=document.getElementById('gg-diag-fallback'); if(!p){ p=document.createElement('div'); p.id='gg-diag-fallback';
-        p.setAttribute('role','dialog'); Object.assign(p.style,{position:'fixed',right:'12px',bottom:'60px',maxWidth:'420px',maxHeight:'50vh',overflow:'auto',background:'#0b0b0c',border:'1px solid #444',borderRadius:'12px',padding:'12px',boxShadow:'0 4px 22px rgba(0,0,0,0.5)',color:'#fff',zIndex:'9999'});
-        p.innerHTML='<div style="display:flex;justify-content:space-between;gap:8px;margin-bottom:6px"><strong style="font:600 14px system-ui">Diagnostics</strong><button id="gg-diag-close" style="padding:6px 8px;border-radius:8px;border:1px solid #444;background:#161618;color:#fff">Close</button></div><pre id="gg-diag-log" style="white-space:pre-wrap;font:12px ui-monospace;margin:0"></pre>';
-        document.body.appendChild(p); const c=document.getElementById('gg-diag-close'); c&&c.addEventListener('click',()=>{p.style.display='none';});
-        const L=[]; L.push('UA: '+(navigator.userAgent||'')); L.push('PixelRatio: '+(window.devicePixelRatio||1)); L.push('Viewport: '+window.innerWidth+'x'+window.innerHeight); L.push('Time: '+new Date().toISOString()); try{L.push('Path: '+location.pathname+location.search);}catch(_){}
-        document.getElementById('gg-diag-log').textContent=L.join('\n');
-      } else { p.style.display='block'; }
-    };
+  const win = typeof window === 'undefined' ? null : window;
+  const doc = win && win.document ? win.document : null;
+  if (!win || !doc) return;
+
+  const alreadyInitialized = () => {
+    const g = win.__GG_DIAG;
+    if (g && (g.initialized || g.ready || g.core || g.loaded)) return true;
+    try {
+      if (doc.querySelector('script[data-gg-diag-core],script[data-gg-diag-capture],script[src*="diag-core"],script[src*="diag-capture"]')) {
+        return true;
+      }
+    } catch (_err) {}
+    return false;
   };
-  onReady(()=>{ removeDup(); guard(); wire();
-    // ensure upgrades script present
-    if(!document.querySelector('script[src*="diag-upgrades.js"]')){ 
-      const s=document.createElement('script'); s.src='../common/diag-upgrades.js'; s.defer=true;
-      const slug=((document.currentScript&& (document.currentScript.dataset.slug||document.currentScript.dataset.game))||'')|| (location.pathname.match(/\/games\/([^\/?#]+)/i)||[])[1] || '';
-      if(slug) s.dataset.slug=slug;
-      document.head.appendChild(s);
+
+  if (alreadyInitialized()) return;
+
+  const onReady = (fn) => {
+    if (typeof fn !== 'function') return;
+    if (doc.readyState === 'loading') {
+      const handler = function(){
+        if (doc.removeEventListener) doc.removeEventListener('DOMContentLoaded', handler);
+        fn();
+      };
+      if (doc.addEventListener) {
+        doc.addEventListener('DOMContentLoaded', handler);
+      }
+    } else {
+      fn();
     }
+  };
+
+  const removeLegacyElements = () => {
+    try {
+      const selectors = [
+        '#diagnostics',
+        '.diagnostics-btn',
+        '.gg-diagnostics',
+        'button[data-gg-diag]',
+        'button.gg-diagnostics',
+        'a.gg-diagnostics',
+        '[data-diag-copy]',
+        '.gg-diag-copy'
+      ];
+      const elements = [];
+      for (let i = 0; i < selectors.length; i += 1) {
+        const selector = selectors[i];
+        try {
+          const found = doc.querySelectorAll ? doc.querySelectorAll(selector) : [];
+          for (let j = 0; found && j < found.length; j += 1) {
+            elements.push(found[j]);
+          }
+        } catch (_err) {}
+      }
+      let labeledButtons = [];
+      try {
+        const candidates = doc.querySelectorAll ? doc.querySelectorAll('button,a') : [];
+        const items = [];
+        for (let i = 0; candidates && i < candidates.length; i += 1) {
+          const el = candidates[i];
+          if (!el) continue;
+          if (el.id === 'gg-diag-btn') continue;
+          const text = typeof el.textContent === 'string' ? el.textContent.trim().toLowerCase() : '';
+          if (text === 'diagnostics' || text === 'open diagnostics') {
+            items.push(el);
+          }
+        }
+        labeledButtons = items;
+      } catch (_err) {}
+      const preferred = (() => {
+        try { return doc.getElementById ? doc.getElementById('gg-diag-btn') : null; } catch (_err) { return null; }
+      })();
+      const targets = elements.concat(labeledButtons);
+      for (let i = 0; i < targets.length; i += 1) {
+        const el = targets[i];
+        if (!el || (preferred && el === preferred)) continue;
+        try {
+          if (typeof el.remove === 'function') {
+            el.remove();
+          } else if (el.parentNode && typeof el.parentNode.removeChild === 'function') {
+            el.parentNode.removeChild(el);
+          }
+        } catch (_err) {}
+      }
+    } catch (_err) {}
+  };
+
+  const ensureScript = (src, marker) => {
+    if (!src || !doc.createElement) return;
+    try {
+      const existing = doc.querySelector ? doc.querySelector('script[' + marker + ']') : null;
+      if (existing) return;
+    } catch (_err) {}
+    try {
+      const script = doc.createElement('script');
+      script.defer = true;
+      script.src = src;
+      if (script.setAttribute) script.setAttribute(marker, '');
+      const parent = doc.head || doc.documentElement || doc.body;
+      if (!parent || typeof parent.appendChild !== 'function') return;
+      parent.appendChild(script);
+    } catch (_err) {}
+  };
+
+  onReady(() => {
+    if (alreadyInitialized()) return;
+
+    removeLegacyElements();
+
+    win.__GG_DIAG_OPTS = { suppressButton: true };
+
+    ensureScript('../common/diag-core.js', 'data-gg-diag-core');
+    ensureScript('../common/diag-capture.js', 'data-gg-diag-capture');
   });
 })();


### PR DESCRIPTION
## Summary
- guard against missing browser APIs before running diagnostics bootstrap logic
- remove legacy diagnostics controls and set suppressButton option for the core loader
- lazily inject diag-core.js and diag-capture.js only when diagnostics have not already been initialized

## Testing
- not run (script-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6cc49d9bc83278fc9d21628605d8f