### PR TITLE
Add quest progress widget to shell

### DIFF
--- a/game.html
+++ b/game.html
@@ -11,7 +11,7 @@
     body {
       margin: 0; background: linear-gradient(180deg, #0b0f14, #111827 35%, #0b0f14);
       color: #e5f0ff; font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-      display: grid; grid-template-rows: auto 1fr auto; gap: 8px;
+      display: grid; grid-template-rows: auto auto 1fr auto; gap: 8px;
     }
     body.legacy-shell {
       display: block;
@@ -71,6 +71,109 @@
     }
     .hidden { display:none; }
     footer { padding: 10px 14px; border-top: 1px solid #243042; color: #a8c3df; }
+    .quest-widget {
+      padding: 0 14px;
+    }
+    .quest-widget-panel {
+      background: rgba(12,18,28,0.92);
+      border: 1px solid #223049;
+      border-radius: 12px;
+      padding: 16px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+      display: grid;
+      gap: 12px;
+    }
+    .quest-widget-heading {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 600;
+    }
+    .quest-widget-xp-total {
+      margin: 0;
+      font-size: 13px;
+      color: var(--muted);
+    }
+    .quest-widget-group {
+      display: grid;
+      gap: 8px;
+    }
+    .quest-widget-subheading {
+      margin: 0;
+      font-size: 14px;
+      color: #d3e6ff;
+    }
+    .quest-widget-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 8px;
+    }
+    .quest-widget-item {
+      border: 1px solid rgba(76,201,240,0.25);
+      border-radius: 10px;
+      padding: 10px 12px;
+      background: rgba(15,22,34,0.8);
+      outline: none;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .quest-widget-item:focus-visible {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(76,201,240,0.35);
+    }
+    .quest-widget-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      font-weight: 600;
+    }
+    .quest-widget-label {
+      font-size: 14px;
+    }
+    .quest-widget-xp {
+      font-size: 12px;
+      color: #4cc9f0;
+      font-weight: 600;
+    }
+    .quest-widget-progress {
+      height: 8px;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.08);
+      margin-top: 8px;
+      overflow: hidden;
+      position: relative;
+    }
+    .quest-widget-progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #4cc9f0, #4895ef);
+    }
+    .quest-widget-status {
+      margin-top: 6px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+    .quest-widget-item.is-complete {
+      border-color: #4cc9f0;
+      background: rgba(76,201,240,0.12);
+    }
+    .quest-widget-item.is-complete .quest-widget-status {
+      color: #7ae0ff;
+      font-weight: 600;
+    }
+    .quest-widget-empty {
+      text-align: center;
+      color: var(--muted);
+      font-style: italic;
+    }
+    .quest-widget-note {
+      margin: 4px 0 0;
+      font-size: 12px;
+      color: var(--muted);
+    }
+    body.legacy-shell .quest-widget {
+      display: none;
+    }
     .sr-only {
       position: absolute;
       width: 1px;
@@ -99,6 +202,8 @@
     </nav>
   </header>
 
+  <section id="questWidgetRoot" class="quest-widget" aria-live="polite"></section>
+
   <main>
     <section class="game-card" aria-live="polite">
       <iframe id="game-frame" title="Game frame" sandbox="allow-scripts allow-same-origin allow-pointer-lock"></iframe>
@@ -123,6 +228,14 @@
   </footer>
 
   <script src="./js/auto-diag-inject.js"></script>
+
+  <script type="module">
+    import { mountQuestWidget } from './shared/quest-widget.js';
+    const root = document.getElementById('questWidgetRoot');
+    if (root) {
+      mountQuestWidget(root, { headingLevel: 2, regionLabel: 'Quest progress tracker' });
+    }
+  </script>
 
   <script>
     (function () {

--- a/shared/quest-widget.js
+++ b/shared/quest-widget.js
@@ -1,0 +1,144 @@
+import { getActiveQuests, getXP, QUESTS_UPDATED_EVENT } from './quests.js';
+
+const DEFAULT_OPTIONS = {
+  headingLevel: 2,
+  regionLabel: 'Quest progress'
+};
+
+function createHeading(level, text){
+  const safeLevel = Math.min(6, Math.max(1, Number(level) || 2));
+  const el = document.createElement(`h${safeLevel}`);
+  el.textContent = text;
+  return el;
+}
+
+function createGroup(title){
+  const container = document.createElement('section');
+  container.className = 'quest-widget-group';
+  const heading = createHeading(3, title);
+  heading.classList.add('quest-widget-subheading');
+  container.appendChild(heading);
+
+  const list = document.createElement('ul');
+  list.className = 'quest-widget-list';
+  list.setAttribute('role', 'list');
+  container.appendChild(list);
+
+  return { container, list };
+}
+
+function renderList(listEl, quests, emptyLabel){
+  listEl.innerHTML = '';
+  if (!quests?.length){
+    const empty = document.createElement('li');
+    empty.className = 'quest-widget-item quest-widget-empty';
+    empty.tabIndex = 0;
+    empty.textContent = emptyLabel;
+    listEl.appendChild(empty);
+    return;
+  }
+
+  quests.forEach(quest => {
+    const item = document.createElement('li');
+    item.className = 'quest-widget-item';
+    item.tabIndex = 0;
+
+    if (quest.completed) item.classList.add('is-complete');
+
+    const row = document.createElement('div');
+    row.className = 'quest-widget-row';
+    const label = document.createElement('span');
+    label.className = 'quest-widget-label';
+    label.textContent = quest.description;
+    row.appendChild(label);
+
+    const xp = document.createElement('span');
+    xp.className = 'quest-widget-xp';
+    xp.textContent = `+${quest.xp} XP`;
+    row.appendChild(xp);
+    item.appendChild(row);
+
+    const progress = document.createElement('div');
+    progress.className = 'quest-widget-progress';
+    progress.setAttribute('role', 'progressbar');
+    progress.setAttribute('aria-valuemin', '0');
+    progress.setAttribute('aria-valuemax', String(quest.goal));
+    const current = Math.min(quest.progress || 0, quest.goal);
+    progress.setAttribute('aria-valuenow', String(current));
+    progress.setAttribute('aria-label', `${quest.description} (${current} of ${quest.goal})`);
+
+    const fill = document.createElement('div');
+    fill.className = 'quest-widget-progress-fill';
+    const pct = quest.goal > 0 ? Math.min(100, (current / quest.goal) * 100) : 0;
+    fill.style.width = `${pct}%`;
+    progress.appendChild(fill);
+    item.appendChild(progress);
+
+    const status = document.createElement('div');
+    status.className = 'quest-widget-status';
+    status.textContent = quest.completed ? 'Completed' : `${current} / ${quest.goal}`;
+    item.appendChild(status);
+
+    listEl.appendChild(item);
+  });
+}
+
+export function mountQuestWidget(root, options = {}){
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  if (!root) return null;
+
+  root.classList.add('quest-widget');
+
+  const panel = document.createElement('section');
+  panel.className = 'quest-widget-panel';
+  panel.setAttribute('role', 'region');
+  panel.setAttribute('aria-live', 'polite');
+  panel.setAttribute('aria-label', opts.regionLabel);
+
+  const heading = createHeading(opts.headingLevel, 'Quests');
+  heading.classList.add('quest-widget-heading');
+  panel.appendChild(heading);
+
+  const xpLine = document.createElement('p');
+  xpLine.className = 'quest-widget-xp-total';
+  panel.appendChild(xpLine);
+
+  const daily = createGroup('Daily quests');
+  const weekly = createGroup('Weekly quest');
+  panel.appendChild(daily.container);
+  panel.appendChild(weekly.container);
+
+  const refreshNote = document.createElement('p');
+  refreshNote.className = 'quest-widget-note';
+  refreshNote.textContent = 'Daily quests reset at 00:00 UTC. Weekly quests reset every Monday (UTC).';
+  panel.appendChild(refreshNote);
+
+  root.appendChild(panel);
+
+  function render(detail){
+    const data = detail && typeof detail === 'object' ? detail : null;
+    const quests = data?.daily && data?.weekly ? data : getActiveQuests();
+    const xp = typeof data?.xp === 'number' ? data.xp : getXP();
+
+    xpLine.textContent = `Total XP: ${xp.toLocaleString()}`;
+    renderList(daily.list, quests.daily, 'No daily quests right now. Check back soon!');
+    renderList(weekly.list, quests.weekly, 'No weekly quest available.');
+  }
+
+  render();
+
+  const onUpdate = (event) => {
+    render(event?.detail);
+  };
+
+  window.addEventListener(QUESTS_UPDATED_EVENT, onUpdate);
+
+  return {
+    destroy(){
+      window.removeEventListener(QUESTS_UPDATED_EVENT, onUpdate);
+      root.innerHTML = '';
+    }
+  };
+}
+
+export default { mountQuestWidget };


### PR DESCRIPTION
## Summary
- add a reusable quest widget that renders daily and weekly progress and mount it in the shell UI
- emit a `quests:updated` event with refreshed progress and XP whenever quest data changes
- document how quests rotate, award XP, and can be observed by widgets

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dd714f3500832791c75b99b50bef47