### PR TITLE
Handle unhandled promise rejections like window errors

### DIFF
--- a/js/runtime-diagnostics.js
+++ b/js/runtime-diagnostics.js
@@ -41,8 +41,15 @@
     const detail = String(e?.message ?? e);
     try { parent && parent.postMessage({ type: 'GAME_ERROR', error: detail, message: detail }, '*'); } catch(_) {}
   });
+  let lastUnhandledRejectionDetail = null;
   window.addEventListener('unhandledrejection', (e)=>{
     push('error', 'unhandledrejection', { reason: (e.reason && (e.reason.message || e.reason.toString())) || 'unknown' });
+    stopHB();
+    const detail = String(e?.reason?.message ?? e?.reason ?? e);
+    if (detail !== lastUnhandledRejectionDetail) {
+      lastUnhandledRejectionDetail = detail;
+      try { parent && parent.postMessage({ type: 'GAME_ERROR', error: detail, message: detail }, '*'); } catch(_) {}
+    }
   });
 
   hbTimer = setInterval(()=>push('info', 'hb#'+Math.round((performance.now()-start)/1000)), 1000);


### PR DESCRIPTION
## Summary
- stop the runtime heartbeat when unhandled promise rejections occur and post the error to the parent frame
- deduplicate repeated rejection posts while keeping local diagnostics logging intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df0470d7508327abf0531683104238