### PR TITLE
Fix Tetris replay tick timing units

### DIFF
--- a/games/tetris/replay.js
+++ b/games/tetris/replay.js
@@ -54,7 +54,7 @@
       return this.pieces[this.pi++];
     }
     tick(dt){
-      this.t+=dt;
+      if(Number.isFinite(dt)) this.t+=dt*1000;
       const ev=[];
       while(this.ai<this.actions.length && this.actions[this.ai].t<=this.t){
         ev.push(this.actions[this.ai++].a);


### PR DESCRIPTION
## Summary
- accumulate elapsed time in the Tetris replay player using milliseconds to align with recorded action timestamps

## Testing
- not run (UI/manual verification not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6d14f2d3483279e346244a7ddbfa3