### PR TITLE
Fix shooter shell canvas id

### DIFF
--- a/gameshells/shooter/index.html
+++ b/gameshells/shooter/index.html
@@ -15,7 +15,7 @@
     <style>html,body{height:100%;margin:0;background:#000;overflow:hidden}</style>
   </head>
   <body>
-    <canvas id="game-canvas" width="800" height="600" aria-label="Alien Shooter canvas"></canvas>
+    <canvas id="game" width="800" height="600" aria-label="Alien Shooter canvas"></canvas>
     <div id="hud">
       <div id="score" aria-live="polite">0</div>
       <button id="pause-btn" aria-pressed="false">Pause</button>
@@ -26,7 +26,7 @@
     <script type="module">
       import { ensureCanvas, ensureElement } from "../../js/bootstrap/dom.js";
       window.addEventListener("DOMContentLoaded", () => {
-        ensureCanvas("game-canvas");
+        ensureCanvas("game");
         ensureElement("#score");
       });
     </script>


### PR DESCRIPTION
## Summary
- rename the shooter shell canvas element id to `game` to match runtime expectations
- update the DOM bootstrap helper to ensure the renamed canvas exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4a0a2af88327a7ed2ff33798d85b