### PR TITLE
Refactor diagnostics pipeline to use pushEvent helper

### DIFF
--- a/docs/diagnostics-migration.md
+++ b/docs/diagnostics-migration.md
@@ -1,0 +1,67 @@
+# Diagnostics migration guide
+
+Games that previously pulled in `shared/diagnostics.js` or the legacy
+`diag-autowire.js` loader should switch to the slimmer
+`games/common/diag-adapter.js` helper. The adapter exposes a single
+`pushEvent(category, payload)` API that forwards structured diagnostics to the
+shared capture shim (`diag-capture.js`) and the modern diagnostics UI.
+
+## Why migrate?
+
+- `shared/diagnostics.js` duplicated queue logic that now lives in the shared
+  capture shim. The file is now a thin compatibility layer that only logs a
+  deprecation warning.
+- `diag-autowire.js` injected several scripts and attempted to manage legacy
+  UIs. The adapter keeps the capture shim as the sole source of console, error
+  and network instrumentation.
+- `pushEvent` guarantees that payloads are normalised and reach the
+  diagnostics overlay regardless of load order.
+
+## Updating modules (`type="module"`)
+
+1. Remove the `<script type="module" src="../../shared/diagnostics.js">` (or
+   similar) tag from the game HTML.
+2. Import the adapter where you previously referenced the shared diagnostics
+   helper:
+
+   ```js
+   import { pushEvent } from '../games/common/diag-adapter.js';
+
+   pushEvent('game', {
+     level: 'info',
+     message: '[my-game] bootstrap complete',
+     details: { scene: 'intro' },
+   });
+   ```
+3. Keep loading `games/common/diag-capture.js` (either directly or through the
+   shell) so console/error/network hooks remain active.
+
+## Updating HTML-only integrations
+
+If a title only injected scripts (for example via `diag-autowire.js`) without a
+module pipeline, replace the legacy loader with a direct reference to the
+capture shim and use the global helper when you need to emit manual events:
+
+```html
+<script src="../common/diag-capture.js" defer></script>
+<script>
+  window.__GG_DIAG_PUSH_EVENT__?.('game', {
+    level: 'info',
+    message: '[my-game] ready',
+  });
+</script>
+```
+
+The capture shim now installs `window.__GG_DIAG_PUSH_EVENT__` once it initialises.
+Games can safely queue events before it is ready — the helper falls back to the
+shared queue until the shim takes over.
+
+## Additional notes
+
+- The adapter returns the normalised entry, which can help during tests:
+  `const entry = pushEvent('game', { message: 'test' });`.
+- Diagnostics adapters registered through
+  `games/common/diagnostics/adapter.js` can continue to use `pushEvent` to feed
+  custom panes.
+- `shared/diagnostics.js` will keep emitting a warning event until the module
+  reference is removed.

--- a/games/common/diag-adapter.js
+++ b/games/common/diag-adapter.js
@@ -1,0 +1,49 @@
+const globalScope = typeof window !== 'undefined'
+  ? window
+  : (typeof globalThis !== 'undefined' ? globalThis : undefined);
+
+const localQueue = [];
+
+function ensureQueue() {
+  if (!globalScope) return localQueue;
+  const queue = globalScope.__GG_DIAG_QUEUE || (globalScope.__GG_DIAG_QUEUE = []);
+  return queue;
+}
+
+function fallbackPushEvent(category, payload) {
+  const queue = ensureQueue();
+  const entry = Object.assign({
+    category,
+    timestamp: typeof payload?.timestamp === 'number' ? payload.timestamp : Date.now(),
+  }, payload);
+  if (typeof entry.level !== 'string') entry.level = 'info';
+  if (typeof entry.message !== 'string') entry.message = entry.message ? String(entry.message) : '';
+  queue.push(entry);
+  if (queue.length > 2000) {
+    queue.splice(0, queue.length - 2000);
+  }
+  return entry;
+}
+
+export function pushEvent(category, payload) {
+  const normalizedCategory = typeof category === 'string' && category.trim()
+    ? category.trim()
+    : 'game';
+  const data = payload && typeof payload === 'object' ? { ...payload } : {};
+  if (!payload || typeof payload !== 'object') {
+    if (payload !== undefined) data.message = String(payload);
+  }
+  data.category = normalizedCategory;
+  if (typeof data.level !== 'string') data.level = 'info';
+  if (typeof data.timestamp !== 'number') data.timestamp = Date.now();
+
+  const dispatcher = globalScope && typeof globalScope.__GG_DIAG_PUSH_EVENT__ === 'function'
+    ? globalScope.__GG_DIAG_PUSH_EVENT__
+    : fallbackPushEvent;
+  const result = dispatcher(normalizedCategory, data);
+  return result || data;
+}
+
+export function isCaptureReady() {
+  return !!(globalScope && globalScope.__DIAG_CAPTURE_READY);
+}

--- a/games/platformer/diagnostics.js
+++ b/games/platformer/diagnostics.js
@@ -1,212 +1,124 @@
+import { pushEvent } from '../common/diag-adapter.js';
+
 const globalScope = typeof window !== 'undefined' ? window : undefined;
 const GAME_ID = 'platformer';
-const BUTTON_ID = 'platformer-diagnostics-button';
-const PANEL_ID = 'platformer-diagnostics-panel';
-let updateTimer = 0;
+const SNAPSHOT_INTERVAL = 5000;
+let intervalId = 0;
 
 function getBootRecord() {
   return globalScope?.__bootStatus?.[GAME_ID] || null;
 }
 
-function formatDetails(details) {
-  if (!details || typeof details !== 'object') return '';
-  const keys = Object.keys(details);
-  if (!keys.length) return '';
-  try {
-    return JSON.stringify(details);
-  } catch (_) {
-    return String(details);
-  }
-}
-
-function renderDiagnostics(panel) {
-  const pre = panel?.querySelector('pre');
-  if (!pre) return;
-  const record = getBootRecord();
-  const now = new Date();
-  const lines = [];
-  lines.push('Retro Platformer Diagnostics');
-  lines.push(`Rendered at: ${now.toISOString()}`);
-  lines.push('');
-
-  if (!record) {
-    lines.push('No boot status captured.');
-    pre.textContent = lines.join('\n');
-    return;
-  }
-
-  const origin = typeof record.createdAt === 'number' ? record.createdAt : 0;
-  const phases = Array.isArray(record.phaseOrder) && record.phaseOrder.length
+function buildPhaseSnapshot(record) {
+  const phases = [];
+  const source = Array.isArray(record.phaseOrder) && record.phaseOrder.length
     ? record.phaseOrder.slice()
     : Object.keys(record.phases || {});
-  phases.sort((a, b) => {
+  source.sort((a, b) => {
     const aAt = record.phases?.[a]?.at ?? 0;
     const bAt = record.phases?.[b]?.at ?? 0;
     return aAt - bAt;
   });
-
-  lines.push('[Phases]');
-  if (!phases.length) {
-    lines.push('- (no phases recorded)');
-  } else {
-    for (const name of phases) {
-      const entry = record.phases?.[name];
-      if (!entry) continue;
-      const at = entry.at ?? 0;
-      const delta = origin ? at - origin : at;
-      lines.push(`- ${name} @ +${Math.round(delta)}ms`);
-      const meta = Object.assign({}, entry);
-      delete meta.at;
-      const detailText = formatDetails(meta);
-      if (detailText) {
-        lines.push(`    details: ${detailText}`);
-      }
-    }
+  for (const name of source.slice(-12)) {
+    const entry = record.phases?.[name];
+    if (!entry) continue;
+    phases.push({
+      name,
+      at: entry.at ?? null,
+      details: Object.keys(entry)
+        .filter((key) => key !== 'at')
+        .reduce((acc, key) => {
+          acc[key] = entry[key];
+          return acc;
+        }, {}),
+    });
   }
-
-  lines.push('');
-  lines.push('[Canvas]');
-  const canvas = record.canvas || {};
-  lines.push(`- size: ${(canvas.width ?? 'n/a')}x${(canvas.height ?? 'n/a')}`);
-  if (typeof canvas.attached !== 'undefined') {
-    lines.push(`- attached: ${canvas.attached}`);
-  }
-  if (canvas.lastChange) {
-    const lastDelta = origin ? canvas.lastChange - origin : canvas.lastChange;
-    lines.push(`- last change: +${Math.round(lastDelta)}ms`);
-  }
-
-  lines.push('');
-  lines.push('[rAF]');
-  const raf = record.raf || {};
-  lines.push(`- ticks: ${raf.tickCount ?? 0}`);
-  if (raf.sinceLastTick) {
-    lines.push(`- last gap: ${Math.round(raf.sinceLastTick)}ms`);
-  }
-  if (raf.stalled) {
-    lines.push('- stalled: true');
-  }
-  if (raf.noTickLogged) {
-    lines.push('- watchdog noted missing ticks');
-  }
-
-  lines.push('');
-  lines.push('[Watchdog logs]');
-  const logs = Array.isArray(record.logs) ? record.logs.slice(-40) : [];
-  if (!logs.length) {
-    lines.push('- (no watchdog logs)');
-  } else {
-    for (const entry of logs) {
-      const ts = entry.timestamp ? new Date(entry.timestamp).toISOString() : now.toISOString();
-      const level = (entry.level || 'info').toUpperCase();
-      lines.push(`- ${ts} ${level} ${entry.message}`);
-      const detailText = formatDetails(entry.details);
-      if (detailText) {
-        lines.push(`    ${detailText}`);
-      }
-    }
-  }
-
-  pre.textContent = lines.join('\n');
+  return phases;
 }
 
-function togglePanel(panel, button) {
-  const isOpen = panel.dataset.open === 'true';
-  if (isOpen) {
-    panel.dataset.open = 'false';
-    panel.style.display = 'none';
-    panel.setAttribute('aria-hidden', 'true');
-    button.setAttribute('aria-expanded', 'false');
-    if (updateTimer) {
-      if (globalScope?.clearInterval) {
-        globalScope.clearInterval(updateTimer);
-      }
-      updateTimer = 0;
-    }
-  } else {
-    panel.dataset.open = 'true';
-    panel.style.display = 'block';
-    panel.setAttribute('aria-hidden', 'false');
-    button.setAttribute('aria-expanded', 'true');
-    renderDiagnostics(panel);
-    if (globalScope?.setInterval) {
-      updateTimer = globalScope.setInterval(() => renderDiagnostics(panel), 1200);
-    } else {
-      updateTimer = 0;
-    }
-  }
+function buildLogSnapshot(record) {
+  if (!Array.isArray(record.logs) || !record.logs.length) return [];
+  return record.logs.slice(-10).map((entry) => ({
+    level: entry.level || 'info',
+    message: entry.message || '',
+    timestamp: entry.timestamp || Date.now(),
+  }));
 }
 
-function ensureUI() {
-  if (!globalScope?.document) return;
-  if (globalScope.document.getElementById(BUTTON_ID)) return;
-
-  const button = globalScope.document.createElement('button');
-  button.id = BUTTON_ID;
-  button.type = 'button';
-  button.className = 'btn';
-  button.textContent = 'Diagnostics';
-  button.style.position = 'fixed';
-  button.style.right = '16px';
-  button.style.bottom = '16px';
-  button.style.zIndex = '1000';
-  button.setAttribute('aria-haspopup', 'dialog');
-  button.setAttribute('aria-expanded', 'false');
-
-  const panel = globalScope.document.createElement('div');
-  panel.id = PANEL_ID;
-  panel.dataset.open = 'false';
-  panel.style.position = 'fixed';
-  panel.style.right = '16px';
-  panel.style.bottom = '68px';
-  panel.style.width = '360px';
-  panel.style.maxWidth = 'calc(100vw - 32px)';
-  panel.style.maxHeight = '60vh';
-  panel.style.padding = '12px 14px';
-  panel.style.borderRadius = '12px';
-  panel.style.border = '1px solid #27314b';
-  panel.style.background = 'rgba(12, 16, 32, 0.95)';
-  panel.style.boxShadow = '0 18px 40px rgba(0, 0, 0, 0.45)';
-  panel.style.display = 'none';
-  panel.style.color = '#e6f0ff';
-  panel.style.fontFamily = 'ui-monospace, SFMono-Regular, Consolas, Menlo, monospace';
-  panel.style.fontSize = '13px';
-  panel.style.lineHeight = '1.5';
-  panel.setAttribute('role', 'dialog');
-  panel.setAttribute('aria-hidden', 'true');
-  panel.setAttribute('aria-label', 'Platformer diagnostics');
-
-  const pre = globalScope.document.createElement('pre');
-  pre.style.margin = '0';
-  pre.style.whiteSpace = 'pre-wrap';
-  pre.style.wordBreak = 'break-word';
-  panel.appendChild(pre);
-
-  button.addEventListener('click', () => togglePanel(panel, button));
-  if (typeof globalScope.addEventListener === 'function') {
-    globalScope.addEventListener('beforeunload', () => {
-      if (updateTimer) {
-        if (globalScope?.clearInterval) {
-          globalScope.clearInterval(updateTimer);
+function buildSnapshot(record) {
+  return {
+    createdAt: record.createdAt ?? null,
+    phases: buildPhaseSnapshot(record),
+    raf: record.raf
+      ? {
+          tickCount: record.raf.tickCount ?? 0,
+          sinceLastTick: record.raf.sinceLastTick ?? null,
+          stalled: !!record.raf.stalled,
+          noTickLogged: !!record.raf.noTickLogged,
         }
-        updateTimer = 0;
+      : null,
+    canvas: record.canvas
+      ? {
+          width: record.canvas.width ?? null,
+          height: record.canvas.height ?? null,
+          attached: record.canvas.attached ?? null,
+          lastChange: record.canvas.lastChange ?? null,
+        }
+      : null,
+    watchdogs: record.watchdogs
+      ? {
+          active: !!record.watchdogs.active,
+          armedAt: record.watchdogs.armedAt ?? null,
+        }
+      : null,
+    logs: buildLogSnapshot(record),
+  };
+}
+
+function publishSnapshot(reason) {
+  const record = getBootRecord();
+  if (!record) {
+    pushEvent('game', {
+      level: 'info',
+      message: `[${GAME_ID}] ${reason}`,
+      details: { note: 'No boot diagnostics recorded yet.' },
+    });
+    return;
+  }
+
+  const latestLog = Array.isArray(record.logs) && record.logs.length
+    ? record.logs[record.logs.length - 1]
+    : null;
+  const level = latestLog?.level === 'error'
+    ? 'error'
+    : record.raf?.stalled
+      ? 'warn'
+      : 'info';
+
+  pushEvent('game', {
+    level,
+    message: `[${GAME_ID}] ${reason}`,
+    details: buildSnapshot(record),
+  });
+}
+
+function startPublishing() {
+  if (!globalScope || !globalScope.document) return;
+  const trigger = () => publishSnapshot('snapshot ready');
+  if (globalScope.document.readyState === 'loading') {
+    globalScope.document.addEventListener('DOMContentLoaded', trigger, { once: true });
+  } else {
+    trigger();
+  }
+  if (typeof globalScope.setInterval === 'function') {
+    intervalId = globalScope.setInterval(() => publishSnapshot('watchdog update'), SNAPSHOT_INTERVAL);
+    globalScope.addEventListener?.('beforeunload', () => {
+      if (intervalId && typeof globalScope.clearInterval === 'function') {
+        globalScope.clearInterval(intervalId);
       }
+      intervalId = 0;
     }, { once: true });
   }
-
-  globalScope.document.body.appendChild(button);
-  globalScope.document.body.appendChild(panel);
 }
 
-function init() {
-  if (!globalScope?.document) return;
-  ensureUI();
-}
-
-if (globalScope?.document) {
-  if (globalScope.document.readyState === 'loading') {
-    globalScope.document.addEventListener('DOMContentLoaded', init, { once: true });
-  } else {
-    init();
-  }
-}
+startPublishing();

--- a/shared/diagnostics.js
+++ b/shared/diagnostics.js
@@ -1,8 +1,6 @@
-const globalScope = typeof window !== 'undefined' ? window : undefined;
-const diagnosticsQueue = globalScope
-  ? (globalScope.__diagnosticsQueue = globalScope.__diagnosticsQueue || [])
-  : [];
+import { pushEvent, isCaptureReady } from '../games/common/diag-adapter.js';
 
+const globalScope = typeof window !== 'undefined' ? window : undefined;
 const slug = detectSlug();
 
 function detectSlug() {
@@ -32,139 +30,6 @@ function findScript() {
   return scripts.find((script) => (script.src || '').includes('/shared/diagnostics.js')) || null;
 }
 
-function sanitize(value, depth = 0, seen = new WeakSet()) {
-  if (value === null || value === undefined) return value;
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
-  if (typeof value === 'bigint') return `${value.toString()}n`;
-  if (typeof value === 'symbol') return value.toString();
-  if (typeof value === 'function') return `[Function${value.name ? ` ${value.name}` : ''}]`;
-  if (value instanceof Error) {
-    return { name: value.name, message: value.message, stack: value.stack };
-  }
-  if (typeof DOMRect !== 'undefined' && value instanceof DOMRect) {
-    return { x: value.x, y: value.y, width: value.width, height: value.height };
-  }
-  if (typeof HTMLElement !== 'undefined' && value instanceof HTMLElement) {
-    const tag = value.tagName?.toLowerCase() || 'element';
-    const id = value.id ? `#${value.id}` : '';
-    const cls = value.className ? `.${String(value.className).replace(/\s+/g, '.')}` : '';
-    return `<${tag}${id}${cls}>`;
-  }
-  if (depth >= 3) return '[Truncated]';
-  if (typeof value === 'object') {
-    if (seen.has(value)) return '[Circular]';
-    seen.add(value);
-    if (Array.isArray(value)) {
-      return value.slice(0, 25).map((item) => sanitize(item, depth + 1, seen));
-    }
-    const output = {};
-    const entries = Object.entries(value).slice(0, 50);
-    for (const [key, val] of entries) {
-      output[key] = sanitize(val, depth + 1, seen);
-    }
-    return output;
-  }
-  try {
-    return JSON.parse(JSON.stringify(value));
-  } catch (_) {
-    return String(value);
-  }
-}
-
-function ensureInterface() {
-  if (!globalScope) return null;
-  const queue = diagnosticsQueue;
-  const existing = globalScope.__diagnostics || {};
-  function log(entry) {
-    if (!entry) return;
-    const normalized = {
-      category: entry.category || 'general',
-      level: entry.level || 'info',
-      message: entry.message || '',
-      details: entry.details ?? null,
-      timestamp: typeof entry.timestamp === 'number' ? entry.timestamp : Date.now(),
-    };
-    if (globalScope.__GG_DIAG && typeof globalScope.__GG_DIAG.log === 'function') {
-      try {
-        globalScope.__GG_DIAG.log(normalized);
-      } catch (error) {
-        queue.push({
-          category: 'diagnostics',
-          level: 'error',
-          message: '[diagnostics] forward failed',
-          details: sanitize(error),
-          timestamp: Date.now(),
-        });
-      }
-      return;
-    }
-    queue.push(normalized);
-    if (queue.length > 1200) {
-      queue.splice(0, queue.length - 1200);
-    }
-  }
-
-  function flush() {
-    if (!globalScope.__GG_DIAG || typeof globalScope.__GG_DIAG.log !== 'function') {
-      return false;
-    }
-    while (queue.length) {
-      const entry = queue.shift();
-      try {
-        globalScope.__GG_DIAG.log(entry);
-      } catch (error) {
-        queue.unshift(entry);
-        queue.push({
-          category: 'diagnostics',
-          level: 'error',
-          message: '[diagnostics] flush failed',
-          details: sanitize(error),
-          timestamp: Date.now(),
-        });
-        return false;
-      }
-    }
-    return true;
-  }
-
-  function getBootStatus() {
-    if (!globalScope.__bootStatus) return {};
-    return sanitize(globalScope.__bootStatus);
-  }
-
-  function exportLogs(format = 'json') {
-    if (!globalScope.__GG_DIAG) return null;
-    if (format === 'text' && typeof globalScope.__GG_DIAG.exportText === 'function') {
-      return globalScope.__GG_DIAG.exportText();
-    }
-    if (typeof globalScope.__GG_DIAG.exportJSON === 'function') {
-      return globalScope.__GG_DIAG.exportJSON();
-    }
-    return null;
-  }
-
-  function getQueueSnapshot() {
-    return queue.slice();
-  }
-
-  function open() {
-    globalScope.__GG_DIAG?.open?.();
-  }
-
-  const api = Object.assign(existing, {
-    log,
-    flush,
-    open,
-    getQueue: getQueueSnapshot,
-    exportLogs,
-    getBootStatus,
-    slug,
-  });
-
-  globalScope.__diagnostics = api;
-  return api;
-}
-
 function summarizeBoot(slugValue) {
   if (!globalScope?.__bootStatus) return null;
   const entry = globalScope.__bootStatus[slugValue];
@@ -177,8 +42,6 @@ function summarizeBoot(slugValue) {
     canvasWarnings: Array.isArray(entry.canvasWarnings) ? entry.canvasWarnings.length : 0,
   };
 }
-
-let loaderPromise = null;
 
 function loadScript(url) {
   return new Promise((resolve, reject) => {
@@ -195,9 +58,11 @@ function loadScript(url) {
   });
 }
 
+let loaderPromise = null;
+
 function ensureLegacyDiagnostics() {
   if (!globalScope) return Promise.resolve();
-  if (globalScope.__GG_DIAG && globalScope.__DIAG_CAPTURE_READY) {
+  if (globalScope.__GG_DIAG && isCaptureReady()) {
     return Promise.resolve();
   }
   if (loaderPromise) return loaderPromise;
@@ -206,45 +71,89 @@ function ensureLegacyDiagnostics() {
   loaderPromise = loadScript(coreUrl)
     .then(() => loadScript(captureUrl))
     .then(() => {
-      globalScope.__DIAG_CAPTURE_READY = true;
+      pushEvent('diagnostics', {
+        level: 'info',
+        message: `[${slug}] legacy diagnostics assets loaded`,
+      });
     })
     .catch((error) => {
-      diagnosticsQueue.push({
-        category: 'diagnostics',
+      pushEvent('diagnostics', {
         level: 'error',
-        message: '[diagnostics] asset load failed',
-        details: sanitize(error),
-        timestamp: Date.now(),
+        message: `[${slug}] failed to load diagnostics assets`,
+        details: error,
       });
       throw error;
     });
   return loaderPromise;
 }
 
+function ensureInterface() {
+  if (!globalScope) return null;
+  const existing = globalScope.__diagnostics;
+  if (existing && existing.__shimmed) return existing;
+  const api = {
+    __shimmed: true,
+    slug,
+    log(entry) {
+      if (!entry) return;
+      const payload = {
+        level: entry.level || 'info',
+        message: entry.message || '',
+      };
+      if (entry.details !== undefined) payload.details = entry.details;
+      if (typeof entry.timestamp === 'number') payload.timestamp = entry.timestamp;
+      pushEvent(entry.category || 'diagnostics', payload);
+    },
+    flush() {
+      return isCaptureReady();
+    },
+    open() {
+      globalScope.__GG_DIAG?.open?.();
+    },
+    getQueue() {
+      const queue = globalScope.__GG_DIAG_QUEUE;
+      return Array.isArray(queue) ? queue.slice() : [];
+    },
+    exportLogs(format = 'json') {
+      if (!globalScope.__GG_DIAG) return null;
+      if (format === 'text' && typeof globalScope.__GG_DIAG.exportText === 'function') {
+        return globalScope.__GG_DIAG.exportText();
+      }
+      if (typeof globalScope.__GG_DIAG.exportJSON === 'function') {
+        return globalScope.__GG_DIAG.exportJSON();
+      }
+      return null;
+    },
+    getBootStatus() {
+      return summarizeBoot(slug);
+    },
+  };
+  globalScope.__diagnostics = api;
+  return api;
+}
+
 async function init() {
   if (!globalScope || typeof document === 'undefined') return;
-  const api = ensureInterface();
-  api?.log({
-    category: 'diagnostics',
-    level: 'info',
-    message: `[${slug}] diagnostics initializing`,
-    details: { readyState: document.readyState },
+  ensureInterface();
+  pushEvent('diagnostics', {
+    level: 'warn',
+    message: `[${slug}] shared/diagnostics.js is deprecated; migrate to games/common/diag-adapter.js`,
   });
   try {
     await ensureLegacyDiagnostics();
-    api?.flush();
-    api?.log({
-      category: 'diagnostics',
+    pushEvent('diagnostics', {
       level: 'info',
       message: `[${slug}] diagnostics ready`,
-      details: { boot: summarizeBoot(slug), queueLength: diagnosticsQueue.length },
+      details: {
+        boot: summarizeBoot(slug),
+        captureReady: isCaptureReady(),
+      },
     });
   } catch (error) {
-    api?.log({
-      category: 'diagnostics',
+    pushEvent('diagnostics', {
       level: 'error',
-      message: `[${slug}] diagnostics failed`,
-      details: sanitize(error),
+      message: `[${slug}] diagnostics setup failed`,
+      details: error,
     });
   }
 }


### PR DESCRIPTION
## Summary
- add a normalized pushEvent helper in diag-capture and expose it through a new diag-adapter module
- update shared and game-specific diagnostics to forward events via the shared helper instead of bespoke queues
- document how to migrate titles away from shared/diagnostics.js or diag-autowire.js toward diag-adapter.js

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb28fbc3083279c5ad4a624307dd4