### PR TITLE
Add Breakout diagnostics adapter and expose game globals

### DIFF
--- a/games/breakout/adapter.js
+++ b/games/breakout/adapter.js
@@ -1,0 +1,97 @@
+import { registerGameDiagnostics } from '../common/diagnostics/adapter.js';
+import { pushEvent } from '../common/diag-adapter.js';
+
+const scope = typeof window !== 'undefined'
+  ? window
+  : (typeof globalThis !== 'undefined' ? globalThis : undefined);
+
+function whenBreakoutReady(callback) {
+  if (!scope || typeof callback !== 'function') return;
+  const queue = Array.isArray(scope.__BREAKOUT_READY__)
+    ? scope.__BREAKOUT_READY__
+    : (scope.__BREAKOUT_READY__ = []);
+  if (scope.Breakout && scope.Breakout.engine) {
+    callback(scope.Breakout);
+    return;
+  }
+  queue.push(callback);
+}
+
+function snapshot(game) {
+  const source = game || {};
+  const ball = source.ball || null;
+  const paddle = source.paddle || null;
+  const bricks = Array.isArray(source.bricks) ? source.bricks : [];
+  return {
+    score: typeof source.score === 'number' ? source.score : Number(source.score) || 0,
+    ball: ball ? {
+      x: ball.x,
+      y: ball.y,
+      vx: ball.vx,
+      vy: ball.vy,
+      speed: ball.speed,
+      radius: ball.r,
+      stuck: !!ball.stuck,
+    } : null,
+    paddle: paddle ? {
+      x: paddle.x,
+      y: paddle.y,
+      w: paddle.w,
+      h: paddle.h,
+    } : null,
+    bricks: bricks.map((brick, index) => ({
+      index,
+      x: brick.x,
+      y: brick.y,
+      w: brick.w,
+      h: brick.h,
+      hp: brick.hp,
+      power: brick.pu || null,
+    })),
+  };
+}
+
+whenBreakoutReady((game) => {
+  try {
+    registerGameDiagnostics('breakout', {
+      hooks: {
+        onReady(context) {
+          pushEvent('breakout', {
+            level: 'info',
+            message: 'Breakout diagnostics adapter ready',
+            details: { score: game.score ?? 0 },
+          });
+          if (typeof context?.requestProbeRun === 'function') {
+            context.requestProbeRun('Initial breakout snapshot');
+          }
+        },
+      },
+      api: {
+        start() {
+          game.engine?.start?.();
+        },
+        pause() {
+          game.engine?.pause?.();
+        },
+        resume() {
+          game.engine?.resume?.();
+        },
+        reset() {
+          game.resetMatch?.();
+        },
+        getScore() {
+          return game.score ?? 0;
+        },
+        async getEntities() {
+          return snapshot(game);
+        },
+      },
+    });
+  } catch (err) {
+    pushEvent('breakout', {
+      level: 'error',
+      message: 'Failed to register Breakout diagnostics adapter',
+      error: err,
+    });
+  }
+});

--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -75,9 +75,7 @@
     else { window.addEventListener("load", function(){ setTimeout(emitReadyOnce, 0); }); }
   })();
   </script>
-  <link rel="stylesheet" href="../common/diag-modal.css">
-  <script src="../common/diagnostics/report-store.js" defer></script>
-  <script src="../common/diag-core.js" defer></script>
+  <script type="module" src="./adapter.js"></script>
   <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose the Breakout engine, entities, score, and reset helper on `window.Breakout` and emit ready callbacks
- add a diagnostics adapter module that registers Breakout with the shared diagnostics registry
- simplify the Breakout shell HTML to load the adapter module alongside the capture script only

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deb61e6c5883279d997022b0c89fa2