### PR TITLE
refactor: simplify profile event exports

### DIFF
--- a/shared/profile-events.js
+++ b/shared/profile-events.js
@@ -1,1 +1,2 @@
+// Event dispatched whenever profile data changes.
 export const PROFILE_EVENT = 'profile:changed';

--- a/shared/profile.js
+++ b/shared/profile.js
@@ -1,8 +1,6 @@
 import { getAchievements } from './achievements.js';
 import { PROFILE_EVENT } from './profile-events.js';
 
-export { PROFILE_EVENT } from './profile-events.js';
-
 const PROFILE_KEY = 'gg:profile';
 const PROFILE_LIST_KEY = 'gg:profiles';
 const LEGACY_XP_KEY = 'gg:xp';


### PR DESCRIPTION
## Summary
- document the shared profile event constant in its dedicated module
- remove the PROFILE_EVENT re-export from shared/profile.js to keep module boundaries clear

## Testing
- npm run test:unit -- tests/profile-overlay.a11y.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df1a0d096883279a20426eee29698e