### PR TITLE
Add tutorial engine with analytics and scripted hints

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,6 @@
+"""Analytics helpers for backend features."""
+
+from .metrics import MetricsEvent, MetricsExporter
+from .tutorial import TutorialAnalytics
+
+__all__ = ["MetricsEvent", "MetricsExporter", "TutorialAnalytics"]

--- a/analytics/metrics.py
+++ b/analytics/metrics.py
@@ -1,0 +1,57 @@
+"""Utilities for exporting analytics events to the metrics system."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class MetricsEvent:
+    """Container describing a single analytics event."""
+
+    name: str
+    payload: Dict[str, object]
+
+
+class MetricsExporter:
+    """Collects analytics events and optionally forwards them to a sink."""
+
+    def __init__(
+        self,
+        emitter: Optional[Callable[[MetricsEvent], None]] = None,
+    ) -> None:
+        self._events: List[MetricsEvent] = []
+        self._emitter = emitter
+
+    def record(self, name: str, payload: Optional[Dict[str, object]] = None) -> None:
+        """Store an event and emit it if a sink is configured."""
+
+        event = MetricsEvent(name=name, payload=dict(payload or {}))
+        self._events.append(event)
+        if self._emitter is not None:
+            self._emitter(event)
+
+    @property
+    def events(self) -> List[MetricsEvent]:
+        """Return a snapshot of the collected events."""
+
+        return list(self._events)
+
+    def export_counts(self) -> Dict[str, int]:
+        """Aggregate counts per metric for quick assertions and summaries."""
+
+        counts: Dict[str, int] = {}
+        for event in self._events:
+            tutorial = event.payload.get("tutorial")
+            key = f"{event.name}:{tutorial}" if tutorial else event.name
+            counts[key] = counts.get(key, 0) + 1
+        return counts
+
+    def clear(self) -> None:
+        """Reset the internal event buffer."""
+
+        self._events.clear()
+
+
+__all__ = ["MetricsEvent", "MetricsExporter"]

--- a/analytics/tutorial.py
+++ b/analytics/tutorial.py
@@ -1,0 +1,48 @@
+"""Analytics helpers tailored to tutorial engagement."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .metrics import MetricsExporter
+
+
+class TutorialAnalytics:
+    """Wraps metric exports for tutorial-specific events."""
+
+    def __init__(self, exporter: Optional[MetricsExporter] = None) -> None:
+        self._exporter = exporter or MetricsExporter()
+
+    @property
+    def exporter(self) -> MetricsExporter:
+        return self._exporter
+
+    def track_tutorial_start(self, tutorial_id: str) -> None:
+        self._exporter.record("tutorial_started", {"tutorial": tutorial_id})
+
+    def track_step_engaged(self, tutorial_id: str, step_id: str) -> None:
+        self._exporter.record(
+            "tutorial_step_engaged",
+            {"tutorial": tutorial_id, "step": step_id},
+        )
+
+    def track_step_completed(self, tutorial_id: str, step_id: str) -> None:
+        self._exporter.record(
+            "tutorial_step_completed",
+            {"tutorial": tutorial_id, "step": step_id},
+        )
+
+    def track_tutorial_completed(self, tutorial_id: str, steps_completed: int) -> None:
+        self._exporter.record(
+            "tutorial_completed",
+            {"tutorial": tutorial_id, "steps": steps_completed},
+        )
+
+    def track_hint_visibility(self, tutorial_id: str, enabled: bool) -> None:
+        self._exporter.record(
+            "tutorial_hints_toggled",
+            {"tutorial": tutorial_id, "enabled": bool(enabled)},
+        )
+
+
+__all__ = ["TutorialAnalytics"]

--- a/scenes/tutorial_scene.py
+++ b/scenes/tutorial_scene.py
@@ -1,0 +1,69 @@
+"""Scene controller dedicated to tutorial flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from analytics import TutorialAnalytics
+from tutorial.engine import TutorialEngine, TutorialStep
+
+
+@dataclass
+class SceneState:
+    """Serializable snapshot consumed by the UI layer."""
+
+    tutorial: Optional[str]
+    step: Optional[str]
+    text: Optional[str]
+    objectives: List[str]
+    hints: List[str]
+    completed: List[str]
+    hints_enabled: bool
+    is_completed: bool
+
+
+class TutorialScene:
+    """High-level façade that wires the tutorial engine to the UI."""
+
+    def __init__(self, engine: Optional[TutorialEngine] = None) -> None:
+        self.engine = engine or TutorialEngine()
+        self.analytics: TutorialAnalytics = self.engine.analytics
+
+    def start(self, tutorial_id: str) -> SceneState:
+        self.engine.load(tutorial_id)
+        return self.state()
+
+    def state(self, context: Optional[Dict[str, object]] = None) -> SceneState:
+        engine_state = self.engine.snapshot()
+        step: Optional[TutorialStep] = self.engine.current_step
+        hints = self.engine.get_hints(context)
+        return SceneState(
+            tutorial=engine_state["tutorial"],
+            step=engine_state["step"],
+            text=step.text if step else None,
+            objectives=step.objectives if step else [],
+            hints=hints,
+            completed=engine_state["completed"],
+            hints_enabled=engine_state["hintsEnabled"],
+            is_completed=engine_state["isCompleted"],
+        )
+
+    def set_hints_enabled(self, enabled: bool) -> None:
+        self.engine.set_hints_enabled(enabled)
+        script = self.engine.script
+        if script:
+            self.analytics.track_hint_visibility(script.id, enabled)
+
+    def on_player_event(self, event: str, context: Optional[Dict[str, object]] = None) -> SceneState:
+        self.engine.record_event(event, context)
+        return self.state(context)
+
+    def toggle_hints(self) -> None:
+        self.set_hints_enabled(not self.engine.hints_enabled)
+
+    def is_completed(self) -> bool:
+        return self.engine.is_completed()
+
+
+__all__ = ["TutorialScene", "SceneState"]

--- a/tests/python/test_tutorial_engine.py
+++ b/tests/python/test_tutorial_engine.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import unittest
+
+from analytics import MetricsExporter, TutorialAnalytics
+from scenes.tutorial_scene import TutorialScene
+from tutorial.engine import TutorialEngine
+
+
+class TutorialEngineTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.metrics = MetricsExporter()
+        self.analytics = TutorialAnalytics(exporter=self.metrics)
+        self.engine = TutorialEngine(analytics=self.analytics)
+        self.engine.load("getting_started")
+
+    def test_progression_and_analytics(self) -> None:
+        self.assertEqual(self.engine.current_step.id, "welcome")
+        self.engine.record_event("ui:start_pressed")
+        self.assertEqual(self.engine.current_step.id, "movement")
+        self.engine.record_event("movement:checkpoint_reached")
+        self.assertEqual(self.engine.current_step.id, "jump")
+        self.engine.record_event("movement:jump_success")
+        self.assertTrue(self.engine.is_completed())
+
+        counts = self.metrics.export_counts()
+        self.assertEqual(counts["tutorial_started:getting_started"], 1)
+        self.assertEqual(counts["tutorial_step_completed:getting_started"], 3)
+        self.assertEqual(counts["tutorial_completed:getting_started"], 1)
+
+    def test_ml_hint_generator_used(self) -> None:
+        captured = {}
+
+        def fake_generator(tutorial_id, step, context, fallback):
+            captured["tutorial"] = tutorial_id
+            captured["step"] = step.id
+            captured["fallback"] = list(fallback)
+            return ["ml hint"]
+
+        engine = TutorialEngine(hint_generator=fake_generator, analytics=self.analytics)
+        engine.load("getting_started")
+        hints = engine.get_hints({"flags": []})
+        self.assertEqual(hints, ["ml hint"])
+        self.assertEqual(captured["tutorial"], "getting_started")
+        self.assertEqual(captured["step"], "welcome")
+        self.assertTrue(captured["fallback"])  # default fallback provided
+
+    def test_fallback_hint_when_ml_unavailable(self) -> None:
+        def broken_generator(*args, **kwargs):  # noqa: ANN001
+            raise RuntimeError("offline")
+
+        engine = TutorialEngine(hint_generator=broken_generator, analytics=self.analytics)
+        engine.load("getting_started")
+        engine.record_event("ui:start_pressed")
+        engine.record_event("movement:checkpoint_reached")
+        hints = engine.get_hints({"flags": ["player_hit_barrier"]})
+        self.assertIn("Jump a split-second earlier", hints[0])
+
+    def test_scene_state_and_hint_toggle(self) -> None:
+        scene = TutorialScene(self.engine)
+        state = scene.state()
+        self.assertTrue(state.hints)
+        scene.set_hints_enabled(False)
+        state_disabled = scene.state()
+        self.assertFalse(state_disabled.hints)
+        scene.toggle_hints()
+        state_enabled = scene.state()
+        self.assertTrue(state_enabled.hints_enabled)
+        scene.on_player_event("ui:start_pressed")
+        progressed = scene.state()
+        self.assertEqual(progressed.step, "movement")
+        counts = self.metrics.export_counts()
+        self.assertEqual(counts["tutorial_hints_toggled:getting_started"], 2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tutorial/__init__.py
+++ b/tutorial/__init__.py
@@ -1,0 +1,5 @@
+"""Tutorial package exposing the engine and script utilities."""
+
+from .engine import TutorialEngine, TutorialScript, TutorialStep
+
+__all__ = ["TutorialEngine", "TutorialScript", "TutorialStep"]

--- a/tutorial/engine.py
+++ b/tutorial/engine.py
@@ -1,0 +1,248 @@
+"""Tutorial engine for coordinating scripted onboarding flows."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Sequence
+
+from analytics import TutorialAnalytics
+
+SCRIPTS_PATH = Path(__file__).with_name("scripts")
+
+
+@dataclass(frozen=True)
+class HintBranch:
+    """A conditional hint variant selected when the context matches."""
+
+    when: Sequence[str]
+    hints: List[str]
+
+
+@dataclass(frozen=True)
+class StepHints:
+    """Collection of hints for a tutorial step."""
+
+    default: List[str] = field(default_factory=list)
+    branches: List[HintBranch] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TutorialStep:
+    """Single step from a tutorial script."""
+
+    id: str
+    text: str
+    objectives: List[str]
+    complete_events: List[str]
+    next_step: Optional[str]
+    hints: StepHints = field(default_factory=StepHints)
+
+
+@dataclass(frozen=True)
+class TutorialScript:
+    """Parsed representation of a tutorial script."""
+
+    id: str
+    title: str
+    description: str
+    steps: Dict[str, TutorialStep]
+    order: List[str]
+    completion: Dict[str, object] = field(default_factory=dict)
+
+
+class ScriptLoader:
+    """Abstract loader for tutorial scripts."""
+
+    def load(self, script_id: str) -> Dict[str, object]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class FileSystemScriptLoader(ScriptLoader):
+    """Loads tutorial definitions from ``tutorial/scripts``."""
+
+    def __init__(self, base_path: Path = SCRIPTS_PATH) -> None:
+        self._base_path = base_path
+
+    def load(self, script_id: str) -> Dict[str, object]:
+        path = self._base_path / f"{script_id}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"Tutorial script '{script_id}' not found at {path}")
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+
+class DefaultHintStrategy:
+    """Deterministic hint selection using scripted branches."""
+
+    def __call__(self, step: TutorialStep, context: Optional[Dict[str, object]] = None) -> List[str]:
+        if not step.hints.default and not step.hints.branches:
+            return []
+        context = context or {}
+        flags = set(context.get("flags", []))
+        for branch in step.hints.branches:
+            if set(branch.when).issubset(flags):
+                return list(branch.hints)
+        return list(step.hints.default)
+
+
+class TutorialEngine:
+    """Coordinates tutorial state progression and hint generation."""
+
+    def __init__(
+        self,
+        script_loader: Optional[ScriptLoader] = None,
+        *,
+        hint_generator: Optional[
+            Callable[[str, TutorialStep, Dict[str, object], List[str]], Optional[Iterable[str]]]
+        ] = None,
+        analytics: Optional[TutorialAnalytics] = None,
+        fallback_hint_strategy: Optional[Callable[[TutorialStep, Optional[Dict[str, object]]], List[str]]] = None,
+    ) -> None:
+        self._loader = script_loader or FileSystemScriptLoader()
+        self._hint_generator = hint_generator
+        self._analytics = analytics or TutorialAnalytics()
+        self._hint_strategy = fallback_hint_strategy or DefaultHintStrategy()
+        self._script: Optional[TutorialScript] = None
+        self._current_step_id: Optional[str] = None
+        self._completed_steps: List[str] = []
+        self._completed_lookup: set[str] = set()
+        self._hints_enabled: bool = True
+
+    @property
+    def analytics(self) -> TutorialAnalytics:
+        return self._analytics
+
+    @property
+    def script(self) -> Optional[TutorialScript]:
+        return self._script
+
+    @property
+    def current_step(self) -> Optional[TutorialStep]:
+        if not self._script or not self._current_step_id:
+            return None
+        return self._script.steps.get(self._current_step_id)
+
+    @property
+    def completed_steps(self) -> List[str]:
+        return list(self._completed_steps)
+
+    @property
+    def hints_enabled(self) -> bool:
+        return self._hints_enabled
+
+    def set_hints_enabled(self, enabled: bool) -> None:
+        self._hints_enabled = bool(enabled)
+
+    def load(self, script_id: str) -> TutorialScript:
+        raw = self._loader.load(script_id)
+        script = self._parse_script(raw)
+        self._script = script
+        self._completed_steps = []
+        self._completed_lookup = set()
+        self._current_step_id = script.order[0] if script.order else None
+        self._analytics.track_tutorial_start(script.id)
+        if self._current_step_id:
+            self._analytics.track_step_engaged(script.id, self._current_step_id)
+        return script
+
+    def _parse_script(self, raw: Dict[str, object]) -> TutorialScript:
+        steps: Dict[str, TutorialStep] = {}
+        order: List[str] = []
+        for entry in raw.get("steps", []):
+            step = self._parse_step(entry)
+            steps[step.id] = step
+            order.append(step.id)
+        return TutorialScript(
+            id=raw.get("id", ""),
+            title=raw.get("title", ""),
+            description=raw.get("description", ""),
+            steps=steps,
+            order=order,
+            completion=raw.get("completion", {}),
+        )
+
+    def _parse_step(self, raw: Dict[str, object]) -> TutorialStep:
+        hints_raw = raw.get("hints", {})
+        branches = [
+            HintBranch(
+                when=list(branch.get("when", [])),
+                hints=list(branch.get("hints", [])),
+            )
+            for branch in hints_raw.get("branches", [])
+        ]
+        hints = StepHints(
+            default=list(hints_raw.get("default", [])),
+            branches=branches,
+        )
+        return TutorialStep(
+            id=raw.get("id", ""),
+            text=raw.get("text", ""),
+            objectives=list(raw.get("objectives", [])),
+            complete_events=list(raw.get("completeEvents", [])),
+            next_step=raw.get("next"),
+            hints=hints,
+        )
+
+    def is_completed(self) -> bool:
+        return bool(self._script) and self._current_step_id is None
+
+    def record_event(self, event: str, context: Optional[Dict[str, object]] = None) -> bool:
+        step = self.current_step
+        if not self._script or not step or step.id in self._completed_lookup:
+            return False
+        if event not in step.complete_events:
+            return False
+        self._completed_lookup.add(step.id)
+        self._completed_steps.append(step.id)
+        self._analytics.track_step_completed(self._script.id, step.id)
+        if step.next_step:
+            self._current_step_id = step.next_step
+            self._analytics.track_step_engaged(self._script.id, step.next_step)
+        else:
+            self._current_step_id = None
+            self._analytics.track_tutorial_completed(self._script.id, len(self._completed_steps))
+        return True
+
+    def get_hints(self, context: Optional[Dict[str, object]] = None) -> List[str]:
+        if not self._hints_enabled:
+            return []
+        step = self.current_step
+        if not step:
+            return []
+        fallback = list(self._hint_strategy(step, context))
+        if self._hint_generator is None:
+            return fallback
+        try:
+            generated = self._hint_generator(
+                self._script.id if self._script else "",
+                step,
+                context or {},
+                list(fallback),
+            )
+        except Exception:
+            return fallback
+        if not generated:
+            return fallback
+        return list(generated)
+
+    def snapshot(self) -> Dict[str, object]:
+        step = self.current_step
+        return {
+            "tutorial": self._script.id if self._script else None,
+            "step": step.id if step else None,
+            "objectives": list(step.objectives) if step else [],
+            "completed": list(self._completed_steps),
+            "isCompleted": self.is_completed(),
+            "hintsEnabled": self._hints_enabled,
+        }
+
+
+__all__ = [
+    "TutorialEngine",
+    "TutorialScript",
+    "TutorialStep",
+    "ScriptLoader",
+    "FileSystemScriptLoader",
+]

--- a/tutorial/scripts/combat_basics.json
+++ b/tutorial/scripts/combat_basics.json
@@ -1,0 +1,98 @@
+{
+  "id": "combat_basics",
+  "title": "Combat Basics",
+  "description": "Practice equipping gear, firing, and dodging attacks.",
+  "steps": [
+    {
+      "id": "equip",
+      "text": "Gear up before engaging hostiles.",
+      "objectives": [
+        "Open the inventory.",
+        "Equip the training blaster."
+      ],
+      "completeEvents": ["inventory:weapon_equipped"],
+      "next": "target",
+      "hints": {
+        "default": [
+          "Press I to open your inventory, then select the blaster to equip it."
+        ],
+        "branches": [
+          {
+            "when": ["inventory_closed"],
+            "hints": [
+              "Tap I to reopen the inventory panel."
+            ]
+          },
+          {
+            "when": ["weapon_already_equipped"],
+            "hints": [
+              "You're ready to fight—close the inventory to continue."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "target",
+      "text": "Hit the stationary target.",
+      "objectives": [
+        "Aim at the target dummy.",
+        "Fire three shots."
+      ],
+      "completeEvents": ["combat:target_destroyed"],
+      "next": "dodge",
+      "hints": {
+        "default": [
+          "Hold right mouse to aim, then left mouse to fire."
+        ],
+        "branches": [
+          {
+            "when": ["shots_missed"],
+            "hints": [
+              "Pause your aim for a moment before shooting to tighten the spread."
+            ]
+          },
+          {
+            "when": ["ammo_empty"],
+            "hints": [
+              "Reload with R to replenish your magazine."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "dodge",
+      "text": "Evade the incoming attack to survive.",
+      "objectives": [
+        "Watch for the telegraphed strike.",
+        "Dash out of the danger zone."
+      ],
+      "completeEvents": ["combat:dodge_success"],
+      "next": null,
+      "hints": {
+        "default": [
+          "Double-tap a movement key to perform a quick dodge."
+        ],
+        "branches": [
+          {
+            "when": ["player_hit"],
+            "hints": [
+              "Move as soon as you see the red warning circle appear."
+            ]
+          },
+          {
+            "when": ["player_idle"],
+            "hints": [
+              "Keep moving—dodges travel farther when you have momentum."
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "completion": {
+    "reward": "combat_bundle",
+    "summary": "You can now take on the first mission."
+  }
+}

--- a/tutorial/scripts/getting_started.json
+++ b/tutorial/scripts/getting_started.json
@@ -1,0 +1,103 @@
+{
+  "id": "getting_started",
+  "title": "Getting Started",
+  "description": "Master core movement so you can explore the arena.",
+  "steps": [
+    {
+      "id": "welcome",
+      "text": "Welcome to the arena! Let's get you moving.",
+      "objectives": [
+        "Press the Start button to continue."
+      ],
+      "completeEvents": ["ui:start_pressed"],
+      "next": "movement",
+      "hints": {
+        "default": [
+          "Tap Start when you're ready to begin."
+        ],
+        "branches": [
+          {
+            "when": ["menu_open"],
+            "hints": [
+              "Close the settings panel to reveal the Start button."
+            ]
+          },
+          {
+            "when": ["player_idle"],
+            "hints": [
+              "The Start button is glowing in the lower-right corner—select it to proceed."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "movement",
+      "text": "Move toward the checkpoint to learn the controls.",
+      "objectives": [
+        "Use WASD or the arrow keys to walk.",
+        "Reach the glowing checkpoint."
+      ],
+      "completeEvents": ["movement:checkpoint_reached"],
+      "next": "jump",
+      "hints": {
+        "default": [
+          "Hold W or the up arrow to advance toward the checkpoint beacon."
+        ],
+        "branches": [
+          {
+            "when": ["player_idle"],
+            "hints": [
+              "Try tapping any movement key to leave the spawn pad."
+            ]
+          },
+          {
+            "when": ["player_off_course"],
+            "hints": [
+              "Steer toward the blue light—the checkpoint marks your destination."
+            ]
+          },
+          {
+            "when": ["player_stuck_wall"],
+            "hints": [
+              "Strafe with A or D to slide along the wall and clear the corner."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "jump",
+      "text": "Jump the barrier to finish the warm-up.",
+      "objectives": [
+        "Press Space to jump over the barrier.",
+        "Enter the exit portal."
+      ],
+      "completeEvents": ["movement:jump_success"],
+      "next": null,
+      "hints": {
+        "default": [
+          "Tap Space while moving forward to clear the barrier."
+        ],
+        "branches": [
+          {
+            "when": ["player_idle"],
+            "hints": [
+              "Begin walking toward the barrier before you attempt the jump."
+            ]
+          },
+          {
+            "when": ["player_hit_barrier"],
+            "hints": [
+              "Jump a split-second earlier so you take off before colliding with the barrier."
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "completion": {
+    "reward": "movement_bundle",
+    "summary": "You can now roam the arena freely."
+  }
+}


### PR DESCRIPTION
## Summary
- add scripted tutorial flows for movement and combat with branching hint data
- implement a tutorial engine that supports optional ML hint generation, deterministic fallbacks, and analytics hooks
- expose a tutorial scene controller plus analytics helpers and tests covering ML and fallback hint paths

## Testing
- python -m unittest discover tests/python
- npm test -- --runTestsByPath tests/metrics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dda80c2fdc8327851c0639ee5b7124