### PR TITLE
Update typography to use Poppins

### DIFF
--- a/game.html
+++ b/game.html
@@ -6,12 +6,12 @@
   <title>Play — Gurjot’s Games</title>
   <link rel="icon" type="image/png" href="assets/favicon.png">
   <style>
-    :root { --bg:#0b0f14; --card:#121821; --muted:#9db0c5; --accent:#4cc9f0; --error:#ff6b6b; }
+    :root { --bg:#0b0f14; --card:#121821; --muted:#9db0c5; --accent:#4cc9f0; --error:#ff6b6b; --font-brand:"Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
     * { box-sizing: border-box; }
     html, body { height: 100%; }
     body {
       margin: 0; background: linear-gradient(180deg, #0b0f14, #111827 35%, #0b0f14);
-      color: #e5f0ff; font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      color: #e5f0ff; font-size: 14px; line-height: 1.5; font-family: var(--font-brand);
       display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto auto 1fr auto; gap: 8px;
       grid-template-areas:
         "header"

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
 @import './styles/tokens.css';
 
 * { box-sizing: border-box; }
 html, body {
   margin:0;
   padding:0;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--font-sans);
   background: var(--bg);
   color: var(--fg);
 }
@@ -139,7 +140,7 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
   box-shadow: 0 10px 40px rgba(0,0,0,0.45);
 }
 .help-overlay section { margin-bottom:12px; }
-.help-overlay h4 { margin:0 0 4px 0; font:700 16px Inter,system-ui; }
+.help-overlay h4 { margin:0 0 4px 0; font:700 16px var(--font-brand); }
 .help-overlay .footer { display:flex; justify-content:space-between; align-items:center; margin-top:12px; }
 .help-overlay .footer .actions { display:flex; gap:6px; }
 .help-overlay .step-indicator { font-size:14px; opacity:.8; }

--- a/styles.themes.css
+++ b/styles.themes.css
@@ -5,7 +5,7 @@
 :root {
   --bg:#0b0b0f; --fg:#eaeaf2; --card:#14141d; --border:#1f1f2a; --chip:#2a2a36;
   --button-bg:#2a2a36; --button-border:#1f1f2a;
-  --accent:#6ee7b7; --font: system-ui, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  --accent:#6ee7b7; --font: var(--font-brand, "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
   --bg-img:none;
 }
 
@@ -13,7 +13,7 @@
 .skin-minimal {
   --bg:#fafafa; --fg:#0b0b0f; --card:#ffffff; --border:#e5e7eb; --chip:#eef2f7;
   --button-bg:#e5e7eb; --button-border:#d1d5db;
-  --accent:#111827; --font: "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  --accent:#111827; --font: var(--font-brand, "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
   --bg-img: none;
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -39,7 +39,8 @@
   --z-modal: 1000;
 
   /* Typography */
-  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  --font-brand: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-sans: var(--font-brand);
   --font-mono: monospace;
   --font-size-sm: 0.875rem;
   --font-size-md: 1rem;


### PR DESCRIPTION
## Summary
- import the Poppins font family and expose it via a shared --font-brand token
- update global and themed stylesheets to adopt the new Poppins-based font stack
- align the inline styles in game.html with the shared font token for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddfc97f1508327aeb4c26c233ef9eb