### PR TITLE
Revamp sitemap generation for flexible catalog support

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,9 +4,15 @@
   <url><loc>/stats.html</loc></url>
   <url><loc>/cabinet.html</loc></url>
   <url><loc>/games/pong/</loc></url>
-  <url><loc>/games/runner/</loc></url>
+  <url><loc>/games/snake/</loc></url>
+  <url><loc>/games/tetris/</loc></url>
+  <url><loc>/games/breakout/</loc></url>
+  <url><loc>/games/chess/</loc></url>
+  <url><loc>/games/chess3d/</loc></url>
+  <url><loc>/games/2048/</loc></url>
   <url><loc>/games/asteroids/</loc></url>
-  <url><loc>/games/shooter/</loc></url>
-  <url><loc>/games/platformer/</loc></url>
   <url><loc>/games/maze3d/</loc></url>
+  <url><loc>/games/platformer/</loc></url>
+  <url><loc>/games/runner/</loc></url>
+  <url><loc>/games/shooter/</loc></url>
 </urlset>

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+import { generateSitemap } from '../tools/generate-sitemap.mjs';
+
+async function createTempDir() {
+  const base = tmpdir();
+  return mkdtemp(path.join(base, 'sitemap-test-'));
+}
+
+describe('generate-sitemap', () => {
+  it('generates sitemap output from the current catalog', async () => {
+    const dir = await createTempDir();
+    const outputPath = path.join(dir, 'sitemap.xml');
+
+    const xml = await generateSitemap({ outputPath });
+
+    expect(xml).toMatch(/<urlset/);
+    expect(xml).toMatch(/<loc>\/stats.html<\/loc>/);
+    const written = await readFile(outputPath, 'utf8');
+    expect(written).toBe(xml);
+  });
+});

--- a/tools/generate-sitemap.mjs
+++ b/tools/generate-sitemap.mjs
@@ -1,17 +1,51 @@
-import {readFile, writeFile} from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFile, writeFile } from 'node:fs/promises';
 
-const data = JSON.parse(await readFile(new URL('../games.json', import.meta.url), 'utf8'));
+import { normalizeCatalogEntries } from '../shared/game-catalog-core.js';
+import { buildIndexPath } from '../shared/game-path-utils.js';
 
-const gamePaths = data.games.map(g => {
-  const p = g.path.replace(/^\.\//, '/');
-  return p.startsWith('/') ? p : `/${p}`;
-});
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
 
-const urls = ['/', '/stats.html', '/cabinet.html', ...gamePaths];
+function toSitemapUrl(value) {
+  if (!value) return null;
+  const str = String(value).trim();
+  if (!str) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(str)) return str;
+  let normalized = str.replace(/^\.\//, '');
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+  return normalized;
+}
 
-const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
-  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-  urls.map(u => `  <url><loc>${u}</loc></url>`).join('\n') +
-  `\n</urlset>\n`;
+export async function generateSitemap({
+  catalogPath = path.join(rootDir, 'games.json'),
+  outputPath = path.join(rootDir, 'sitemap.xml')
+} = {}) {
+  const data = JSON.parse(await readFile(catalogPath, 'utf8'));
+  const entries = Array.isArray(data) ? data : data.games ?? [];
+  const games = normalizeCatalogEntries(entries);
 
-await writeFile(new URL('../sitemap.xml', import.meta.url), xml);
+  const gamePaths = games
+    .map(game => toSitemapUrl(game?.playUrl || game?.playPath || (game?.basePath ? buildIndexPath(game.basePath) : null)))
+    .filter(Boolean);
+
+  const urls = Array.from(new Set(['/', '/stats.html', '/cabinet.html', ...gamePaths]));
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n`
+    + `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n`
+    + urls.map(u => `  <url><loc>${u}</loc></url>`).join('\n')
+    + `\n</urlset>\n`;
+
+  await writeFile(outputPath, xml);
+  return xml;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  generateSitemap().catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- update the sitemap generator to normalize catalog input, derive play paths, and export a reusable function
- regenerate the committed sitemap.xml using the updated generator
- add a vitest check that ensures sitemap creation succeeds against the current games.json

## Testing
- npm run test:unit
- npm run sitemap

------
https://chatgpt.com/codex/tasks/task_e_68dd75c9d8048327872e3f6534eb5e02