### PR TITLE
Treat g2048 slug as a legacy load path

### DIFF
--- a/game.html
+++ b/game.html
@@ -168,14 +168,18 @@
         setFrameSrc("./404.html");
       } else {
         const modernSrc = `./gameshells/${slug}/index.html`;
-        const legacySrc = `./games/${slug}/index.html`;
+        const legacySlug = slug === 'g2048' ? '2048' : slug;
+        const legacySrc = `./games/${legacySlug}/index.html`;
 
         write(`checking modern wrapper → ${modernSrc}`);
 
         const forceLegacy = qs.has('legacy') || qs.get('shell') === 'legacy';
         const forceModern = qs.has('modern') || qs.get('shell') === 'modern';
-        if (forceLegacy) {
-          setFrameSrc(legacySrc, "forced legacy");
+        const slugNeedsLegacy = slug === 'g2048';
+
+        if (forceLegacy || slugNeedsLegacy) {
+          const reason = forceLegacy ? "forced legacy" : "legacy (auto for g2048)";
+          setFrameSrc(legacySrc, reason);
         } else if (forceModern) {
           setFrameSrc(modernSrc, "forced modern");
         } else {


### PR DESCRIPTION
## Summary
- force the g2048 slug to skip the modern wrapper fetch and load the legacy game page immediately
- map the legacy iframe source to the existing 2048 board so the playable layout renders

## Testing
- manual `npx serve -l 4173` + `http://127.0.0.1:4173/game?slug=2048`


------
https://chatgpt.com/codex/tasks/task_e_68d6e740c8c88327819299d52cd8778f