### PR TITLE
Fix profile event circular dependency

### DIFF
--- a/js/profile-overlay.js
+++ b/js/profile-overlay.js
@@ -3,10 +3,10 @@ import {
   getAggregatedStats,
   login,
   listProfiles,
-  removeProfile,
-  PROFILE_EVENT
+  removeProfile
 } from '../shared/profile.js';
 import { getAchievements } from '../shared/achievements.js';
+import { PROFILE_EVENT } from '../shared/profile-events.js';
 import { getActiveQuests, getXP, QUESTS_UPDATED_EVENT } from '../shared/quests.js';
 import { getLastPlayed } from '../shared/ui.js';
 import { loadGameCatalog } from '../shared/game-catalog.js';

--- a/shared/achievements.js
+++ b/shared/achievements.js
@@ -1,7 +1,7 @@
 // Shared achievement system
 // Schema: { id, title, desc, icon, condition: (event, stats) => boolean }
 
-import { PROFILE_EVENT } from './profile.js';
+import { PROFILE_EVENT } from './profile-events.js';
 
 function normalizeProfileName(name) {
   if (typeof name !== 'string') return 'default';

--- a/shared/profile-events.js
+++ b/shared/profile-events.js
@@ -1,0 +1,1 @@
+export const PROFILE_EVENT = 'profile:changed';

--- a/shared/profile.js
+++ b/shared/profile.js
@@ -1,4 +1,7 @@
 import { getAchievements } from './achievements.js';
+import { PROFILE_EVENT } from './profile-events.js';
+
+export { PROFILE_EVENT } from './profile-events.js';
 
 const PROFILE_KEY = 'gg:profile';
 const PROFILE_LIST_KEY = 'gg:profiles';
@@ -57,8 +60,6 @@ export function readProfileStats(profileInput = getProfile()) {
     return { xp: 0, plays: 0 };
   }
 }
-
-export const PROFILE_EVENT = 'profile:changed';
 
 function sanitizeProfile(input = {}) {
   const name = typeof input.name === 'string' ? input.name.trim() : '';

--- a/tests/profile-overlay.a11y.test.js
+++ b/tests/profile-overlay.a11y.test.js
@@ -43,10 +43,13 @@ describe('profile overlay focus management', () => {
         getAggregatedStats: vi.fn(() => ({ xp: 0, plays: 0, achievements: [] })),
         login: vi.fn((name, avatar = '') => ({ name, avatar })),
         listProfiles: vi.fn(() => profiles.map(profile => ({ ...profile }))),
-        removeProfile: vi.fn(),
-        PROFILE_EVENT: 'profile:changed'
+        removeProfile: vi.fn()
       };
     });
+
+    vi.mock('../shared/profile-events.js', () => ({
+      PROFILE_EVENT: 'profile:changed'
+    }));
 
     vi.mock('../shared/achievements.js', () => ({
       getAchievements: vi.fn(() => [])


### PR DESCRIPTION
## Summary
- create a shared profile events module that exports the profile change event name
- update profile, achievements, and profile overlay code to reference the shared constant and avoid circular imports
- adjust tests to mock the new module when verifying the profile overlay

## Testing
- npm run test:unit *(fails: known canvas context limitations and cache API expectations in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df0463b0a083278955e587cb59de9b