### PR TITLE
Ignore own broadcast messages in platformer co-op

### DIFF
--- a/games/platformer/net.js
+++ b/games/platformer/net.js
@@ -10,6 +10,8 @@ export function connect(){
 
 channel.onmessage = e => {
   const msg = e.data;
+  if (msg?.id === myId) return;
+
   if (msg.type === 'hello') {
     if (!connected) {
       peerId = msg.id;


### PR DESCRIPTION
## Summary
- ignore BroadcastChannel messages originating from the current tab before evaluating connection state
- maintain the existing handshake while only establishing peer linkage after confirming a remote sender

## Testing
- Manual testing not run (browser interaction not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6d20548988327ba829fdda7c31cd5