### PR TITLE
Escape static router path segments

### DIFF
--- a/scripts/router.js
+++ b/scripts/router.js
@@ -17,10 +17,18 @@ export class Router {
 
   register(path, loader, guard) {
     const keys = [];
-    const pattern = new RegExp('^' + path.replace(/:([^/]+)/g, (_, k) => {
-      keys.push(k);
-      return '([^/]+)';
-    }) + '$');
+    const escapeRegExp = segment => segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const patternSource = path
+      .split(/(:[^/]+)/g)
+      .map(part => {
+        if (part.startsWith(':')) {
+          keys.push(part.slice(1));
+          return '([^/]+)';
+        }
+        return escapeRegExp(part);
+      })
+      .join('');
+    const pattern = new RegExp('^' + patternSource + '$');
     this.routes.push({ pattern, keys, loader, guard });
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -30,10 +30,18 @@ export class Router {
 
   register(path: string, loader: Loader, guard?: Guard) {
     const keys: string[] = [];
-    const pattern = new RegExp('^' + path.replace(/:([^/]+)/g, (_, k) => {
-      keys.push(k);
-      return '([^/]+)';
-    }) + '$');
+    const escapeRegExp = (segment: string) => segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const patternSource = path
+      .split(/(:[^/]+)/g)
+      .map(part => {
+        if (part.startsWith(':')) {
+          keys.push(part.slice(1));
+          return '([^/]+)';
+        }
+        return escapeRegExp(part);
+      })
+      .join('');
+    const pattern = new RegExp('^' + patternSource + '$');
     this.routes.push({ pattern, keys, loader, guard });
   }
 

--- a/tests/router.guard.test.js
+++ b/tests/router.guard.test.js
@@ -37,4 +37,28 @@ describe('Router guard navigation', () => {
     replaceSpy.mockRestore();
     history.replaceState({}, '', originalPathname);
   });
+
+  test('static routes with dots only match exact paths', async () => {
+    const outlet = document.createElement('div');
+    const router = new Router(outlet);
+
+    const statsHandler = vi.fn();
+    const statsLoader = vi.fn(async () => ({ default: statsHandler }));
+    const statsXHandler = vi.fn();
+    const statsXLoader = vi.fn(async () => ({ default: statsXHandler }));
+
+    router.register('/stats.html', statsLoader);
+    router.register('/statsXhtml', statsXLoader);
+
+    await router.resolve('/stats.html');
+    expect(statsLoader).toHaveBeenCalledTimes(1);
+    expect(statsHandler).toHaveBeenCalledTimes(1);
+    expect(statsXLoader).not.toHaveBeenCalled();
+
+    await router.resolve('/statsXhtml');
+    expect(statsLoader).toHaveBeenCalledTimes(1);
+    expect(statsHandler).toHaveBeenCalledTimes(1);
+    expect(statsXLoader).toHaveBeenCalledTimes(1);
+    expect(statsXHandler).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- escape the static portions of router paths before parameter substitution to prevent unintended regex matches
- apply the same escaping logic to the distributed router script
- cover dotted static routes with a test to ensure exact matching behavior

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dd76b497a88327bade69c647c1a2c2