### PR TITLE
Add hidden score element for Snake shell integration

### DIFF
--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -105,6 +105,8 @@
     <div class="game-shell__surface">
       <div class="wrap">
         <canvas id="game" width="640" height="480" role="img" aria-label="Snake game board"></canvas>
+        <!-- Hidden score element exists to satisfy shell score watchers -->
+        <div id="score" hidden></div>
       </div>
     </div>
   </main>

--- a/games/snake/snake.js
+++ b/games/snake/snake.js
@@ -132,6 +132,7 @@ function resolveHudContainer() {
 }
 
 const hud = resolveHudContainer();
+const scoreNode = document.getElementById('score');
 hud.innerHTML = `Arrows/WASD or swipe • R restart • P pause
   <label><input type="checkbox" id="dailyToggle"/> Daily</label>
   <ol id="dailyScores" style="margin:4px 0 0 0;padding-left:20px;font-size:14px"></ol>
@@ -419,13 +420,18 @@ function step() {
   lastTickTime = performance.now();
 }
 
-function render() {
+function draw() {
   if(!postedReady){
     postedReady=true;
     try { window.parent?.postMessage({ type:'GAME_READY', slug:'snake' }, '*'); } catch {}
   }
   const time = performance.now();
   CELL = c.width / N;
+
+  if (scoreNode) {
+    scoreNode.textContent = String(score);
+    scoreNode.dataset.gameScore = String(score);
+  }
 
   // background with alternating tints
   for (let y = 0; y < N; y++) {
@@ -570,6 +576,6 @@ engine.update = dt => {
     step();
   }
 };
-engine.render = render;
+engine.render = draw;
 engine.start();
 if (typeof reportReady === 'function') reportReady('snake');


### PR DESCRIPTION
## Summary
- add a hidden #score element to the Snake shell markup for score observers
- update the Snake draw loop to keep the node text and data-game-score in sync with the current score

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de0472402883279c1c6fa4fa26342d