### PR TITLE
Configure Cloudflare Worker deployment with Wrangler

### DIFF
--- a/cloudflare/worker.ts
+++ b/cloudflare/worker.ts
@@ -1,0 +1,27 @@
+export interface Env {
+  ASSETS: {
+    fetch(request: Request): Promise<Response>;
+  };
+}
+
+const SPA_FALLBACK_PATH = "/index.html";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    let response = await env.ASSETS.fetch(request);
+
+    if (
+      response.status === 404 &&
+      request.method === "GET" &&
+      !url.pathname.includes(".")
+    ) {
+      const fallbackUrl = new URL(SPA_FALLBACK_PATH, url.origin);
+      const fallbackRequest = new Request(fallbackUrl.toString(), request);
+      response = await env.ASSETS.fetch(fallbackRequest);
+    }
+
+    return response;
+  },
+};

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,8 +6,18 @@ Follow these steps to deploy the game library:
    ```bash
    npm install
    ```
-2. Build the project if needed.
-3. Upload the files to your hosting provider or serve them with a Node server.
+2. Verify the Worker configuration and static asset bundle with a dry run. This
+   smoke test validates `wrangler.toml` before pushing a production deploy:
+   ```bash
+   npm run deploy:check
+   ```
+3. Deploy the site to Cloudflare Workers using the Wrangler configuration in
+   the repository root:
+   ```bash
+   npm run deploy
+   ```
+   The scripts call `npx wrangler deploy --config wrangler.toml`, which uploads
+   the static site files and routes requests through `cloudflare/worker.ts`.
 4. Configure environment variables as described in [CONFIGURATION](CONFIGURATION.md).
 5. Monitor logs and verify the site loads in a browser.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test:smoke": "vitest run tests/runner.smoke.test.js",
     "sitemap": "node tools/generate-sitemap.mjs",
     "health": "node tools/healthcheck.mjs",
-    "sync:games": "node tools/sync-game-catalog.mjs"
+    "sync:games": "node tools/sync-game-catalog.mjs",
+    "deploy": "npx wrangler deploy --config wrangler.toml",
+    "deploy:check": "npx wrangler deploy --config wrangler.toml --dry-run"
   },
   "devDependencies": {
     "acorn": "^8.15.0",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,11 @@
+name = "game-library"
+main = "cloudflare/worker.ts"
+compatibility_date = "2024-06-20"
+
+assets = { directory = ".", exclude = [
+  "node_modules/**",
+  "scripts/**",
+  "tests/**",
+  "tools/**",
+  ".git/**"
+] }


### PR DESCRIPTION
## Summary
- add a Wrangler configuration that serves the site through a Cloudflare Worker module and uploads static assets
- introduce npm scripts for deploying and performing a dry-run smoke check
- document the new Wrangler-based deployment flow for the project

## Testing
- not run (configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68deb3fcdf6483279b5eb19ef472dcbc