### PR TITLE
Add hidden score element for shooter analytics compatibility

### DIFF
--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -148,7 +148,9 @@
             
 </head>
 <body class="game-shell">
-  <div class="hud">Score: <span id="score">0</span> • Best: <span id="best">0</span> • Power: <span id="power">None</span> • Shield: <span id="shield">0</span> • Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Shoot: <kbd>Space</kbd> • Turret: <kbd>T</kbd> • Wall: <kbd>F</kbd> • Pause: <kbd>P</kbd> • Restart: <kbd>R</kbd></div>
+  <div class="hud">Score: <span id="scoreDisplay">0</span> • Best: <span id="best">0</span> • Power: <span id="power">None</span> • Shield: <span id="shield">0</span> • Move: <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> • Shoot: <kbd>Space</kbd> • Turret: <kbd>T</kbd> • Wall: <kbd>F</kbd> • Pause: <kbd>P</kbd> • Restart: <kbd>R</kbd></div>
+  <!-- Hidden score node kept for shell/analytics compatibility. -->
+  <span id="score" hidden aria-hidden="true"></span>
   <main class="game-shell__main">
     <div class="game-shell__surface">
       <div class="wrap">

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -12,6 +12,8 @@ export function boot() {
   const bullets = [];
   const enemies = [];
   let t = 0, score = 0;
+  const scoreElement = document.getElementById('score');
+  const scoreDisplay = document.getElementById('scoreDisplay');
 
   const keys = new Set();
   addEventListener('keydown', e => keys.add(e.key));
@@ -91,6 +93,14 @@ export function boot() {
     ctx.fillText(`Score: ${score}`, 16, 26);
     ctx.fillText(`HP: ${player.hp}`, 16, 48);
     ctx.fillText('Move: WASD/Arrows • Shoot: Space/Enter', 16, 70);
+
+    if (scoreElement) {
+      scoreElement.textContent = String(score);
+      scoreElement.dataset.gameScore = String(score);
+    }
+    if (scoreDisplay) {
+      scoreDisplay.textContent = String(score);
+    }
   }
 
   let raf = 0;


### PR DESCRIPTION
## Summary
- add a hidden score element for shell and analytics integrations
- keep the HUD score visible and update it together with the hidden node
- wire draw() to sync text content and data attributes for the score element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de046eaab083278142c81d3471250f