### PR TITLE
Handle maze3d catalog fetch failure

### DIFF
--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -20,7 +20,12 @@ async function loadCatalog() {
   throw lastError || new Error('catalog unavailable');
 }
 
-const games = await loadCatalog();
+let games = [];
+try {
+  games = await loadCatalog();
+} catch (err) {
+  console.warn('maze3d: catalog fetch failed, using empty list', err);
+}
 
 const help = games.find(g => g.id === 'maze3d')?.help || {};
 injectHelpButton({ gameId: 'maze3d', ...help });


### PR DESCRIPTION
## Summary
- wrap the maze3d catalog load in a try/catch and warn when it fails
- default to an empty games array so subsequent lookups still run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de046458b08327a7d6125aca24ff49