### PR TITLE
Guard Maze3D PointerLockControls global patch

### DIFF
--- a/games/maze3d/PointerLockControls.js
+++ b/games/maze3d/PointerLockControls.js
@@ -163,9 +163,15 @@ function onPointerlockError() {
 export { PointerLockControls };
 
 if (typeof window !== 'undefined' && window.THREE && !window.THREE.PointerLockControls) {
-        Object.defineProperty(window.THREE, 'PointerLockControls', {
-                value: PointerLockControls,
-                configurable: true,
-                writable: true
-        });
+        try {
+                if (Object.isExtensible(window.THREE)) {
+                        Object.defineProperty(window.THREE, 'PointerLockControls', {
+                                value: PointerLockControls,
+                                configurable: true,
+                                writable: true
+                        });
+                }
+        } catch (error) {
+                // Silently skip if the property cannot be defined.
+        }
 }


### PR DESCRIPTION
## Summary
- wrap the PointerLockControls global assignment in a try/catch guard so it only patches extensible THREE instances

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d6d1f46428832793d0d5e01371f7cc