### PR TITLE
Expose Chess3D diagnostics controller

### DIFF
--- a/games/chess3d/adapter.js
+++ b/games/chess3d/adapter.js
@@ -1,0 +1,107 @@
+import { registerGameDiagnostics } from "../common/diagnostics/adapter.js";
+import { pushEvent } from "../common/diag-adapter.js";
+
+const GAME_ID = "chess3d";
+const globalScope = typeof window !== "undefined" ? window : undefined;
+
+function getController() {
+  return globalScope?.Chess3D || null;
+}
+
+function snapshotVector(vector) {
+  if (!vector) return null;
+  return {
+    x: typeof vector.x === "number" ? vector.x : null,
+    y: typeof vector.y === "number" ? vector.y : null,
+    z: typeof vector.z === "number" ? vector.z : null,
+  };
+}
+
+function snapshotCamera(camera) {
+  if (!camera) return null;
+  return {
+    position: snapshotVector(camera.position),
+    rotation: snapshotVector(camera.rotation),
+    up: snapshotVector(camera.up),
+    fov: typeof camera.fov === "number" ? camera.fov : null,
+    aspect: typeof camera.aspect === "number" ? camera.aspect : null,
+    near: typeof camera.near === "number" ? camera.near : null,
+    far: typeof camera.far === "number" ? camera.far : null,
+  };
+}
+
+function buildSnapshot(controller) {
+  const depth = typeof controller.getAIDepth === "function"
+    ? controller.getAIDepth()
+    : null;
+  return {
+    state: controller.state || null,
+    aiDepth: typeof depth === "number" ? depth : null,
+    lastEvaluation: controller.lastEvaluation || null,
+    camera: snapshotCamera(controller.camera || null),
+  };
+}
+
+function registerAdapter() {
+  if (!globalScope) return;
+  const controller = getController();
+  if (!controller) {
+    pushEvent("game", {
+      level: "error",
+      message: `[${GAME_ID}] diagnostics adapter failed: controller unavailable`,
+    });
+    return;
+  }
+
+  let lastState = controller.state || null;
+  const unsubscribe = typeof controller.onStateChange === "function"
+    ? controller.onStateChange((state, meta) => {
+        lastState = state;
+        pushEvent("game", {
+          level: state === "gameover" ? "warn" : "info",
+          message: `[${GAME_ID}] state changed to ${state}`,
+          details: {
+            previous: meta?.previous ?? null,
+            state,
+            initial: !!meta?.initial,
+          },
+        });
+      })
+    : null;
+
+  registerGameDiagnostics(GAME_ID, {
+    hooks: {},
+    api: {
+      start() {
+        controller.startRenderLoop?.();
+      },
+      pause() {
+        controller.stopRenderLoop?.();
+      },
+      resume() {
+        controller.startRenderLoop?.();
+      },
+      setDifficulty(level) {
+        controller.setAIDepth?.(level);
+      },
+      getEntities() {
+        return {
+          state: lastState,
+          snapshot: buildSnapshot(controller),
+        };
+      },
+    },
+  });
+
+  if (typeof globalScope?.addEventListener === "function" && unsubscribe) {
+    globalScope.addEventListener(
+      "beforeunload",
+      () => {
+        try { unsubscribe(); } catch (_) {}
+      },
+      { once: true },
+    );
+  }
+}
+
+registerAdapter();


### PR DESCRIPTION
## Summary
- expose a global Chess3D controller with render loop controls, AI depth setters, evaluation tracking, and state change notifications
- record AI probe duration events and keep evaluation state in sync across resets and jump actions
- import a diagnostics adapter after boot to register Chess3D with the shared diagnostics registry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb623423c83278fff22f51a3e2926