### PR TITLE
Adjust status overlay pointer handling

### DIFF
--- a/game.html
+++ b/game.html
@@ -57,10 +57,11 @@
       height: 100vh;
     }
     .status {
-      pointer-events:auto; background: rgba(12,18,28,0.92); border:1px solid #223049; border-radius:12px;
+      pointer-events:none; background: rgba(12,18,28,0.92); border:1px solid #223049; border-radius:12px;
       padding:16px; width:min(560px, 90%);
       color:#f3f7ff;
     }
+    .status .logbox { pointer-events:auto; }
     .status h2 { margin:0 0 6px; font-size:16px; }
     .status p { margin:6px 0 0; color: var(--muted); }
     .row { display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }


### PR DESCRIPTION
## Summary
- disable pointer interaction on the status overlay so missing readiness signals no longer block gameplay
- re-enable pointer events on the embedded log scroller to keep it selectable and scrollable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daf99dba48832781a2b7050307a422