### PR TITLE
Handle dynamic touch control mappings

### DIFF
--- a/tests/runtime.controls.test.ts
+++ b/tests/runtime.controls.test.ts
@@ -23,3 +23,31 @@ test('dispose removes listeners', () => {
   addSpy.mockRestore();
   removeSpy.mockRestore();
 });
+
+test('touch buttons toggle each code in array mappings', () => {
+  const c = new Controls({ map: { a: ['KeyZ', 'KeyX'] } });
+  const button = Array.from(c.element!.querySelectorAll('button')).find(b => b.textContent === 'A') as HTMLButtonElement;
+  const state = (c as any).state as Map<string, boolean>;
+  button.dispatchEvent(new Event('touchstart', { cancelable: true }));
+  expect(state.get('KeyZ')).toBe(true);
+  expect(state.get('KeyX')).toBe(true);
+  button.dispatchEvent(new Event('touchend'));
+  expect(state.get('KeyZ')).toBe(false);
+  expect(state.get('KeyX')).toBe(false);
+  c.dispose();
+});
+
+test('touch buttons respect mapping changes while pressed', () => {
+  const c = new Controls({ map: { a: 'KeyZ' } });
+  const button = Array.from(c.element!.querySelectorAll('button')).find(b => b.textContent === 'A') as HTMLButtonElement;
+  const state = (c as any).state as Map<string, boolean>;
+  button.dispatchEvent(new Event('touchstart', { cancelable: true }));
+  expect(state.get('KeyZ')).toBe(true);
+  c.setMapping('a', 'KeyX');
+  expect(state.get('KeyZ')).toBe(false);
+  expect(state.get('KeyX')).toBe(true);
+  button.dispatchEvent(new Event('touchend'));
+  expect(state.get('KeyZ')).toBe(false);
+  expect(state.get('KeyX')).toBe(false);
+  c.dispose();
+});


### PR DESCRIPTION
## Summary
- update the runtime Controls touch button handlers to resolve current mappings per event and keep touch state in sync with remaps
- regenerate the compiled runtime controls bundle to match the TypeScript source
- add unit tests covering array mappings and runtime mapping updates while a touch button is held

## Testing
- npm run test:unit -- runtime.controls.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddb3a13bac8327acd3222a1aca88ad