### PR TITLE
Auto start shooter game on module load

### DIFF
--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -155,3 +155,11 @@ export function boot() {
   }
   addEventListener('beforeunload', ()=>stopLoop());
 }
+
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+}


### PR DESCRIPTION
## Summary
- automatically invoke the shooter game's boot routine once the script loads while keeping the named export available
- guard the boot invocation behind DOM readiness checks to avoid running before the document is ready

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e4a1651c8327a4e2aa3339d71b99