### PR TITLE
Prevent legacy diagnostic duplication

### DIFF
--- a/js/auto-diag-inject.js
+++ b/js/auto-diag-inject.js
@@ -7,6 +7,8 @@
       const doc = frame.contentDocument || frame.contentWindow?.document;
       if(!doc) return;
       if(doc.getElementById('gg-diag-autowire')) return; // already injected
+      // Legacy shells already handle diagnostics when data-shell-diag markers exist.
+      if(doc.querySelector('script[data-shell-diag], [data-shell-diag]')) return;
       const s = doc.createElement('script');
       s.id = 'gg-diag-autowire';
       // Use absolute path from loader to avoid relative path issues


### PR DESCRIPTION
## Summary
- skip injecting diag-autowire when legacy diagnostic markers are detected inside the iframe

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6f7a17f788327a4b5a406c009fb5e