### PR TITLE
Add site header logo link to cabinet and stats pages

### DIFF
--- a/cabinet.html
+++ b/cabinet.html
@@ -17,6 +17,7 @@
 <body>
   <div class="wrap">
     <header class="site-header">
+      <a class="logo" href="./"><img src="assets/logo.svg" alt="Gurjot’s Games"></a>
       <strong data-i18n="cabinetMode">Cabinet Mode</strong>
       <span id="label" class="muted" style="margin-left:auto"></span>
       <label for="langSelect" class="sr-only">Language</label>

--- a/stats.html
+++ b/stats.html
@@ -15,6 +15,7 @@
 </head>
 <body>
   <header class="site-header" style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px">
+    <a class="logo" href="./"><img src="assets/logo.svg" alt="Gurjot’s Games"></a>
     <h1 style="margin:0" data-i18n="statsTitle">📈 Stats Dashboard</h1>
     <nav style="display:flex;gap:8px;align-items:center">
       <a class="btn" href="./index.html" data-i18n="back">← Back</a>

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,18 @@ a { color: inherit; text-decoration: none; }
   background: var(--header-bg);
   border-bottom:1px solid var(--border);
 }
+.site-header {
+  column-gap:16px;
+}
+.site-header .logo {
+  display:inline-flex;
+  align-items:center;
+}
+.site-header .logo img {
+  display:block;
+  height:32px;
+  width:auto;
+}
 .site-footer {
   border-top:1px solid var(--border);
   border-bottom:none;


### PR DESCRIPTION
## Summary
- add the branded logo link at the start of the cabinet and stats headers for consistency
- extend the shared site header styles so the new logo aligns cleanly with existing controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddfeaa422483278dac2822951bd628