### PR TITLE
Add profile overlay trigger and dialog

### DIFF
--- a/css/bolt-landing.css
+++ b/css/bolt-landing.css
@@ -31,6 +31,7 @@ body.bolt-body{
 /* NAV */
 .bolt-nav{background:transparent}
 .bolt-nav-inner{display:flex;align-items:center;justify-content:space-between;height:74px}
+.bolt-nav-actions{display:flex;align-items:center;gap:18px}
 .bolt-brand{text-decoration:none;color:var(--bolt-text);display:flex;align-items:center;gap:10px}
 .bolt-logo{display:block;width:32px;height:auto;filter:drop-shadow(0 8px 20px rgba(0,0,0,.2))}
 .bolt-brand-text{font-weight:800;letter-spacing:.3px;text-shadow:0 2px 18px rgba(0,0,0,.28)}

--- a/game.html
+++ b/game.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Play — Gurjot’s Games</title>
   <link rel="icon" type="image/png" href="assets/favicon.png">
+  <link rel="stylesheet" href="styles/profile-overlay.css">
   <style>
     :root {
       color-scheme: dark;
@@ -293,10 +294,17 @@
         <a id="backLink" class="btn btn-primary" href="./index.html" aria-label="Back to home">← Back</a>
         <h1 id="gameTitle">Loading…</h1>
       </div>
-      <nav>
-        <button id="btnReload" class="btn" aria-label="Reload game">Reload</button>
-        <button id="btnDiag" class="btn btn-ghost" aria-label="Show diagnostics">Diagnostics</button>
-      </nav>
+      <div class="bolt-nav-actions">
+        <nav>
+          <button id="btnReload" class="btn" aria-label="Reload game">Reload</button>
+          <button id="btnDiag" class="btn btn-ghost" aria-label="Show diagnostics">Diagnostics</button>
+        </nav>
+        <button type="button" class="bolt-profile-trigger" data-profile-trigger aria-haspopup="dialog" aria-expanded="false">
+          <span class="sr-only">Open profile overlay</span>
+          <span data-profile-avatar aria-hidden="true"></span>
+          <span data-profile-name></span>
+        </button>
+      </div>
     </header>
 
     <section id="questWidgetRoot" class="quest-widget" aria-live="polite"></section>
@@ -326,6 +334,7 @@
   </div>
 
   <script src="./js/auto-diag-inject.js"></script>
+  <script type="module" src="./js/profile-overlay.js"></script>
 
   <script type="module">
     import { mountQuestWidget } from './shared/quest-widget.js';

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/bolt-landing.css?v=20250911175011">
+  <link rel="stylesheet" href="styles/profile-overlay.css">
   <link rel="icon" type="image/png" href="assets/favicon.png">
   <style>
     .sr-only {
@@ -38,11 +39,18 @@
         <img class="bolt-logo" src="assets/logo.svg" alt="Gurjot’s Games logo">
         <span class="bolt-brand-text"><strong>Gurjot's</strong> Games</span>
       </a>
-      <nav class="bolt-links">
-        <a href="game.html" class="bolt-link">Games</a>
-        <a href="#about" class="bolt-link">About</a>
-        <a href="#contact" class="bolt-link">Contact</a>
-      </nav>
+      <div class="bolt-nav-actions">
+        <nav class="bolt-links">
+          <a href="game.html" class="bolt-link">Games</a>
+          <a href="#about" class="bolt-link">About</a>
+          <a href="#contact" class="bolt-link">Contact</a>
+        </nav>
+        <button type="button" class="bolt-profile-trigger" data-profile-trigger aria-haspopup="dialog" aria-expanded="false">
+          <span class="sr-only">Open profile overlay</span>
+          <span data-profile-avatar aria-hidden="true"></span>
+          <span data-profile-name></span>
+        </button>
+      </div>
     </div>
   </header>
 
@@ -167,6 +175,7 @@
       if (y) y.textContent = new Date().getFullYear();
     });
   </script>
+  <script type="module" src="js/profile-overlay.js"></script>
   <script type="module" src="js/bolt-landing.js?v=20250911175011"></script>
 </body>
 </html>

--- a/js/profile-overlay.js
+++ b/js/profile-overlay.js
@@ -1,0 +1,436 @@
+import {
+  getProfile,
+  getAggregatedStats,
+  login,
+  listProfiles,
+  removeProfile,
+  PROFILE_EVENT
+} from '../shared/profile.js';
+import { getAchievements } from '../shared/achievements.js';
+import { getActiveQuests, getXP, QUESTS_UPDATED_EVENT } from '../shared/quests.js';
+import { getLastPlayed } from '../shared/ui.js';
+
+const trigger = document.querySelector('[data-profile-trigger]');
+if (trigger) {
+  const nameNode = trigger.querySelector('[data-profile-name]');
+  const avatarNode = trigger.querySelector('[data-profile-avatar]');
+
+  let overlay = null;
+  let dialog = null;
+  let lastFocused = null;
+  let catalogPromise = null;
+  let catalogTitles = new Map();
+
+  const selectors = {
+    list: '[data-profile-list]',
+    metrics: '[data-profile-metrics]',
+    quests: '[data-profile-quests]',
+    history: '[data-profile-history]',
+    add: '[data-add-profile]'
+  };
+
+  function setAvatarVisual(node, profile) {
+    if (!node || !profile) return;
+    const name = profile.name || 'Guest';
+    const avatar = profile.avatar || '';
+    node.textContent = '';
+    node.classList.remove('has-image');
+    node.style.removeProperty('background-image');
+
+    if (avatar) {
+      node.classList.add('has-image');
+      node.style.backgroundImage = `url("${avatar}")`;
+    } else {
+      const initial = name.trim().charAt(0) || 'G';
+      node.textContent = initial.toUpperCase();
+    }
+  }
+
+  function updateTrigger(profile = getProfile()) {
+    if (avatarNode) {
+      setAvatarVisual(avatarNode, profile);
+    }
+    if (nameNode) {
+      nameNode.textContent = profile.name || 'Guest';
+    }
+    trigger.setAttribute('aria-label', `Open profile overlay for ${profile.name || 'Guest'}`);
+  }
+
+  function createOverlay() {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'profile-overlay';
+    wrapper.setAttribute('aria-hidden', 'true');
+    wrapper.innerHTML = `
+      <div class="profile-overlay-backdrop" data-close></div>
+      <div class="profile-overlay-dialog" role="dialog" aria-modal="true" aria-labelledby="profileOverlayTitle" tabindex="-1">
+        <div class="profile-overlay-header">
+          <h2 id="profileOverlayTitle">Player profile</h2>
+          <button type="button" class="profile-overlay-close" data-close aria-label="Close profile overlay">×</button>
+        </div>
+        <section class="profile-section">
+          <div class="profile-switch-header">
+            <h3>Switch profile</h3>
+            <button type="button" class="profile-add-btn" data-add-profile>Add profile</button>
+          </div>
+          <ul class="profile-switch-list" data-profile-list role="list"></ul>
+        </section>
+        <section class="profile-section">
+          <h3>Metrics</h3>
+          <div class="profile-metrics-grid" data-profile-metrics></div>
+        </section>
+        <section class="profile-section">
+          <h3>Quest progress</h3>
+          <div class="profile-quests-group" data-profile-quests></div>
+        </section>
+        <section class="profile-section">
+          <h3>Recent history</h3>
+          <ul class="profile-history-list" data-profile-history role="list"></ul>
+        </section>
+      </div>
+    `;
+    document.body.appendChild(wrapper);
+    return wrapper;
+  }
+
+  function ensureOverlay() {
+    if (!overlay) {
+      overlay = createOverlay();
+      dialog = overlay.querySelector('.profile-overlay-dialog');
+      overlay.addEventListener('click', onOverlayClick);
+    }
+    if (!dialog) {
+      dialog = overlay.querySelector('.profile-overlay-dialog');
+    }
+    return overlay;
+  }
+
+  function renderSwitchList(profiles = listProfiles()) {
+    const root = overlay.querySelector(selectors.list);
+    if (!root) return;
+    root.innerHTML = '';
+    const current = getProfile();
+    if (!profiles.length) {
+      const empty = document.createElement('li');
+      empty.className = 'profile-empty';
+      empty.textContent = 'No profiles yet. Add a profile to get started.';
+      root.appendChild(empty);
+      return;
+    }
+
+    profiles.forEach(profile => {
+      const item = document.createElement('li');
+      item.className = 'profile-switch-item';
+      if (profile.name === current.name) {
+        item.classList.add('is-active');
+      }
+
+      const mainBtn = document.createElement('button');
+      mainBtn.type = 'button';
+      mainBtn.className = 'profile-switch-main';
+      mainBtn.dataset.switch = profile.name;
+
+      const avatar = document.createElement('span');
+      avatar.className = 'profile-switch-avatar';
+      setAvatarVisual(avatar, profile);
+      mainBtn.appendChild(avatar);
+
+      const textWrap = document.createElement('span');
+      textWrap.className = 'profile-switch-text';
+      const name = document.createElement('span');
+      name.className = 'profile-switch-name';
+      name.textContent = profile.name;
+      const meta = document.createElement('span');
+      meta.className = 'profile-switch-meta';
+      meta.textContent = profile.name === current.name ? 'Active profile' : 'Switch to profile';
+      textWrap.appendChild(name);
+      textWrap.appendChild(meta);
+
+      mainBtn.appendChild(textWrap);
+      item.appendChild(mainBtn);
+
+      const canRemove = profile.name !== current.name && profile.name.toLowerCase() !== 'guest';
+      if (canRemove) {
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'profile-remove-btn';
+        removeBtn.dataset.remove = profile.name;
+        removeBtn.textContent = 'Remove';
+        item.appendChild(removeBtn);
+      }
+
+      root.appendChild(item);
+    });
+  }
+
+  function renderMetrics() {
+    const container = overlay.querySelector(selectors.metrics);
+    if (!container) return;
+    const stats = getAggregatedStats();
+    const unlocked = stats.achievements || [];
+    const achievements = getAchievements().filter(a => a.unlocked).slice(0, 3);
+    const questXP = getXP();
+    container.innerHTML = `
+      <div class="profile-metric">
+        <span class="profile-metric-label">Lifetime XP</span>
+        <span class="profile-metric-value">${Number(stats.xp || 0).toLocaleString()}</span>
+      </div>
+      <div class="profile-metric">
+        <span class="profile-metric-label">Total plays</span>
+        <span class="profile-metric-value">${Number(stats.plays || 0).toLocaleString()}</span>
+      </div>
+      <div class="profile-metric">
+        <span class="profile-metric-label">Achievements</span>
+        <span class="profile-metric-value">${unlocked.length}</span>
+        ${achievements.length ? `<p class="profile-metric-note">Recent: ${achievements.map(a => a.title).join(', ')}</p>` : ''}
+      </div>
+      <div class="profile-metric">
+        <span class="profile-metric-label">Quest XP</span>
+        <span class="profile-metric-value">${Number(questXP || 0).toLocaleString()}</span>
+      </div>
+    `;
+  }
+
+  function createQuestCard(quest, typeLabel) {
+    const card = document.createElement('article');
+    card.className = 'profile-quest-card';
+    if (quest.completed) {
+      card.dataset.complete = 'true';
+    }
+
+    const header = document.createElement('header');
+    const label = document.createElement('span');
+    label.textContent = quest.description;
+    const xp = document.createElement('span');
+    xp.textContent = `+${quest.xp} XP`;
+    header.appendChild(label);
+    header.appendChild(xp);
+
+    const type = document.createElement('span');
+    type.className = 'profile-quest-status';
+    type.textContent = typeLabel;
+
+    const progress = document.createElement('div');
+    progress.className = 'profile-quest-progress';
+    const fill = document.createElement('span');
+    const current = Math.min(quest.progress || 0, quest.goal || 0);
+    const pct = quest.goal ? Math.min(100, (current / quest.goal) * 100) : 0;
+    fill.style.width = `${pct}%`;
+    progress.appendChild(fill);
+
+    const status = document.createElement('div');
+    status.className = 'profile-quest-status';
+    status.textContent = quest.completed ? 'Completed' : `${current} / ${quest.goal}`;
+
+    card.appendChild(header);
+    card.appendChild(type);
+    card.appendChild(progress);
+    card.appendChild(status);
+    return card;
+  }
+
+  function renderQuests(detail) {
+    const container = overlay.querySelector(selectors.quests);
+    if (!container) return;
+    container.innerHTML = '';
+    const data = detail && typeof detail === 'object' && detail.daily && detail.weekly ? detail : getActiveQuests();
+    const combined = [
+      ...(Array.isArray(data.daily) ? data.daily.map(q => ({ ...q, __type: 'Daily quest' })) : []),
+      ...(Array.isArray(data.weekly) ? data.weekly.map(q => ({ ...q, __type: 'Weekly quest' })) : [])
+    ];
+    if (!combined.length) {
+      const empty = document.createElement('p');
+      empty.className = 'profile-empty';
+      empty.textContent = 'No quests available right now. Check back soon!';
+      container.appendChild(empty);
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    combined.forEach(quest => {
+      fragment.appendChild(createQuestCard(quest, quest.__type));
+    });
+    container.appendChild(fragment);
+  }
+
+  function renderHistory() {
+    const container = overlay.querySelector(selectors.history);
+    if (!container) return;
+    container.innerHTML = '';
+    const slugs = getLastPlayed(6);
+    if (!Array.isArray(slugs) || !slugs.length) {
+      const empty = document.createElement('li');
+      empty.className = 'profile-empty';
+      empty.textContent = 'No recent plays yet. Launch a game to build your history.';
+      container.appendChild(empty);
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    slugs.forEach((slug, index) => {
+      const item = document.createElement('li');
+      item.className = 'profile-history-item';
+      item.dataset.slug = slug;
+
+      const title = document.createElement('strong');
+      const label = catalogTitles.get(slug) || slug;
+      title.textContent = `${index + 1}. ${label}`;
+
+      const meta = document.createElement('span');
+      meta.textContent = slug;
+
+      item.appendChild(title);
+      item.appendChild(meta);
+      fragment.appendChild(item);
+    });
+    container.appendChild(fragment);
+
+    if (!catalogPromise) {
+      catalogPromise = loadCatalogTitles().then(map => {
+        catalogTitles = map;
+        updateHistoryTitles();
+      });
+    }
+  }
+
+  function updateHistoryTitles() {
+    if (!overlay) return;
+    const items = overlay.querySelectorAll('[data-profile-history] .profile-history-item');
+    items.forEach((item, index) => {
+      const slug = item.dataset.slug;
+      const titleNode = item.querySelector('strong');
+      if (!slug || !titleNode) return;
+      const label = catalogTitles.get(slug) || slug;
+      titleNode.textContent = `${index + 1}. ${label}`;
+    });
+  }
+
+  async function loadCatalogTitles() {
+    const urls = ['./games.json', './public/games.json'];
+    for (const url of urls) {
+      try {
+        const res = await fetch(url, { cache: 'no-cache' });
+        if (!res?.ok) continue;
+        const data = await res.json();
+        const list = Array.isArray(data) ? data : Array.isArray(data?.games) ? data.games : [];
+        const map = new Map();
+        list.forEach(entry => {
+          const slug = entry?.slug || entry?.id;
+          if (!slug) return;
+          const title = entry?.title || entry?.name || slug;
+          map.set(slug, title);
+        });
+        if (map.size) return map;
+      } catch (error) {
+        console.warn('[profile-overlay] Failed to load catalog titles from', url, error);
+      }
+    }
+    return new Map();
+  }
+
+  function renderAll(detail) {
+    renderSwitchList(detail?.profiles || listProfiles());
+    renderMetrics();
+    renderQuests(detail);
+    renderHistory();
+  }
+
+  function openOverlay(detail) {
+    ensureOverlay();
+    renderAll(detail);
+    overlay.setAttribute('aria-hidden', 'false');
+    trigger.setAttribute('aria-expanded', 'true');
+    document.body.classList.add('profile-overlay-open');
+    lastFocused = document.activeElement;
+    dialog?.focus();
+    window.addEventListener('keydown', onKeyDown);
+  }
+
+  function closeOverlay() {
+    if (!overlay) return;
+    overlay.setAttribute('aria-hidden', 'true');
+    trigger.setAttribute('aria-expanded', 'false');
+    document.body.classList.remove('profile-overlay-open');
+    window.removeEventListener('keydown', onKeyDown);
+    if (lastFocused && typeof lastFocused.focus === 'function') {
+      lastFocused.focus();
+    } else {
+      trigger.focus();
+    }
+  }
+
+  function onOverlayClick(event) {
+    const target = event.target;
+    if (!target) return;
+    if (target.matches('[data-close]')) {
+      closeOverlay();
+      return;
+    }
+    if (target.matches(selectors.add)) {
+      const nameInput = window.prompt('Enter a profile name:');
+      const name = nameInput ? nameInput.trim() : '';
+      if (!name) return;
+      const avatarInput = window.prompt('Avatar image URL (optional):') || '';
+      const avatar = avatarInput.trim();
+      const profile = login(name, avatar);
+      updateTrigger(profile);
+      renderSwitchList();
+      renderMetrics();
+      renderHistory();
+      return;
+    }
+    const switchBtn = target.closest('[data-switch]');
+    if (switchBtn) {
+      const nextName = switchBtn.dataset.switch;
+      if (nextName && nextName !== getProfile().name) {
+        const saved = listProfiles().find(p => p.name === nextName);
+        const profile = login(nextName, saved?.avatar || '');
+        updateTrigger(profile);
+        renderAll();
+      }
+      closeOverlay();
+      return;
+    }
+    const removeBtn = target.closest('[data-remove]');
+    if (removeBtn) {
+      const name = removeBtn.dataset.remove;
+      if (!name) return;
+      const confirmed = window.confirm(`Remove profile "${name}"? This keeps any saved data locally but removes it from the switcher.`);
+      if (!confirmed) return;
+      removeProfile(name);
+      renderAll();
+      return;
+    }
+  }
+
+  function onKeyDown(event) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeOverlay();
+    }
+  }
+
+  trigger.addEventListener('click', () => {
+    ensureOverlay();
+    const isOpen = overlay.getAttribute('aria-hidden') === 'false';
+    if (isOpen) {
+      closeOverlay();
+    } else {
+      openOverlay();
+    }
+  });
+
+  updateTrigger();
+
+  window.addEventListener(PROFILE_EVENT, (event) => {
+    const detail = event?.detail || {};
+    updateTrigger(detail.profile || getProfile());
+    if (overlay && overlay.getAttribute('aria-hidden') === 'false') {
+      renderAll(detail);
+    }
+  });
+
+  window.addEventListener(QUESTS_UPDATED_EVENT, (event) => {
+    if (!overlay || overlay.getAttribute('aria-hidden') === 'true') return;
+    renderQuests(event?.detail);
+    renderMetrics();
+  });
+}

--- a/shared/profile.js
+++ b/shared/profile.js
@@ -1,23 +1,121 @@
 import { getAchievements } from './achievements.js';
 
 const PROFILE_KEY = 'gg:profile';
+const PROFILE_LIST_KEY = 'gg:profiles';
 
-export function getProfile() {
+export const PROFILE_EVENT = 'profile:changed';
+
+function sanitizeProfile(input = {}) {
+  const name = typeof input.name === 'string' ? input.name.trim() : '';
+  const avatar = typeof input.avatar === 'string' ? input.avatar.trim() : '';
+  const safeName = name || 'Guest';
+  return { name: safeName.slice(0, 60), avatar };
+}
+
+function readProfileList() {
   try {
-    return JSON.parse(localStorage.getItem(PROFILE_KEY)) || { name: 'Guest', avatar: '' };
+    const raw = localStorage.getItem(PROFILE_LIST_KEY);
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Map();
+    for (const entry of parsed) {
+      const profile = sanitizeProfile(entry);
+      if (!profile.name) continue;
+      if (profile.name.toLowerCase() === 'guest' && !profile.avatar) continue;
+      seen.set(profile.name, profile);
+    }
+    return Array.from(seen.values());
   } catch {
-    return { name: 'Guest', avatar: '' };
+    return [];
   }
 }
 
+function writeProfileList(list) {
+  const safeList = Array.isArray(list) ? list.map(sanitizeProfile).filter(p => p.name && (p.name.toLowerCase() !== 'guest' || p.avatar)) : [];
+  try {
+    if (!safeList.length) {
+      localStorage.removeItem(PROFILE_LIST_KEY);
+    } else {
+      localStorage.setItem(PROFILE_LIST_KEY, JSON.stringify(safeList));
+    }
+  } catch {}
+}
+
+function dispatchProfileChange(detail = {}) {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') return;
+  let event = null;
+  if (typeof window.CustomEvent === 'function') {
+    event = new window.CustomEvent(PROFILE_EVENT, { detail });
+  } else if (typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+    event = document.createEvent('CustomEvent');
+    event.initCustomEvent(PROFILE_EVENT, false, false, detail);
+  }
+  if (event) window.dispatchEvent(event);
+}
+
+export function getProfile() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(PROFILE_KEY));
+    if (stored && typeof stored === 'object') {
+      return sanitizeProfile(stored);
+    }
+  } catch {}
+  return { name: 'Guest', avatar: '' };
+}
+
 export function login(name, avatar = '') {
-  const profile = { name, avatar };
+  const profile = sanitizeProfile({ name, avatar });
   try {
     localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
-    // also set profile name for achievement storage
-    localStorage.setItem('profile', name);
+    localStorage.setItem('profile', profile.name);
   } catch {}
+
+  const entries = readProfileList().filter(item => item.name !== profile.name);
+  if (profile.name.toLowerCase() !== 'guest' || profile.avatar) {
+    entries.push(profile);
+  }
+  writeProfileList(entries);
+
+  dispatchProfileChange({ profile, profiles: listProfiles() });
   return profile;
+}
+
+export function listProfiles() {
+  const current = sanitizeProfile(getProfile());
+  const entries = readProfileList();
+  const map = new Map();
+  for (const entry of entries) {
+    map.set(entry.name, entry);
+  }
+  map.set(current.name, current);
+  if (!map.has('Guest')) {
+    map.set('Guest', { name: 'Guest', avatar: '' });
+  }
+
+  const items = Array.from(map.values());
+  items.sort((a, b) => {
+    if (a.name === current.name && b.name !== current.name) return -1;
+    if (b.name === current.name && a.name !== current.name) return 1;
+    return a.name.localeCompare(b.name);
+  });
+  return items;
+}
+
+export function removeProfile(name) {
+  const target = typeof name === 'string' ? name.trim() : '';
+  if (!target) return listProfiles();
+
+  const saved = readProfileList().filter(entry => entry.name !== target);
+  writeProfileList(saved);
+
+  const current = getProfile();
+  if (current.name === target) {
+    const fallback = saved[0] || { name: 'Guest', avatar: '' };
+    login(fallback.name, fallback.avatar);
+  } else {
+    dispatchProfileChange({ profile: current, profiles: listProfiles() });
+  }
+  return listProfiles();
 }
 
 export function getAggregatedStats() {
@@ -33,13 +131,28 @@ export function getAggregatedStats() {
 
 export function initProfileUI(container) {
   if (!container) return;
-  const { name, avatar } = getProfile();
-  const { achievements } = getAggregatedStats();
-  container.innerHTML = `
-    <img src="${avatar || 'assets/favicon.png'}" alt="avatar" class="avatar" style="width:24px;height:24px;border-radius:50%;"> 
-    <span class="name">${name}</span>
-    <span class="ach-count">🏆 ${achievements.length}</span>
-  `;
+
+  const render = () => {
+    const { name, avatar } = getProfile();
+    const { achievements } = getAggregatedStats();
+    container.innerHTML = `
+      <img src="${avatar || 'assets/favicon.png'}" alt="avatar" class="avatar" style="width:24px;height:24px;border-radius:50%;">
+      <span class="name">${name}</span>
+      <span class="ach-count">🏆 ${achievements.length}</span>
+    `;
+  };
+
+  render();
+
+  if (typeof window !== 'undefined') {
+    const handler = () => render();
+    window.addEventListener(PROFILE_EVENT, handler);
+    return {
+      destroy() {
+        window.removeEventListener(PROFILE_EVENT, handler);
+      }
+    };
+  }
 }
 
 export function onConnectionChange(cb) {

--- a/styles/profile-overlay.css
+++ b/styles/profile-overlay.css
@@ -1,0 +1,429 @@
+:root {
+  --profile-trigger-bg: rgba(12, 18, 28, 0.45);
+  --profile-trigger-border: rgba(255, 255, 255, 0.18);
+  --profile-trigger-hover: rgba(67, 97, 238, 0.18);
+  --profile-trigger-text: #f3f7ff;
+  --profile-overlay-panel: rgba(12, 18, 28, 0.96);
+  --profile-overlay-border: rgba(255, 255, 255, 0.12);
+  --profile-overlay-muted: rgba(201, 213, 255, 0.75);
+  --profile-overlay-chip: rgba(255, 255, 255, 0.05);
+  --profile-overlay-strong: rgba(255, 255, 255, 0.85);
+}
+
+body.profile-overlay-open {
+  overflow: hidden;
+}
+
+.bolt-nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.bolt-profile-trigger,
+[data-profile-trigger] {
+  appearance: none;
+  border: 1px solid var(--profile-trigger-border);
+  background: var(--profile-trigger-bg);
+  color: var(--profile-trigger-text);
+  border-radius: 999px;
+  padding: 6px 14px 6px 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font: 600 14px/1.2 Poppins, system-ui, -apple-system, "Segoe UI", sans-serif;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.bolt-profile-trigger:hover,
+[data-profile-trigger]:hover {
+  background: var(--profile-trigger-hover);
+  transform: translateY(-1px);
+}
+
+.bolt-profile-trigger:focus-visible,
+[data-profile-trigger]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(67, 97, 238, 0.35);
+}
+
+[data-profile-trigger][aria-expanded="true"] {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+}
+
+[data-profile-avatar] {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  overflow: hidden;
+  color: #0f172a;
+  flex-shrink: 0;
+  position: relative;
+}
+
+[data-profile-avatar].has-image {
+  background: rgba(255, 255, 255, 0.04);
+  color: transparent;
+}
+
+[data-profile-avatar].has-image::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  border-radius: inherit;
+  background-image: inherit;
+}
+
+[data-profile-name] {
+  color: inherit;
+  font-weight: 600;
+}
+
+.profile-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1400;
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-overlay[aria-hidden="false"] {
+  display: flex;
+}
+
+.profile-overlay-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 11, 31, 0.72);
+  backdrop-filter: blur(6px);
+}
+
+.profile-overlay-dialog {
+  position: relative;
+  background: var(--profile-overlay-panel);
+  color: var(--profile-overlay-strong);
+  border: 1px solid var(--profile-overlay-border);
+  border-radius: 18px;
+  padding: 24px;
+  width: min(520px, 92vw);
+  max-height: min(680px, 92vh);
+  overflow: auto;
+  box-shadow: 0 30px 80px rgba(5, 11, 31, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.profile-overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.profile-overlay-header h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.profile-overlay-close {
+  appearance: none;
+  border: 1px solid var(--profile-overlay-border);
+  background: transparent;
+  color: inherit;
+  border-radius: 999px;
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.profile-overlay-close:hover,
+.profile-overlay-close:focus-visible {
+  background: rgba(67, 97, 238, 0.12);
+  outline: none;
+}
+
+.profile-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.profile-section h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--profile-overlay-muted);
+}
+
+.profile-switch-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.profile-add-btn {
+  appearance: none;
+  border: 1px solid var(--profile-overlay-border);
+  background: rgba(67, 97, 238, 0.18);
+  color: inherit;
+  border-radius: 12px;
+  padding: 6px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.profile-add-btn:hover,
+.profile-add-btn:focus-visible {
+  background: rgba(67, 97, 238, 0.28);
+  outline: none;
+}
+
+.profile-switch-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.profile-switch-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--profile-overlay-chip);
+  border: 1px solid var(--profile-overlay-border);
+  border-radius: 14px;
+  padding: 10px 12px;
+}
+
+.profile-switch-item.is-active {
+  border-color: rgba(76, 201, 240, 0.6);
+  box-shadow: 0 0 0 1px rgba(76, 201, 240, 0.4);
+}
+
+.profile-switch-main {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.profile-switch-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  color: #0f172a;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.profile-switch-avatar.has-image {
+  background: rgba(255, 255, 255, 0.04);
+  color: transparent;
+}
+
+.profile-switch-avatar.has-image::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  border-radius: inherit;
+  background-image: inherit;
+}
+
+.profile-switch-text {
+  display: inline-flex;
+  flex-direction: column;
+}
+
+.profile-switch-name {
+  font-weight: 600;
+}
+
+.profile-switch-meta {
+  font-size: 12px;
+  color: var(--profile-overlay-muted);
+}
+
+.profile-remove-btn {
+  appearance: none;
+  border: 1px solid var(--profile-overlay-border);
+  background: transparent;
+  color: inherit;
+  border-radius: 10px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.profile-remove-btn:hover,
+.profile-remove-btn:focus-visible {
+  background: rgba(239, 68, 68, 0.22);
+  border-color: rgba(239, 68, 68, 0.45);
+  outline: none;
+}
+
+.profile-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.profile-metric {
+  background: var(--profile-overlay-chip);
+  border: 1px solid var(--profile-overlay-border);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.profile-metric-label {
+  display: block;
+  font-size: 12px;
+  color: var(--profile-overlay-muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.profile-metric-value {
+  display: block;
+  margin-top: 6px;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.profile-metric-note {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--profile-overlay-muted);
+}
+
+.profile-quests-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.profile-quest-card {
+  background: var(--profile-overlay-chip);
+  border: 1px solid var(--profile-overlay-border);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-quest-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.profile-quest-progress {
+  height: 6px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.profile-quest-progress span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(120deg, #4cc9f0, #4361ee);
+}
+
+.profile-quest-status {
+  font-size: 12px;
+  color: var(--profile-overlay-muted);
+}
+
+.profile-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.profile-history-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--profile-overlay-chip);
+  border: 1px solid var(--profile-overlay-border);
+  border-radius: 12px;
+  padding: 10px 12px;
+}
+
+.profile-history-item strong {
+  font-weight: 600;
+  flex: 1;
+}
+
+.profile-history-item span {
+  font-size: 12px;
+  color: var(--profile-overlay-muted);
+}
+
+.profile-empty {
+  font-size: 14px;
+  color: var(--profile-overlay-muted);
+}
+
+@media (max-width: 640px) {
+  .bolt-profile-trigger,
+  [data-profile-trigger] {
+    padding: 6px 12px 6px 6px;
+  }
+
+  [data-profile-name] {
+    font-size: 13px;
+  }
+
+  .profile-overlay-dialog {
+    width: 92vw;
+    max-height: 90vh;
+    padding: 20px;
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // sw.js — safe service worker with pass-through for games and scripts
-const CACHE_VERSION = 'v3_2';
+const CACHE_VERSION = 'v3_3';
 
 const CORE_SHELL_ASSETS = [
   '/',
@@ -7,7 +7,9 @@ const CORE_SHELL_ASSETS = [
   '/game.html',
   '/play.html',
   '/css/bolt-landing.css?v=20250911175011',
+  '/styles/profile-overlay.css',
   '/js/bolt-landing.js?v=20250911175011',
+  '/js/profile-overlay.js',
   '/js/auto-diag-inject.js',
   '/js/game-loader.js',
   '/js/preflight.js',


### PR DESCRIPTION
## Summary
- add a reusable profile trigger to the landing and game headers with shared styling
- implement a profile overlay module that surfaces switching, metrics, quests, and history information
- expand profile helpers and precache settings to support the new overlay assets

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dedfe48ce88327b578fe4d080740ea