### PR TITLE
Expose Maze3D controls and wire diagnostics

### DIFF
--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -108,6 +108,7 @@
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="maze3d"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="maze3d" data-apply-theme="false"></script>
+  <script src="../common/diag-autowire.js" defer></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>
@@ -138,8 +139,5 @@
   })();
   </script>
   <link rel="stylesheet" href="../common/diag-modal.css">
-  <script src="../common/diagnostics/report-store.js" defer></script>
-  <script src="../common/diag-core.js" defer></script>
-  <script src="../common/diag-capture.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose a `window.Maze3D` helper with lifecycle controls, ready hook, and entity references
- emit network diagnostics events when cooperative position updates are sent
- switch the Maze3D shell to the shared diagnostics autowire loader instead of direct script tags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb62482b0832786ac232468d2d5ca