### PR TITLE
Handle chess3d catalog load failures

### DIFF
--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -25,7 +25,12 @@ async function loadCatalog() {
   throw lastError || new Error('catalog unavailable');
 }
 
-const games = await loadCatalog();
+let games = [];
+try {
+  games = await loadCatalog();
+} catch (error) {
+  warn('chess3d', '[Chess3D] failed to load catalog', error);
+}
 
 let renderLoopId = 0;
 let renderLoopPaused = false;
@@ -53,7 +58,8 @@ let handleShellResume = () => {};
 
 log('chess3d', '[Chess3D] booting');
 
-const help = games.find(g => g.id === 'chess3d')?.help || {};
+const helpEntry = games?.find?.((g) => g.id === 'chess3d');
+const help = helpEntry?.help || {};
 injectHelpButton({ gameId: 'chess3d', ...help });
 
 const stage = document.getElementById('stage');


### PR DESCRIPTION
## Summary
- keep a default empty games catalog and warn if loading fails
- guard help lookup against catalog fetch errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de04622e1483278e499bfa7b1765c4