### PR TITLE
Improve Tetris canvas responsiveness

### DIFF
--- a/games/tetris/play.html
+++ b/games/tetris/play.html
@@ -12,9 +12,22 @@
       border: 1px solid rgba(255, 255, 255, 0.08);
       box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
       display: block;
-      width: min(100%, 420px);
+      width: min(100%, 720px);
       height: auto;
       margin: 0 auto;
+    }
+
+    body.game-shell .hud {
+      --hud-max-width: var(--tetris-hud-max-width, 720px);
+      --hud-center: var(--tetris-hud-center, 50%);
+      --hud-top: var(--tetris-hud-top, 16px);
+    }
+
+    body.game-shell .hud .toast {
+      left: var(--hud-center);
+      top: var(--hud-top);
+      max-width: min(100%, var(--hud-max-width));
+      width: min(100%, var(--hud-max-width));
     }
   </style>
 </head>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -35,8 +35,29 @@ if(c){
   c.dataset.baseh=String(BASE_H);
   c.width=BASE_W;
   c.height=BASE_H;
-  fitCanvasToParent(c,420,840,24);
-  addEventListener('resize',()=>fitCanvasToParent(c,420,840,24));
+  const CANVAS_PADDING=24;
+  const MAX_CANVAS_WIDTH=720;
+  const MAX_CANVAS_HEIGHT=1440;
+
+  function syncHudLayout(){
+    const root=document.documentElement?.style;
+    if(!root) return;
+    const rect=c.getBoundingClientRect();
+    root.setProperty('--tetris-hud-max-width',`${Math.round(rect.width)}px`);
+    root.setProperty('--tetris-hud-center',`${Math.round(rect.left+rect.width/2)}px`);
+    const top=Math.max(rect.top+16,CANVAS_PADDING);
+    root.setProperty('--tetris-hud-top',`${Math.round(top)}px`);
+  }
+
+  function applyResponsiveCanvas(){
+    const availableW=Math.max(BASE_W,Math.min(window.innerWidth-CANVAS_PADDING*2,MAX_CANVAS_WIDTH));
+    const availableH=Math.max(BASE_H,Math.min(window.innerHeight-CANVAS_PADDING*2,MAX_CANVAS_HEIGHT));
+    fitCanvasToParent(c,availableW,availableH,CANVAS_PADDING);
+    syncHudLayout();
+  }
+
+  applyResponsiveCanvas();
+  addEventListener('resize',applyResponsiveCanvas);
 }else{
   const error=new Error('Tetris: unable to locate a canvas element (#t or #gameCanvas).');
   console.error(error);


### PR DESCRIPTION
## Summary
- allow the Tetris canvas to grow to 720×1440 with viewport-aware bounds and keep the resize listener in sync
- update HUD alignment variables whenever the canvas fits so overlays remain centered on the playfield
- widen the play page canvas styling and scope HUD toast styles to respect the new dynamic width

## Testing
- npm run test:unit


------
https://chatgpt.com/codex/tasks/task_e_68d6f7b8fdb48327923a5ecb7f22580f