### PR TITLE
Fix 2048 theme toggle accessibility messaging

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -878,15 +878,15 @@ function removeModalFocusTrap() {
 // Theme toggle accessibility
 const themeToggle = document.getElementById('themeToggle');
 if (themeToggle) {
-  const originalClickHandler = themeToggle.onclick;
   themeToggle.addEventListener('click', () => {
-    // Allow original handler to run first
+    // Allow the existing toggle handler to update the theme first
     setTimeout(() => {
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      // Update both text and ARIA label
-      themeToggle.textContent = newTheme === 'dark' ? 'Light' : 'Dark';
-      themeToggle.setAttribute('aria-label', `Switch to ${newTheme === 'dark' ? 'light' : 'dark'} theme`);
-      announceToScreenReader(`Switched to ${newTheme} theme.`);
+      const activatedTheme = currentTheme;
+      const nextTheme = activatedTheme === 'dark' ? 'light' : 'dark';
+      // Update both text and ARIA label to reflect the current and next themes
+      themeToggle.textContent = nextTheme === 'dark' ? 'Light' : 'Dark';
+      themeToggle.setAttribute('aria-label', `Switch to ${nextTheme} theme`);
+      announceToScreenReader(`Switched to ${activatedTheme} theme.`);
     }, 100);
   });
 }


### PR DESCRIPTION
## Summary
- ensure the theme toggle accessibility updates use the already-updated theme state
- remove the unused cached click handler reference

## Testing
- npm run test:unit
- Manual: toggled the 2048 theme to verify the button text, aria-label, and announcement match the active theme

------
https://chatgpt.com/codex/tasks/task_e_68d6d2d685b88327821011d9ff8a7a44