### PR TITLE
Fix hint hotkey to use existing helper

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -534,7 +534,7 @@ addEventListener('keydown', e=>{
   }
   if(e.key==='h'||e.key==='H') {
     e.preventDefault();
-    showHint();
+    getHint();
     announceToScreenReader('Hint shown on board.');
   }
 });


### PR DESCRIPTION
## Summary
- update the 2048 keyboard handler to call the existing getHint helper instead of the missing showHint function

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df488bdb608327be8ad6a31ac8cfb3