### PR TITLE
Add recently played history section to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Our mission is to build a friendly, open playground for accessible HTML5 games. 
 ## ✨ Features
 
 - **Curated game library** – browse and launch games from a unified interface that works on desktop and mobile.
+- **Recently played shortcuts** – the landing page highlights your stored history for quick access to favorite titles.
 - **Game loader with diagnostics** – `js/game-loader.js` boots each game and surfaces clear error messages when something goes wrong.
 - **Service Worker caching** – a network‑first strategy keeps JavaScript fresh while enabling offline support for assets.
 - **Accessible design** – semantic HTML, ARIA labels and responsive layouts provide an inclusive experience.

--- a/css/bolt-landing.css
+++ b/css/bolt-landing.css
@@ -102,6 +102,11 @@ body.bolt-body{
 @media (max-width: 760px){ .bolt-grid{grid-template-columns:repeat(2,1fr)}}
 @media (max-width: 420px){ .bolt-grid{grid-template-columns:1fr}}
 
+.bolt-history{margin:30px 0 34px;padding:22px 22px 26px;border:1px solid var(--bolt-border);border-radius:22px;background:rgba(0,0,0,.22);backdrop-filter:blur(6px)}
+.bolt-history[hidden]{display:none}
+.bolt-history-title{margin:0 0 18px;font-size:24px}
+.bolt-history-grid{margin:0}
+
 .bolt-card{background:linear-gradient(180deg, var(--bolt-card) 0%, var(--bolt-card-2) 100%);border:1px solid var(--bolt-border);border-radius:18px;overflow:hidden;display:flex;flex-direction:column;transition:transform .2s ease, background .2s ease, border-color .2s ease}
 .bolt-card:hover{transform:translateY(-2px);border-color:rgba(255,255,255,.25)}
 .bolt-shot{aspect-ratio: 16/9; display:grid; place-items:center; position:relative; background:#0f1020}


### PR DESCRIPTION
## Summary
- surface stored last-played games on the landing page using shared history data
- add styling for the recently played section and ensure it is hidden when empty
- document the new shortcut feature in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd714dd08c8327b07ad9c79c22f4d1