### PR TITLE
fix(loader): surface error detail in shell overlay

### DIFF
--- a/js/diag-upgrades.js
+++ b/js/diag-upgrades.js
@@ -17,7 +17,7 @@
     const force = opts && opts.force;
     if (!postedError || force) {
       postedError = true;
-      post("GAME_ERROR", { error: message });
+      post("GAME_ERROR", { error: message, message });
     }
     return message;
   };

--- a/js/game-loader.js
+++ b/js/game-loader.js
@@ -66,6 +66,7 @@
     if (readyToSignal) window.parent?.postMessage?.({type:'GAME_READY', slug}, '*');
   }catch(e){
     console.error('[loader] error', e);
-    window.parent?.postMessage?.({type:'GAME_ERROR', slug, message:String(e?.message||e)}, '*');
+    const detail = String(e?.message ?? e);
+    window.parent?.postMessage?.({type:'GAME_ERROR', slug, error:detail, message:detail}, '*');
   }
 })();

--- a/js/preflight.js
+++ b/js/preflight.js
@@ -42,7 +42,8 @@
       var slug = (window.GG && window.GG.slug) ||
                  (document.body && document.body.dataset && document.body.dataset.slug) ||
                  (new URLSearchParams(location.search).get('slug')) || 'game';
-      try { window.parent && window.parent.postMessage({type:'GAME_ERROR', slug: slug, message: (kind?('['+kind+'] '):'') + String(msg||'error')}, '*'); } catch(e){}
+      var detail = (kind?('['+kind+'] '):'') + String(msg||'error');
+      try { window.parent && window.parent.postMessage({type:'GAME_ERROR', slug: slug, error: detail, message: detail}, '*'); } catch(e){}
     }
     window.addEventListener('error', function(e){
       var m = (e && (e.message || (e.error && e.error.message))) || 'Script error';

--- a/js/runtime-diagnostics.js
+++ b/js/runtime-diagnostics.js
@@ -38,7 +38,8 @@
 
   window.addEventListener('error', (e)=>{
     push('error', 'window.error', { message: e.message, source: e.filename, line: e.lineno, col: e.colno });
-    try { parent && parent.postMessage({ type: 'GAME_ERROR', message: e.message }, '*'); } catch(_) {}
+    const detail = String(e?.message ?? e);
+    try { parent && parent.postMessage({ type: 'GAME_ERROR', error: detail, message: detail }, '*'); } catch(_) {}
   });
   window.addEventListener('unhandledrejection', (e)=>{
     push('error', 'unhandledrejection', { reason: (e.reason && (e.reason.message || e.reason.toString())) || 'unknown' });
@@ -57,7 +58,8 @@
     },
     error(message){
       stopHB();
-      try { parent && parent.postMessage({ type:'GAME_ERROR', message }, '*'); push('error','sent GAME_ERROR: '+message); } catch(_){ }
+      const detail = String(message ?? 'Unknown error');
+      try { parent && parent.postMessage({ type:'GAME_ERROR', error: detail, message: detail }, '*'); push('error','sent GAME_ERROR: '+detail); } catch(_){ }
     },
     dump(){ return logs.slice(); }
   };

--- a/shared/game-asset-preloader.js
+++ b/shared/game-asset-preloader.js
@@ -33,13 +33,14 @@ function reportAssetError(slug, url, err) {
   const key = `${slug}|${url}`;
   if (reportedFailures.has(key)) return;
   reportedFailures.add(key);
-  const message = `[assets] failed to load ${url}: ${err?.message || err || 'unknown error'}`;
-  console.error(message);
+  const detail = `[assets] failed to load ${url}: ${err?.message || err || 'unknown error'}`;
+  console.error(detail);
   try {
     window.parent?.postMessage?.({
       type: 'GAME_ERROR',
       slug,
-      message: `First-frame asset failed to load: ${url}`
+      error: detail,
+      message: detail
     }, '*');
   } catch (_) {}
 }

--- a/shared/hiscore.js
+++ b/shared/hiscore.js
@@ -1,7 +1,10 @@
 // Utility helpers to use inside games (optional)
 export function postScore(score){ try{ parent.postMessage({type:'GAME_SCORE', score}, '*'); }catch{} }
 export function ready(){ try{ parent.postMessage({type:'GAME_READY'}, '*'); }catch{} }
-export function error(message){ try{ parent.postMessage({type:'GAME_ERROR', message}, '*'); }catch{} }
+export function error(message){
+  const detail = String(message ?? 'Unknown error');
+  try{ parent.postMessage({type:'GAME_ERROR', error: detail, message: detail}, '*'); }catch{}
+}
 
 // Optional listeners for pause/mute/restart sent from shell
 export function attachShellControls({ onPause, onResume, onRestart, onMute } = {}){


### PR DESCRIPTION
## Summary
- ensure the loader posts both `error` and `message` fields with the thrown detail when surfacing `GAME_ERROR`
- align shared diagnostics helpers to emit the same shape so the shell overlay consistently shows the underlying failure text

## Testing
- npm test -- game-boot.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ddf8ee35d88327ade459d174a5fe9a