### PR TITLE
Enhance cabinet controls with active states

### DIFF
--- a/cabinet.html
+++ b/cabinet.html
@@ -71,15 +71,33 @@
       label.textContent = g.title || g.slug || url;
     }
 
+    function updateControls(){
+      const hasGames = games.length > 0;
+      const running = !!timer && hasGames;
+
+      startBtn.classList.toggle('is-active', running);
+      startBtn.classList.toggle('is-inactive', hasGames && !running);
+      stopBtn.classList.toggle('is-active', hasGames && !running);
+      stopBtn.classList.toggle('is-inactive', running);
+
+      startBtn.disabled = running || !hasGames;
+      stopBtn.disabled = !running || !hasGames;
+    }
+
     function start(){
-      if (!games.length) return;
-      show(idx);
+      if (!games.length) {
+        updateControls();
+        return;
+      }
       stop();
+      show(idx);
       timer = setInterval(() => show(++idx), ROTATE_MS);
+      updateControls();
     }
     function stop(){
       if (timer) clearInterval(timer);
       timer = null;
+      updateControls();
     }
 
     fsBtn.onclick = () => {
@@ -91,6 +109,7 @@
     stopBtn.onclick = stop;
 
     await loadGames();
+    updateControls();
     if (games.length) start();
   </script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,20 @@ a:focus-visible, button:focus-visible, [role="button"]:focus-visible { outline: 
   :root { scroll-behavior: smooth; }
 }
 a { color: inherit; text-decoration: none; }
+.btn.is-active {
+  background: var(--accent);
+  border-color: transparent;
+  color: var(--bg);
+}
+.btn.is-inactive {
+  background: var(--button-bg);
+  border-color: var(--button-border);
+  color: var(--fg-muted, rgba(255, 255, 255, 0.7));
+  opacity: 0.7;
+}
+.btn:disabled {
+  cursor: not-allowed;
+}
 .site-header, .site-footer {
   display:flex;
   align-items:center;


### PR DESCRIPTION
## Summary
- add button state management for the cabinet start and stop controls
- extend shared styles with active and inactive button treatments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de021bbee88327a46d8cc183b25937