### PR TITLE
Refactor diagnostics console with tabbed report view

### DIFF
--- a/games/common/diag-autowire.js
+++ b/games/common/diag-autowire.js
@@ -111,6 +111,7 @@
 
     win.__GG_DIAG_OPTS = { suppressButton: true };
 
+    ensureScript('../common/diagnostics/report-store.js', 'data-gg-diag-report');
     ensureScript('../common/diag-core.js', 'data-gg-diag-core');
     ensureScript('../common/diag-capture.js', 'data-gg-diag-capture');
   });

--- a/games/common/diag-modal.css
+++ b/games/common/diag-modal.css
@@ -10,6 +10,17 @@ body.gg-diag-scroll-locked {
   display: none !important;
 }
 
+.diag-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2147483599;
+}
+
+.diag-overlay .gg-diag-modal {
+  pointer-events: auto;
+}
+
 .gg-diag-fab {
   position: fixed;
   bottom: 1.5rem;
@@ -128,11 +139,68 @@ body.gg-diag-scroll-locked {
 .gg-diag-modal-body {
   padding: clamp(0.75rem, 3vw, 1.5rem);
   flex: 1;
-  overflow: auto;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   background: rgba(9, 15, 24, 0.96);
+}
+
+.gg-diag-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding-bottom: 0.65rem;
+  border-bottom: 1px solid rgba(96, 165, 250, 0.14);
+}
+
+.gg-diag-tab {
+  border: 1px solid transparent;
+  background: rgba(37, 99, 235, 0.12);
+  color: rgba(226, 232, 240, 0.85);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.gg-diag-tab:hover,
+.gg-diag-tab:focus-visible {
+  background: rgba(59, 130, 246, 0.25);
+  border-color: rgba(147, 197, 253, 0.6);
+  color: #f8fbff;
+  transform: translateY(-1px);
+}
+
+.gg-diag-tab:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.45);
+  outline-offset: 2px;
+}
+
+.gg-diag-tab[aria-selected="true"] {
+  background: rgba(37, 99, 235, 0.45);
+  border-color: rgba(147, 197, 253, 0.8);
+  color: #fdfcff;
+  box-shadow: inset 0 0 0 1px rgba(191, 219, 254, 0.35);
+}
+
+.gg-diag-panels {
+  flex: 1;
+  position: relative;
+}
+
+.gg-diag-panel {
+  height: 100%;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.gg-diag-panel[hidden] {
+  display: none !important;
 }
 
 .gg-diag-loglist {
@@ -144,6 +212,21 @@ body.gg-diag-scroll-locked {
   gap: 0.65rem;
   font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, Menlo, Consolas, "Liberation Mono", monospace;
   font-size: 0.8125rem;
+}
+
+.gg-diag-panel-list {
+  padding-bottom: 0.5rem;
+}
+
+.gg-diag-panel-empty {
+  margin: 0;
+  padding: 1rem 0.75rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(96, 165, 250, 0.3);
+  background: rgba(15, 23, 42, 0.52);
+  color: rgba(191, 219, 254, 0.75);
+  text-align: center;
+  font-size: 0.85rem;
 }
 
 .gg-diag-logitem {
@@ -203,6 +286,130 @@ body.gg-diag-scroll-locked {
   justify-content: flex-end;
   background: rgba(10, 17, 28, 0.92);
   border-top: 1px solid rgba(96, 165, 250, 0.14);
+}
+
+.gg-diag-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(96, 165, 250, 0.18);
+  border: 1px solid rgba(96, 165, 250, 0.38);
+  color: #dbeafe;
+}
+
+.gg-diag-badge--pass {
+  background: rgba(34, 197, 94, 0.22);
+  border-color: rgba(74, 222, 128, 0.55);
+  color: #bbf7d0;
+}
+
+.gg-diag-badge--warn {
+  background: rgba(251, 191, 36, 0.22);
+  border-color: rgba(250, 204, 21, 0.55);
+  color: #fde68a;
+}
+
+.gg-diag-badge--fail {
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.45);
+  color: #fecaca;
+}
+
+.gg-diag-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.gg-diag-summary-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.gg-diag-summary-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.82);
+}
+
+.gg-diag-summary-updated {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.gg-diag-summary-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.gg-diag-summary-card {
+  background: rgba(17, 27, 42, 0.72);
+  border: 1px solid rgba(96, 165, 250, 0.18);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.42);
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.gg-diag-summary-value {
+  font-size: 1.45rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.gg-diag-summary-sub {
+  font-size: 0.82rem;
+  color: rgba(191, 219, 254, 0.78);
+}
+
+.gg-diag-summary-subtle {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.gg-diag-summary-metric {
+  font-weight: 600;
+  color: rgba(244, 244, 245, 0.9);
+}
+
+.gg-diag-env {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.gg-diag-env-meta {
+  font-size: 0.85rem;
+  color: rgba(191, 219, 254, 0.78);
+}
+
+.gg-diag-env-pre {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(96, 165, 250, 0.18);
+  border-radius: 12px;
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.9);
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
 }
 
 .gg-diag-action {

--- a/games/common/diagnostics/report-store.js
+++ b/games/common/diagnostics/report-store.js
@@ -1,0 +1,275 @@
+/* Gurjot's Games — diagnostics/report-store.js
+   Aggregates diagnostics events for the modern console UI.
+*/
+(function(){
+  const global = typeof window !== "undefined" ? window : (typeof globalThis !== "undefined" ? globalThis : null);
+  if (!global) return;
+  if (global.GGDiagReportStore && typeof global.GGDiagReportStore.createReportStore === "function") {
+    return;
+  }
+
+  function createReportStoreModule(){
+    const PROBE_CATEGORIES = new Set(["performance", "service-worker", "heartbeat", "metrics", "telemetry", "probe", "resource", "feature", "capability"]);
+    const DEFAULTS = {
+      maxEntries: 500,
+      maxConsole: 500,
+      maxNetwork: 200,
+      maxProbes: 200,
+      maxEnvHistory: 12,
+    };
+
+    function sanitizeLimit(value, fallback){
+      const num = Number(value);
+      if (!Number.isFinite(num) || num <= 0) return fallback;
+      return Math.max(1, Math.floor(num));
+    }
+
+    function createReportStore(options = {}){
+      const maxEntries = sanitizeLimit(options.maxEntries, DEFAULTS.maxEntries);
+      const config = {
+        maxEntries,
+        maxConsole: sanitizeLimit(options.maxConsole, maxEntries),
+        maxNetwork: sanitizeLimit(options.maxNetwork, DEFAULTS.maxNetwork),
+        maxProbes: sanitizeLimit(options.maxProbes, DEFAULTS.maxProbes),
+        maxEnvHistory: sanitizeLimit(options.maxEnvHistory, DEFAULTS.maxEnvHistory),
+      };
+
+      const summary = {
+        startedAt: Date.now(),
+        updatedAt: null,
+        total: 0,
+        errors: 0,
+        warns: 0,
+        info: 0,
+        debug: 0,
+        status: "pass",
+        statusLabel: "Healthy",
+        categories: {},
+        network: { total: 0, failures: 0, warnings: 0, last: null },
+        lastError: null,
+        lastWarn: null,
+      };
+
+      const state = {
+        all: [],
+        console: [],
+        network: [],
+        probes: [],
+        envHistory: [],
+        environment: null,
+      };
+
+      function add(entry){
+        if (!entry) return snapshot();
+        const normalized = normalizeEntry(entry);
+        pushLimited(state.all, normalized, config.maxEntries);
+        pushLimited(state.console, normalized, config.maxConsole);
+        categorize(normalized);
+        updateSummary(normalized);
+        return snapshot();
+      }
+
+      function snapshot(){
+        return {
+          summary: cloneSummary(),
+          console: state.console.slice(),
+          probes: state.probes.slice(),
+          network: state.network.slice(),
+          environment: state.environment ? { ...state.environment } : null,
+          envHistory: state.envHistory.slice(),
+        };
+      }
+
+      function toJSON(){
+        const snap = snapshot();
+        return {
+          generatedAt: new Date().toISOString(),
+          summary: snap.summary,
+          console: snap.console,
+          probes: snap.probes,
+          network: snap.network,
+          environment: snap.environment,
+          envHistory: snap.envHistory,
+        };
+      }
+
+      function toText(){
+        const snap = snapshot();
+        const lines = [];
+        lines.push("=== Diagnostics Summary ===");
+        lines.push(`Generated: ${new Date().toISOString()}`);
+        lines.push(`Status: ${snap.summary.statusLabel}`);
+        lines.push(`Total entries: ${snap.summary.total}`);
+        lines.push(`Errors: ${snap.summary.errors}, Warnings: ${snap.summary.warns}`);
+        if (snap.summary.network.total) {
+          lines.push(`Network: ${snap.summary.network.total} requests (${snap.summary.network.failures} fail, ${snap.summary.network.warnings} warn)`);
+        }
+        if (snap.summary.lastError) {
+          lines.push(`Last error: [${formatISO(snap.summary.lastError.timestamp)}] ${snap.summary.lastError.message}`);
+        }
+        lines.push("");
+        lines.push("=== Console Entries ===");
+        if (snap.console.length) {
+          snap.console.forEach((entry) => lines.push(formatLine(entry)));
+        } else {
+          lines.push("No console entries captured.");
+        }
+        lines.push("");
+        lines.push("=== Probes ===");
+        if (snap.probes.length) {
+          snap.probes.forEach((entry) => lines.push(formatLine(entry)));
+        } else {
+          lines.push("No probe activity captured.");
+        }
+        lines.push("");
+        lines.push("=== Network ===");
+        if (snap.network.length) {
+          snap.network.forEach((entry) => lines.push(formatLine(entry)));
+        } else {
+          lines.push("No network requests recorded.");
+        }
+        lines.push("");
+        lines.push("=== Environment ===");
+        if (snap.environment) {
+          lines.push(safeStringify(snap.environment.details ?? snap.environment));
+        } else {
+          lines.push("No environment snapshot available.");
+        }
+        return lines.join("\n");
+      }
+
+      function categorize(entry){
+        const categoryKey = entry.category.toLowerCase();
+        if (categoryKey === "network") {
+          pushLimited(state.network, entry, config.maxNetwork);
+          return;
+        }
+        if (categoryKey === "environment") {
+          const envSnapshot = summarizeEntry(entry, true);
+          state.environment = envSnapshot;
+          pushLimited(state.envHistory, envSnapshot, config.maxEnvHistory);
+          return;
+        }
+        if (PROBE_CATEGORIES.has(categoryKey)) {
+          pushLimited(state.probes, entry, config.maxProbes);
+        }
+      }
+
+      function updateSummary(entry){
+        summary.total += 1;
+        const level = entry.level;
+        if (level === "error") {
+          summary.errors += 1;
+          summary.lastError = summarizeEntry(entry);
+        } else if (level === "warn") {
+          summary.warns += 1;
+          summary.lastWarn = summarizeEntry(entry);
+        } else if (level === "info") {
+          summary.info += 1;
+        } else if (level === "debug") {
+          summary.debug += 1;
+        }
+        const categoryKey = entry.category.toLowerCase();
+        summary.categories[categoryKey] = (summary.categories[categoryKey] || 0) + 1;
+        summary.updatedAt = entry.timestamp;
+        if (categoryKey === "network") {
+          summary.network.total += 1;
+          if (level === "error") summary.network.failures += 1;
+          else if (level === "warn") summary.network.warnings += 1;
+          summary.network.last = summarizeEntry(entry);
+        }
+        summary.status = deriveSummaryStatus(summary);
+        summary.statusLabel = statusLabelFromSummaryStatus(summary.status);
+      }
+
+      function cloneSummary(){
+        return {
+          startedAt: summary.startedAt,
+          updatedAt: summary.updatedAt,
+          total: summary.total,
+          errors: summary.errors,
+          warns: summary.warns,
+          info: summary.info,
+          debug: summary.debug,
+          status: summary.status,
+          statusLabel: summary.statusLabel,
+          categories: Object.assign({}, summary.categories),
+          network: Object.assign({}, summary.network, { last: summary.network.last ? { ...summary.network.last } : null }),
+          lastError: summary.lastError ? { ...summary.lastError } : null,
+          lastWarn: summary.lastWarn ? { ...summary.lastWarn } : null,
+        };
+      }
+
+      function normalizeEntry(entry){
+        const timestamp = typeof entry.timestamp === "number" ? entry.timestamp : Date.now();
+        const level = String(entry.level || "info").toLowerCase();
+        const category = String(entry.category || "general");
+        return {
+          timestamp,
+          level,
+          category,
+          message: entry.message != null ? String(entry.message) : "",
+          details: entry.details ?? null,
+        };
+      }
+
+      function summarizeEntry(entry, includeDetails){
+        const summaryEntry = {
+          timestamp: entry.timestamp,
+          level: entry.level,
+          category: entry.category,
+          message: entry.message,
+        };
+        if (includeDetails) {
+          summaryEntry.details = entry.details;
+        }
+        return summaryEntry;
+      }
+
+      function pushLimited(list, item, limit){
+        list.push(item);
+        if (list.length > limit) {
+          list.splice(0, list.length - limit);
+        }
+      }
+
+      function deriveSummaryStatus(value){
+        if (value.errors > 0) return "fail";
+        if (value.warns > 0) return "warn";
+        return "pass";
+      }
+
+      function statusLabelFromSummaryStatus(status){
+        if (status === "fail") return "Errors detected";
+        if (status === "warn") return "Warnings detected";
+        return "Healthy";
+      }
+
+      function safeStringify(value){
+        try { return JSON.stringify(value, null, 2); } catch (_) { return String(value); }
+      }
+
+      function formatLine(entry){
+        return `[${formatISO(entry.timestamp)}] ${entry.category}/${entry.level} ${entry.message}`;
+      }
+
+      function formatISO(value){
+        if (typeof value !== "number") return "";
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? "" : date.toISOString();
+      }
+
+      return {
+        config,
+        add,
+        snapshot,
+        toJSON,
+        toText,
+      };
+    }
+
+    return { createReportStore };
+  }
+
+  global.GGDiagReportStore = createReportStoreModule();
+})();


### PR DESCRIPTION
## Summary
- add a diagnostics report store module and wire the console to tabbed Summary/Console/Probes/Network/Env panes
- restyle the diagnostics modal with tab navigation, badges, scrollable panels, and updated overlay pointer behavior
- autowire the new report store script alongside the existing diagnostics loader

## Testing
- manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68de0882bea8832785fbf7e5a134df1d