### PR TITLE
Replace legacy diagnostics UI with modal includes

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -427,7 +427,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="2048"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="g2048" data-apply-theme="false" data-focus-target="#board"></script>
 
-  <script src="../common/diag-autowire.js" data-game="2048"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
 <script>
 (function(){
@@ -456,14 +455,9 @@
   else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
 })();
 </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>
 

--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -45,7 +45,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="asteroids"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="asteroids"></script>
 
-  <script src="../common/diag-autowire.js" data-game="asteroids"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -74,13 +73,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -46,7 +46,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="breakout"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="breakout"></script>
 
-  <script src="../common/diag-autowire.js" data-game="breakout"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -75,13 +74,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -97,7 +97,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="chess" data-apply-theme="false"></script>
 
-  <script src="../common/diag-autowire.js" data-game="chess"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -126,13 +125,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -70,7 +70,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="chess3d"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="chess3d" data-apply-theme="false"></script>
 
-  <script src="../common/diag-autowire.js" data-game="chess3d"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -99,13 +98,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -109,7 +109,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="maze3d"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="maze3d" data-apply-theme="false"></script>
 
-  <script src="../common/diag-autowire.js" data-game="maze3d"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -138,13 +137,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -132,7 +132,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="platformer"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="platformer"></script>
 
-  <script src="../common/diag-autowire.js" data-game="platformer"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -161,13 +160,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -28,7 +28,6 @@
     <script src="./pong.js" defer></script>
     <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="pong" data-apply-theme="false" data-focus-target="#app"></script>
 
-  <script src="../common/diag-autowire.js" data-game="pong"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
     <script>
     (function(){
@@ -57,13 +56,8 @@
       else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
     })();
     </script>
-  <style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
-</body>
+    <link rel="stylesheet" href="../common/diag-modal.css">
+    <script src="../common/diag-core.js" defer></script>
+    <script src="../common/diag-capture.js" defer></script>
+  </body>
 </html>

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -149,7 +149,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="runner"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="runner" data-apply-theme="false"></script>
 
-  <script src="../common/diag-autowire.js" data-game="runner"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -178,13 +177,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -177,7 +177,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="shooter"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="shooter"></script>
 
-  <script src="../common/diag-autowire.js" data-game="shooter"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -206,13 +205,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -123,7 +123,6 @@
   <script type="module" src="../../shared/juice/overlay.js" data-game="snake"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="snake"></script>
 
-  <script src="../common/diag-autowire.js" data-game="snake"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -152,13 +151,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -85,7 +85,6 @@
   </script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="tetris"></script>
 
-  <script src="../common/diag-autowire.js" data-game="tetris"></script>
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
   (function(){
@@ -114,13 +113,8 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-<style>
-  #gg-diag-btn{position:fixed;right:12px;bottom:12px;padding:10px 12px;border-radius:10px;border:1px solid #444;background:#111;color:#fff;font:600 14px system-ui;z-index:9999;opacity:0.88}
-  #gg-diag-btn:focus{outline:2px solid #6cf;outline-offset:2px}
-</style>
-<button id="gg-diag-btn" aria-label="Open diagnostics">Diagnostics</button>
-<script>
-  (function(){var b=document.getElementById('gg-diag-btn'); if(b){ b.addEventListener('click', function(){ try{ window.__GG_DIAG && window.__GG_DIAG.open && window.__GG_DIAG.open(); }catch(e){ alert('Diagnostics not available'); } }); }})(); 
-</script>
+  <link rel="stylesheet" href="../common/diag-modal.css">
+  <script src="../common/diag-core.js" defer></script>
+  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the legacy inline diagnostics button, styles, and diag-autowire script from each game shell page
- include the shared diagnostics modal assets at the end of every game body while preserving the existing game-shell configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6cd4c8c488327bac9be1834145302