### PR TITLE
Center Tetris shell layout

### DIFF
--- a/gameshells/tetris/index.html
+++ b/gameshells/tetris/index.html
@@ -12,7 +12,46 @@
       }
     }
     </script>
-    <style>html,body{height:100%;margin:0;background:#000;overflow:hidden}</style>
+    <style>
+      html,
+      body {
+        height: 100%;
+      }
+
+      body {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        padding: 24px;
+        box-sizing: border-box;
+        background: #000;
+        color: #fff;
+        overflow: hidden;
+      }
+
+      canvas,
+      #hud {
+        width: min(90vw, 45vh);
+        max-width: 100%;
+      }
+
+      canvas {
+        aspect-ratio: 1 / 2;
+        height: auto;
+        max-height: 90vh;
+        display: block;
+      }
+
+      #hud {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+    </style>
   </head>
   <body>
     <canvas


### PR DESCRIPTION
## Summary
- use a flex-based layout to center the Tetris canvas and HUD against the dark background
- constrain the canvas and HUD sizing with aspect-ratio friendly max dimensions so they remain centered on varying viewports

## Testing
- Manually viewed http://127.0.0.1:4173/gameshells/tetris/index.html

------
https://chatgpt.com/codex/tasks/task_e_68d6e74592d08327bc59c3c8ee5ae8af