### PR TITLE
Update name in Wrangler configuration file to match deployed Worker

### DIFF
--- a/games/platformer/adapter.js
+++ b/games/platformer/adapter.js
@@ -1,5 +1,4 @@
 import { registerGameDiagnostics } from '../common/diagnostics/adapter.js';
-import { pushEvent } from '../common/diag-adapter.js';
 
 const globalScope = typeof window !== 'undefined' ? window : undefined;
 const GAME_SLUG = 'platformer';
@@ -46,40 +45,9 @@ if (globalScope) {
   platformer.onState.push(handleState);
   platformer.onScore.push(handleScore);
 
-  const openDiagnostics = () => {
-    if (globalScope.__GG_DIAG && typeof globalScope.__GG_DIAG.open === 'function') {
-      globalScope.__GG_DIAG.open();
-    } else {
-      pushEvent('diagnostics', {
-        level: 'info',
-        message: `[${GAME_SLUG}] diagnostics UI not ready yet`,
-      });
-    }
-  };
-
-  const wireButton = () => {
-    const btn = globalScope.document?.getElementById('diag-open');
-    if (!btn) return;
-    const existing = btn.dataset.ggDiagWired === 'true';
-    if (existing) return;
-    btn.dataset.ggDiagWired = 'true';
-    btn.setAttribute('aria-haspopup', 'dialog');
-    btn.addEventListener('click', (event) => {
-      event.preventDefault();
-      openDiagnostics();
-    });
-  };
-
-  if (globalScope.document?.readyState === 'loading') {
-    globalScope.document.addEventListener('DOMContentLoaded', wireButton, { once: true });
-  } else {
-    wireButton();
-  }
-
   registerGameDiagnostics(GAME_SLUG, {
     hooks: {
       onReady(context) {
-        wireButton();
         if (platformer.onState.includes(handleState) === false) {
           platformer.onState.push(handleState);
         }

--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -128,8 +128,6 @@
     <div class="btn" id="shareBtn" style="margin-top:8px">Share</div>
   </div></div>
 
-  <button type="button" id="diag-open" class="btn" style="position:fixed;bottom:16px;right:16px;z-index:32">Diagnostics</button>
-
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="platformer"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="platformer"></script>


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement