### PR TITLE
Add about and contact sections to landing page

### DIFF
--- a/css/bolt-landing.css
+++ b/css/bolt-landing.css
@@ -105,6 +105,57 @@ body.bolt-body{
 @media (max-width: 760px){ .bolt-grid{grid-template-columns:repeat(2,1fr)}}
 @media (max-width: 420px){ .bolt-grid{grid-template-columns:1fr}}
 
+.bolt-section-lead{margin:10px 0 26px;max-width:720px;color:var(--bolt-muted);font-size:18px}
+
+.bolt-about,
+.bolt-contact{
+  position:relative;
+  padding:60px 0 70px;
+  border-top:1px solid var(--bolt-border);
+  background:
+    radial-gradient(1000px 800px at 10% 0%, rgba(255,255,255,.12), transparent 40%),
+    radial-gradient(1200px 900px at 90% 10%, rgba(255,255,255,.08), transparent 45%),
+    linear-gradient(180deg, rgba(0,0,0,.08), rgba(0,0,0,.16));
+}
+
+.bolt-about::before,
+.bolt-contact::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  background:radial-gradient(circle at 50% 0%, rgba(255,255,255,.08), transparent 55%);
+  opacity:.6;
+}
+
+.bolt-about .bolt-container,
+.bolt-contact .bolt-container{position:relative}
+
+.bolt-about-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:30px;max-width:920px}
+@media (max-width:820px){.bolt-about-grid{grid-template-columns:1fr}}
+.bolt-about-grid h3{margin:0 0 10px;font-size:20px}
+.bolt-about-grid p{margin:0;color:var(--bolt-muted);line-height:1.6}
+
+.bolt-contact-cards{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:18px;max-width:960px}
+@media (max-width:960px){.bolt-contact-cards{grid-template-columns:repeat(2,minmax(0,1fr))}}
+@media (max-width:640px){.bolt-contact-cards{grid-template-columns:1fr}}
+.bolt-contact-card{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  padding:18px 20px;
+  border-radius:16px;
+  text-decoration:none;
+  color:var(--bolt-text);
+  background:rgba(0,0,0,.22);
+  border:1px solid var(--bolt-border);
+  transition:transform .2s ease, border-color .2s ease, background .2s ease;
+}
+.bolt-contact-card:hover{transform:translateY(-2px);border-color:rgba(255,255,255,.3);background:rgba(0,0,0,.28)}
+.bolt-contact-card:focus-visible{outline:none;box-shadow:var(--bolt-focus)}
+.bolt-contact-label{font-size:14px;color:var(--bolt-muted);text-transform:uppercase;letter-spacing:.08em}
+.bolt-contact-value{font-weight:700;font-size:18px}
+
 .bolt-history{margin:30px 0 34px;padding:22px 22px 26px;border:1px solid var(--bolt-border);border-radius:22px;background:rgba(0,0,0,.22);backdrop-filter:blur(6px)}
 .bolt-history[hidden]{display:none}
 .bolt-history-title{margin:0 0 18px;font-size:24px}

--- a/index.html
+++ b/index.html
@@ -85,6 +85,46 @@
     </div>
   </section>
 
+  <!-- ABOUT SECTION -->
+  <section id="about" class="bolt-about">
+    <div class="bolt-container">
+      <h2 class="bolt-section-title">About Gurjot's Games</h2>
+      <p class="bolt-section-lead">We curate a hand-picked library of classics, indie hits, and modern experiences so every gamer can find their next adventure.</p>
+      <div class="bolt-about-grid">
+        <div>
+          <h3>Built for discovery</h3>
+          <p>Our catalog highlights trending titles, spotlighted creators, and community favorites to make it easy to jump into something new.</p>
+        </div>
+        <div>
+          <h3>Always evolving</h3>
+          <p>Fresh games, seasonal events, and exclusive challenges are added regularly so there is always a new quest waiting for you.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CONTACT SECTION -->
+  <section id="contact" class="bolt-contact">
+    <div class="bolt-container">
+      <h2 class="bolt-section-title">Get in Touch</h2>
+      <p class="bolt-section-lead">Have a game suggestion, found a bug, or just want to say hi? We would love to hear from you.</p>
+      <div class="bolt-contact-cards">
+        <a class="bolt-contact-card" href="mailto:hello@gurjotsgames.com">
+          <span class="bolt-contact-label">Email</span>
+          <span class="bolt-contact-value">hello@gurjotsgames.com</span>
+        </a>
+        <a class="bolt-contact-card" href="https://twitter.com" target="_blank" rel="noopener">
+          <span class="bolt-contact-label">Twitter</span>
+          <span class="bolt-contact-value">@GurjotsGames</span>
+        </a>
+        <a class="bolt-contact-card" href="https://discord.com" target="_blank" rel="noopener">
+          <span class="bolt-contact-label">Discord</span>
+          <span class="bolt-contact-value">Join our community ↗</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
   <footer class="bolt-footer">
     <div class="bolt-container bolt-footer-inner">
       <p>© <span id="bolt-year"></span> Gurjot's Games. Built for speed & fun.</p>


### PR DESCRIPTION
## Summary
- add dedicated About and Contact sections to the landing page after the games grid
- style the new sections with gradient backgrounds, grids, and interactive contact cards to match the existing aesthetic

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ddfbb8f0188327ac4ed633ace8c783