### PR TITLE
Refine runner physics step handling

### DIFF
--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -494,13 +494,18 @@ class RunnerGame {
     this.lastTime = timestamp;
     const step = clamp(delta, 0, 3);
     if (!this.paused && !this.gameOver) {
-      this.advance(step);
+      let remaining = step;
+      while (remaining > 0) {
+        const slice = Math.min(1, remaining);
+        this.advanceStep(slice);
+        remaining -= slice;
+      }
     }
     this.draw();
     this.rafId = requestAnimationFrame(this.boundLoop);
   }
 
-  advance(step) {
+  advanceStep(step) {
     const travel = this.speed * step;
     this.distance += travel;
     this.spawnTimer -= travel;


### PR DESCRIPTION
## Summary
- update the runner loop to process physics in 60 Hz slices for better collision consistency
- extract the per-step logic into a dedicated `advanceStep` helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deffee75a88327ba6761d640d3a915