### PR TITLE
Reset announced score tracking on new 2048 games

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -328,6 +328,7 @@ function reset(keepUndo=false, reasonOverride){
   updateCanvas();
   grid=Array.from({length:N},()=>Array(N).fill(0));
   score=0; over=false; won=false; hintDir=null; anim=null;
+  lastAnnouncedScore = 0;
   
   // Clean up animation state
   newTileAnim = null;


### PR DESCRIPTION
## Summary
- reset the screen reader score tracking when starting a new 2048 game so announcements begin fresh each run

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df492b64e08327a67d44c1ca785887