### PR TITLE
Ensure runner HUD exposes score attribute

### DIFF
--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -582,7 +582,11 @@ class RunnerGame {
     if (force || newScore !== this.lastDrawnScore) {
       this.score = newScore;
       this.lastDrawnScore = newScore;
-      if (this.hud.score) this.hud.score.textContent = String(newScore);
+      if (this.hud.score) {
+        this.hud.score.textContent = String(newScore);
+        // Shell observer expects the score attribute to stay in sync.
+        this.hud.score.dataset.gameScore = String(newScore);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- update the runner HUD score element to expose the current score through a data attribute for shell observers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de046c980483279b21870c8f0d79ee