### PR TITLE
chore: improve landing status focus handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
         <button id="bolt-clear" type="button" title="Clear search">✕</button>
       </form>
       <div id="bolt-filters" class="bolt-filters" aria-label="Filter by category" role="tablist"></div>
-      <div id="bolt-status" class="bolt-status" role="status" aria-live="polite" aria-atomic="true">
+      <div id="bolt-status" class="bolt-status" role="status" aria-live="polite" aria-atomic="true" tabindex="-1">
         <span class="sr-only">Game loading status:</span>
         Loading games…
       </div>

--- a/js/bolt-landing.js
+++ b/js/bolt-landing.js
@@ -170,6 +170,7 @@ async function boot(){
 
     render(allGames);
     renderHistory(lastPlayedSlugs);
+    STATUS?.setAttribute('tabindex', '-1');
     STATUS.focus?.();
   } catch(err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- add a tabindex to the landing page status region so it can receive focus
- set the tabindex attribute before programmatically focusing the status node during game loading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddf91272a483279a6683c7b121ceb0