### PR TITLE
Load pong.js as an ES module

### DIFF
--- a/games/pong/main.js
+++ b/games/pong/main.js
@@ -115,6 +115,7 @@ function loadRealGameScript() {
       return;
     }
     const script = document.createElement('script');
+    script.type = 'module';
     script.src = new URL('./pong.js', import.meta.url).href;
     script.defer = true;
     script.dataset.pongMain = '1';


### PR DESCRIPTION
## Summary
- ensure the dynamically injected pong game script is loaded as an ES module while preserving readiness handlers

## Testing
- npm run test:unit -- tests/pong.match.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df43b3d88483278efce479efc183f5