### PR TITLE
Replace hero metric emojis with gradient SVG icons

### DIFF
--- a/assets/icons/joystick.svg
+++ b/assets/icons/joystick.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <defs>
+    <linearGradient id="grad-joystick" x1="5" y1="3" x2="19" y2="21" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#grad-joystick)" d="M12 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5Zm-5 6.5h10a4 4 0 0 1 4 4v2.75c0 1.24-1.01 2.25-2.25 2.25H5.25A2.25 2.25 0 0 1 3 16.75V14a4 4 0 0 1 4-4Zm2.25 2.5a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Zm5.5 0a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"/>
+  <path fill="url(#grad-joystick)" d="M9.25 20a.75.75 0 0 0 0 1.5h5.5a.75.75 0 0 0 0-1.5h-5.5Z" opacity="0.8"/>
+</svg>

--- a/assets/icons/players.svg
+++ b/assets/icons/players.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <defs>
+    <linearGradient id="grad-players" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#60a5fa"/>
+      <stop offset="1" stop-color="#c084fc"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#grad-players)" d="M9.5 6.5a2.75 2.75 0 1 1-5.5 0 2.75 2.75 0 0 1 5.5 0Zm10 0a2.75 2.75 0 1 1-5.5 0 2.75 2.75 0 0 1 5.5 0ZM2.5 17.5c0-2.761 2.239-5 5-5h1c2.761 0 5 2.239 5 5v1a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-1Zm11 0c0-2.761 2.239-5 5-5h1c2.761 0 5 2.239 5 5v1a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-1Z" opacity="0.55"/>
+  <path fill="url(#grad-players)" d="M12 10.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Zm0 9.75c3.175 0 5.75 2.046 5.75 4.75a.5.5 0 0 1-.5.5h-10.5a.5.5 0 0 1-.5-.5c0-2.704 2.575-4.75 5.75-4.75Z"/>
+</svg>

--- a/assets/icons/star.svg
+++ b/assets/icons/star.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <defs>
+    <linearGradient id="grad-star" x1="6" y1="4" x2="18" y2="20" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fbbf24"/>
+      <stop offset="1" stop-color="#fb7185"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#grad-star)" d="M11.11 3.26c.35-.94 1.65-.94 2 0l1.64 4.41 4.71.34c1.02.07 1.44 1.35.66 1.99l-3.61 2.96 1.11 4.55c.24.98-.82 1.76-1.68 1.24L12 16.84l-3.54 2.91c-.86.52-1.92-.26-1.68-1.24l1.11-4.55-3.61-2.96c-.78-.64-.36-1.92.66-1.99l4.71-.34 1.64-4.41Z"/>
+</svg>

--- a/assets/icons/uptime.svg
+++ b/assets/icons/uptime.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <defs>
+    <linearGradient id="grad-uptime" x1="5" y1="5" x2="19" y2="19" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#34d399"/>
+      <stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#grad-uptime)" d="M12 4a8 8 0 1 1-7.95 8.88.75.75 0 0 1 1.49-.24A6.5 6.5 0 1 0 12 5.5a.75.75 0 0 1 0-1.5Zm5.53 3.22a.75.75 0 0 1 .25 1.03l-2.8 4.5a2.75 2.75 0 1 1-1.3-1.02l3.66-3.3a.75.75 0 0 1 1.19.79ZM12 14.75a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z"/>
+</svg>

--- a/css/bolt-landing.css
+++ b/css/bolt-landing.css
@@ -64,7 +64,12 @@ body.bolt-body{
 .bolt-metrics{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;max-width:840px;margin:14px auto 22px}
 @media (max-width: 860px){.bolt-metrics{grid-template-columns:repeat(2,1fr)}}
 .bolt-metric{display:flex;gap:12px;align-items:center;justify-content:center;background:rgba(0,0,0,.18);border:1px solid var(--bolt-border);border-radius:16px;padding:14px 16px;backdrop-filter:blur(4px)}
-.bolt-ic{font-size:20px}
+.bolt-ic{
+  width:32px;
+  height:32px;
+  display:block;
+  flex-shrink:0;
+}
 .bolt-met-n{font-weight:800;font-size:20px}
 .bolt-met-l{font-size:12px;opacity:.9}
 .bolt-cta{

--- a/index.html
+++ b/index.html
@@ -60,10 +60,34 @@
       <p class="bolt-hero-sub">Welcome to the ultimate gaming destination! Discover amazing games, challenge your skills, and have endless fun.</p>
       <p class="bolt-cta-line"><span>Ready Player One?</span> 🎮</p>
       <div class="bolt-metrics">
-        <div class="bolt-metric"><div class="bolt-ic">👥</div><div><div class="bolt-met-n">10K+</div><div class="bolt-met-l">Players</div></div></div>
-        <div class="bolt-metric"><div class="bolt-ic">🕹</div><div><div class="bolt-met-n" id="bolt-game-count">50+</div><div class="bolt-met-l">Games</div></div></div>
-        <div class="bolt-metric"><div class="bolt-ic">⭐</div><div><div class="bolt-met-n">4.8</div><div class="bolt-met-l">Rating</div></div></div>
-        <div class="bolt-metric"><div class="bolt-ic">⚡</div><div><div class="bolt-met-n">99%</div><div class="bolt-met-l">Uptime</div></div></div>
+        <div class="bolt-metric">
+          <img class="bolt-ic" src="assets/icons/players.svg" alt="" role="presentation">
+          <div>
+            <div class="bolt-met-n">10K+</div>
+            <div class="bolt-met-l">Players</div>
+          </div>
+        </div>
+        <div class="bolt-metric">
+          <img class="bolt-ic" src="assets/icons/joystick.svg" alt="" role="presentation">
+          <div>
+            <div class="bolt-met-n" id="bolt-game-count">50+</div>
+            <div class="bolt-met-l">Games</div>
+          </div>
+        </div>
+        <div class="bolt-metric">
+          <img class="bolt-ic" src="assets/icons/star.svg" alt="" role="presentation">
+          <div>
+            <div class="bolt-met-n">4.8</div>
+            <div class="bolt-met-l">Rating</div>
+          </div>
+        </div>
+        <div class="bolt-metric">
+          <img class="bolt-ic" src="assets/icons/uptime.svg" alt="" role="presentation">
+          <div>
+            <div class="bolt-met-n">99%</div>
+            <div class="bolt-met-l">Uptime</div>
+          </div>
+        </div>
       </div>
       <a href="#games" class="bolt-cta">Start Playing ↗</a>
     </div>


### PR DESCRIPTION
## Summary
- add four gradient-filled SVG icons for players, games, rating, and uptime metrics
- update the hero metric blocks to use the new icons instead of emoji
- tweak the metric icon styling to size the SVG artwork consistently

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68de039883108327995810a623c6bbf5