### PR TITLE
Normalize game boot quest tagging from catalog

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -14,7 +14,8 @@ The client-side interface communicates with modular game logic. State is saved l
 ## Updating Game Data
 
 Game metadata displayed on the landing page lives in the repository root `games.json` file.
-The deployed site now consumes `/games.json` directly (with a compatibility fallback to `/public/games.json` for older builds). Treat `games.json` as the source of truth and re-run the sync script when entries change.
+The deployed site now consumes `/games.json` directly (with a compatibility fallback to `/public/games.json` for older builds). Pages can boot straight from that raw catalog data — the runtime normalizes entries so games with only an `id` still expose their tags for quests.
+Treat `games.json` as the source of truth and re-run the sync script when entries change.
 
 To add a new entry:
 

--- a/shared/game-boot.js
+++ b/shared/game-boot.js
@@ -2,6 +2,7 @@
 // Usage in a game page: <script type="module" src="../../shared/game-boot.js" data-slug="runner"></script>
 import { injectBackButton, injectHelpButton, recordLastPlayed } from './ui.js';
 import { recordPlay } from './quests.js';
+import { normalizeCatalogEntries } from './game-catalog-core.js';
 import { renderFallbackPanel } from './fallback.js';
 import { preloadFirstFrameAssets } from './game-asset-preloader.js';
 
@@ -33,8 +34,14 @@ async function track(){
     }
     if (!data) throw new Error('catalog unavailable');
     const games = Array.isArray(data.games) ? data.games : (Array.isArray(data) ? data : []);
-    const g = games.find(g => g.slug === slug);
-    if (g) tags = g.tags || [];
+    const normalized = normalizeCatalogEntries(games);
+    const normalizedMatch = normalized.find(g => g.slug === slug || g.id === slug);
+    const rawMatch = normalizedMatch ? null : games.find(g => g?.slug === slug || g?.id === slug);
+    const match = normalizedMatch || rawMatch;
+    if (match) {
+      const sourceTags = normalizedMatch ? normalizedMatch.tags : match.tags;
+      tags = Array.isArray(sourceTags) ? sourceTags : [];
+    }
   } catch {}
   recordPlay(slug, tags);
 }

--- a/tests/game-boot.test.js
+++ b/tests/game-boot.test.js
@@ -1,0 +1,102 @@
+/* @vitest-environment jsdom */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { getActiveQuests, getXP } from '../shared/quests.js';
+
+vi.mock('../shared/ui.js', () => ({
+  injectBackButton: vi.fn(),
+  injectHelpButton: vi.fn(),
+  recordLastPlayed: vi.fn()
+}));
+
+vi.mock('../shared/fallback.js', () => ({
+  renderFallbackPanel: vi.fn()
+}));
+
+vi.mock('../shared/game-asset-preloader.js', () => ({
+  preloadFirstFrameAssets: vi.fn()
+}));
+
+function findDateForDailyQuest(id){
+  const start = new Date('2025-01-01');
+  for (let i = 0; i < 365; i++){
+    const d = new Date(start.getTime() + i * 86400000);
+    const qs = getActiveQuests(d).daily;
+    if (qs.some(q => q.id === id)) return d;
+  }
+  throw new Error('quest not found');
+}
+
+describe('game boot quest tracking', () => {
+  const originalCurrentScript = Object.getOwnPropertyDescriptor(document, 'currentScript');
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+    document.body.innerHTML = '';
+    delete global.fetch;
+    if (originalCurrentScript){
+      Object.defineProperty(document, 'currentScript', originalCurrentScript);
+    } else {
+      delete document.currentScript;
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete global.fetch;
+    if (originalCurrentScript){
+      Object.defineProperty(document, 'currentScript', originalCurrentScript);
+    } else {
+      delete document.currentScript;
+    }
+  });
+
+  it('increments the 3D quest when chess3d boots from raw catalog data', async () => {
+    const targetDate = findDateForDailyQuest('d_play3d3');
+    vi.useFakeTimers();
+    vi.setSystemTime(targetDate);
+
+    const catalog = [
+      { id: 'chess3d', tags: ['3D'] },
+      { id: 'runner', tags: ['endless'] }
+    ];
+
+    global.fetch = vi.fn(async url => {
+      if (url === '/games.json'){
+        return {
+          ok: true,
+          status: 200,
+          async json(){
+            return catalog;
+          }
+        };
+      }
+      return {
+        ok: false,
+        status: 404,
+        async json(){
+          return {};
+        }
+      };
+    });
+
+    const script = document.createElement('script');
+    script.dataset.slug = 'chess3d';
+    document.body.appendChild(script);
+    Object.defineProperty(document, 'currentScript', {
+      configurable: true,
+      value: script
+    });
+
+    await import('../shared/game-boot.js');
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const quest = getActiveQuests(targetDate).daily.find(q => q.id === 'd_play3d3');
+    expect(quest?.progress).toBe(1);
+    expect(getXP()).toBe(0);
+    expect(global.fetch).toHaveBeenCalledWith('/games.json', expect.any(Object));
+  });
+});
+


### PR DESCRIPTION
## Summary
- normalize game boot catalog lookups so entries are matched by slug or id before retrieving tags
- ensure quest tracking receives the normalized tag list and cover chess3d booting with raw catalog data
- document that runtime normalization allows pages to load directly from the raw `games.json` catalog

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dd6f89f9cc8327a4870c60ac42b577