### PR TITLE
Handle cached game shell without query parameters

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -130,12 +130,13 @@ self.addEventListener('fetch', (event) => {
       }
       return networkResponse;
     } catch (error) {
-      const cached = await cache.match(req);
+      const cached = await cache.match(req) || await cache.match(url.pathname);
       if (cached) {
         return cached;
       }
       if (req.mode === 'navigate' || req.destination === 'document') {
-        const fallback = await cache.match('/index.html');
+        const fallbackPath = url.pathname.startsWith('/game') ? '/game.html' : '/index.html';
+        const fallback = await cache.match(fallbackPath);
         if (fallback) {
           return fallback;
         }


### PR DESCRIPTION
## Summary
- ensure the service worker checks for cached shells by pathname when queries are present
- select document fallbacks between the game and index shells based on the request path

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68def4f71bc08327a5f295d42b099a79