### PR TITLE
Improve Snake boot diagnostics

### DIFF
--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -122,6 +122,7 @@
   <script type="module" src="./snake.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="snake"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="snake"></script>
+  <script src="../common/diag-autowire.js" defer></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
@@ -151,8 +152,5 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-  <link rel="stylesheet" href="../common/diag-modal.css">
-  <script src="../common/diag-core.js" defer></script>
-  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the Snake game resolves the `#game` canvas and creates a fallback before sizing helpers run
- add shared `window.__bootStatus` logging plus canvas and requestAnimationFrame watchdogs to catch future boot regressions
- switch the Snake diagnostics wiring to the unified auto-wired module so the new logs surface without duplicate overlays

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6fa06ff5083278c0735f707d42cf9