### PR TITLE
Use hosting-aware websocket URL for chess matchmaking

### DIFF
--- a/games/chess/chess.js
+++ b/games/chess/chess.js
@@ -561,7 +561,8 @@ function handleFindMatch(){
   ChessNet.onMove(handleIncomingMove);
   ChessNet.onStatus(handleNetworkStatus);
   ChessNet.onPlayers(handlePlayers);
-  ChessNet.connect('wss://example.com/chess', rating);
+  const wsUrl=new URL('/ws/chess', location.origin); // Intentionally follows hosting domain/protocol.
+  ChessNet.connect(wsUrl.href, rating);
 }
 if(findMatchBtn) findMatchBtn.addEventListener('click', handleFindMatch);
 


### PR DESCRIPTION
## Summary
- derive the chess matchmaking WebSocket endpoint from the current location
- pass the generated URL string to `ChessNet.connect` so it preserves the host protocol

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de045f2da4832798951bb1887523fa