### PR TITLE
Remove sticky positioning from Bolt landing header

### DIFF
--- a/css/bolt-landing.css
+++ b/css/bolt-landing.css
@@ -29,7 +29,7 @@ body.bolt-body{
 .bolt-container{max-width:1200px;margin:0 auto;padding:0 22px}
 
 /* NAV */
-.bolt-nav{position:sticky;top:0;z-index:30;background:transparent}
+.bolt-nav{background:transparent}
 .bolt-nav-inner{display:flex;align-items:center;justify-content:space-between;height:74px}
 .bolt-brand{text-decoration:none;color:var(--bolt-text);display:flex;align-items:center;gap:10px}
 .bolt-logo{font-size:26px;filter:drop-shadow(0 8px 20px rgba(0,0,0,.2))}


### PR DESCRIPTION
## Summary
- remove the sticky positioning rules from the Bolt landing page header so it scrolls naturally with the page

## Testing
- manual verification via local HTTP server that scrolling allows the navigation to leave the viewport

------
https://chatgpt.com/codex/tasks/task_e_68d6e4c480608327a8591f36355cbe2a