### PR TITLE
Fix 2048 theme toggle accessibility text update

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -881,12 +881,12 @@ if (themeToggle) {
   themeToggle.addEventListener('click', () => {
     // Allow the existing toggle handler to update the theme first
     setTimeout(() => {
-      const activatedTheme = currentTheme;
-      const nextTheme = activatedTheme === 'dark' ? 'light' : 'dark';
+      // currentTheme has already been updated by the primary click handler
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
       // Update both text and ARIA label to reflect the current and next themes
-      themeToggle.textContent = nextTheme === 'dark' ? 'Light' : 'Dark';
+      themeToggle.textContent = currentTheme === 'dark' ? 'Light' : 'Dark';
       themeToggle.setAttribute('aria-label', `Switch to ${nextTheme} theme`);
-      announceToScreenReader(`Switched to ${activatedTheme} theme.`);
+      announceToScreenReader(`Switched to ${currentTheme} theme.`);
     }, 100);
   });
 }


### PR DESCRIPTION
## Summary
- adjust the delayed theme toggle handler to use the post-toggle `currentTheme` when updating button text and aria-labels
- add a note explaining that the primary click handler already updates `currentTheme`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de0454ec5883278025284a272b1a6f