### PR TITLE
Tighten game iframe sandbox

### DIFF
--- a/game.html
+++ b/game.html
@@ -311,7 +311,7 @@
 
     <main>
       <section class="game-card" aria-live="polite">
-        <iframe id="game-frame" title="Game frame" sandbox="allow-scripts allow-same-origin allow-pointer-lock"></iframe>
+        <iframe id="game-frame" title="Game frame" sandbox="allow-scripts allow-pointer-lock"></iframe>
         <div class="overlay" id="overlay" aria-hidden="false">
           <div class="status" id="statusPanel" role="status" aria-live="polite" aria-atomic="true">
             <span class="sr-only" id="statusContext">Game status message</span>


### PR DESCRIPTION
## Summary
- remove the allow-same-origin permission from the embedded game iframe to tighten the sandbox

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df49ecfb54832787541609b3c6d0e0