### PR TITLE
Add preview art support to game cards

### DIFF
--- a/scripts/components/game-card.js
+++ b/scripts/components/game-card.js
@@ -5,6 +5,9 @@ loadStyle('styles/components/game-card.css');
 const template = document.createElement('template');
 template.innerHTML = `
   <article class="game-card">
+    <div class="game-card__media" hidden>
+      <img class="game-card__art" alt="" loading="lazy" />
+    </div>
     <h3 class="game-title"></h3>
     <p class="game-short"></p>
     <div class="tags"></div>
@@ -15,6 +18,18 @@ template.innerHTML = `
 export function createGameCard(game) {
   const fragment = template.content.cloneNode(true);
   const card = fragment.querySelector('.game-card');
+  const sprite = game.firstFrame?.sprites?.[0] || null;
+  const media = card.querySelector('.game-card__media');
+
+  if (sprite) {
+    const art = media.querySelector('.game-card__art');
+    art.src = sprite;
+    art.alt = `${game.title} preview frame`;
+    media.hidden = false;
+  } else {
+    media.remove();
+  }
+
   card.querySelector('.game-title').textContent = game.title;
   card.querySelector('.game-short').textContent = game.short || '';
   const tagsEl = card.querySelector('.tags');

--- a/styles/components/game-card.css
+++ b/styles/components/game-card.css
@@ -10,6 +10,27 @@
   gap: 0.5rem;
 }
 
+.game-card__media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: #f5f5f5;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.game-card__media[hidden] {
+  display: none;
+}
+
+.game-card__art {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0));
+}
+
 .game-card h3 {
   margin: 0;
   font-size: 1.1rem;

--- a/tests/game-card.preview.test.js
+++ b/tests/game-card.preview.test.js
@@ -1,0 +1,31 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createGameCard } from '../scripts/components/game-card.js';
+
+describe('createGameCard', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  it('renders preview art when firstFrame sprite is provided', () => {
+    const game = {
+      id: 'demo',
+      title: 'Demo Game',
+      short: 'A test entry',
+      firstFrame: {
+        sprites: ['https://example.com/demo.png']
+      }
+    };
+
+    const card = createGameCard(game);
+    const media = card.querySelector('.game-card__media');
+    const art = card.querySelector('.game-card__art');
+
+    expect(media).toBeTruthy();
+    expect(media?.hasAttribute('hidden')).toBe(false);
+    expect(art).toBeTruthy();
+    expect(art?.getAttribute('src')).toBe('https://example.com/demo.png');
+    expect(art?.getAttribute('alt')).toBe('Demo Game preview frame');
+  });
+});


### PR DESCRIPTION
## Summary
- render preview art in game cards when a first frame sprite is available
- style the new media block so cards look consistent with or without art
- cover the preview markup with a jsdom unit test

## Testing
- npx vitest run tests/game-card.preview.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd76bca1508327b0c063247dac5e37