### PR TITLE
Refine Pong diagnostics integration

### DIFF
--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -25,7 +25,7 @@
     <script>
       try { window.parent && window.parent.postMessage({type:'IFRAME_LOADED', slug:'pong'}, '*'); } catch(e){}
     </script>
-    <script src="./pong.js" defer></script>
+    <script type="module" src="./pong.js"></script>
     <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="pong" data-apply-theme="false" data-focus-target="#app"></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->


### PR DESCRIPTION
## Summary
- remove the inline diagnostics UI from Pong and expose lifecycle helpers via `window.Pong`
- import the diagnostics adapter to emit state updates when the mode or AI changes
- load the Pong entrypoint as a module so it can rely on the shared adapter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb628bfa48327b01a454bc75d2d7f