### PR TITLE
Fix runner shell canvas id mismatch

### DIFF
--- a/gameshells/runner/index.html
+++ b/gameshells/runner/index.html
@@ -15,7 +15,7 @@
     <style>html,body{height:100%;margin:0;background:#000;overflow:hidden}</style>
   </head>
   <body>
-    <canvas id="game-canvas" width="800" height="600" aria-label="City Runner canvas"></canvas>
+    <canvas id="game" width="800" height="600" aria-label="City Runner canvas"></canvas>
     <div id="hud">
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
@@ -26,7 +26,7 @@
     <script type="module">
       import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
-        ensureCanvas("game-canvas");
+        ensureCanvas("game");
         ensureElement("#score");
       });
     </script>


### PR DESCRIPTION
## Summary
- rename the runner shell canvas element from `game-canvas` to `game`
- update the canvas bootstrap to look up the new id so ensureCanvas matches resolveCanvas

## Testing
- not run (environment does not render the game shell)


------
https://chatgpt.com/codex/tasks/task_e_68d6d21aabe88327ba6be58d3b3411f1