### PR TITLE
Add predictive game prefetching to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ deduplicates requests, and stores successful responses for future sessions. Netw
 cached response (including the main shell), so both navigating the catalog and launching previously saved games work even while
 offline.
 
+The landing page now performs predictive warmup as you explore the grid. Hovering, focusing, touching, or even scrolling a game
+card into view schedules a precache request for that game's entry point and its "first frame" assets (sprites, audio, fonts,
+etc.). These hints flow through `precacheAssets()` so the queue waits for an active service worker before downloading anything,
+reducing unnecessary traffic for cold starts while keeping likely-next games snappy when you click Play.
+
 ## 🚀 Getting Started
 
 ### Prerequisites

--- a/shared/sw.js
+++ b/shared/sw.js
@@ -1,19 +1,103 @@
 import { warn } from '../tools/reporters/console-signature.js';
 
-export function registerSW() {
-  if ('serviceWorker' in navigator) {
-    const swUrl = new URL('../sw.js', import.meta.url);
-    navigator.serviceWorker.register(swUrl.href).catch(err => {
-      warn('shared', 'Service worker registration failed', err);
-    });
+const PRECACHE_QUEUE = new Set();
+let flushTimer = null;
+let controllerListenerAttached = false;
+
+function attachControllerListener() {
+  if (controllerListenerAttached || !('serviceWorker' in navigator)) return;
+  controllerListenerAttached = true;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    scheduleFlush(0);
+  });
+}
+
+function normalizeAssetCandidate(asset) {
+  if (!asset) return null;
+  let url = null;
+  if (typeof asset === 'string') {
+    url = asset;
+  } else if (typeof asset === 'object' && typeof asset.url === 'string') {
+    url = asset.url;
+  }
+  if (!url) return null;
+  try {
+    const normalized = new URL(url, window.location.origin);
+    normalized.hash = '';
+    return normalized.href;
+  } catch (_) {
+    return null;
   }
 }
 
-export function cacheGameAssets(slug, files = ['index.html', 'main.js', 'thumb.png']) {
-  if (!('serviceWorker' in navigator)) return;
-  const base = `/games/${slug}/`;
-  const assets = files.map(f => base + f);
-  if (navigator.serviceWorker.controller) {
-    navigator.serviceWorker.controller.postMessage({ type: 'PRECACHE', assets });
+function scheduleFlush(delay = 0) {
+  if (flushTimer != null) return;
+  flushTimer = window.setTimeout(() => {
+    flushTimer = null;
+    void flushQueue();
+  }, delay);
+}
+
+async function flushQueue() {
+  if (!PRECACHE_QUEUE.size) return;
+  if (!('serviceWorker' in navigator)) {
+    PRECACHE_QUEUE.clear();
+    return;
   }
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const controller = navigator.serviceWorker.controller || registration?.active || registration?.waiting || null;
+    if (!controller) {
+      scheduleFlush(250);
+      return;
+    }
+    const assets = Array.from(PRECACHE_QUEUE);
+    PRECACHE_QUEUE.clear();
+    controller.postMessage({ type: 'PRECACHE', assets });
+  } catch (err) {
+    warn('shared', 'Failed to flush precache queue', err);
+    scheduleFlush(1000);
+  }
+}
+
+export function registerSW() {
+  if (!('serviceWorker' in navigator)) return;
+  const swUrl = new URL('../sw.js', import.meta.url);
+  attachControllerListener();
+  navigator.serviceWorker.register(swUrl.href).then(() => {
+    scheduleFlush(0);
+  }).catch(err => {
+    warn('shared', 'Service worker registration failed', err);
+  });
+}
+
+export function precacheAssets(assets) {
+  if (!('serviceWorker' in navigator)) return;
+  const list = Array.isArray(assets) ? assets : [assets];
+  let added = false;
+  for (const asset of list) {
+    const normalized = normalizeAssetCandidate(asset);
+    if (!normalized) continue;
+    if (!PRECACHE_QUEUE.has(normalized)) {
+      PRECACHE_QUEUE.add(normalized);
+      added = true;
+    }
+  }
+  if (!added) return;
+  attachControllerListener();
+  scheduleFlush(0);
+}
+
+export function cacheGameAssets(slug, files = ['index.html', 'main.js', 'thumb.png']) {
+  if (!slug || !Array.isArray(files) || !files.length) return;
+  const baseUrl = new URL(`/games/${slug}/`, window.location.origin);
+  const assets = files.map(file => {
+    try {
+      return new URL(file, baseUrl).href;
+    } catch (_) {
+      return null;
+    }
+  }).filter(Boolean);
+  if (!assets.length) return;
+  precacheAssets(assets);
 }


### PR DESCRIPTION
## Summary
- switch the landing page to use `loadGameCatalog()` and keep a slug-indexed map with first-frame metadata
- wire service worker registration plus predictive hover/scroll prefetch hooks that call the new precache queue
- extend the shared service worker helpers and README to describe the predictive warmup behaviour

## Testing
- `npm run test:unit` *(fails: existing runner smoke test canvas stub and outdated cache name expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68def2bb466083279fe41b457b6e1d68