### PR TITLE
Fix Snake shell helpers and diagnostics

### DIFF
--- a/common/diag-capture.js
+++ b/common/diag-capture.js
@@ -1,0 +1,17 @@
+(function(){
+  try {
+    const doc = document;
+    if (!doc) return;
+    const current = doc.currentScript;
+    const script = doc.createElement('script');
+    script.defer = true;
+    script.src = '/games/common/diag-capture.js';
+    if (current && current.parentNode) {
+      current.parentNode.insertBefore(script, current.nextSibling);
+    } else {
+      (doc.head || doc.documentElement || doc.body || doc).appendChild(script);
+    }
+  } catch (err) {
+    console.warn('[diag-capture proxy] failed to load /games/common/diag-capture.js', err);
+  }
+})();

--- a/common/diag-core.js
+++ b/common/diag-core.js
@@ -1,0 +1,17 @@
+(function(){
+  try {
+    const doc = document;
+    if (!doc) return;
+    const current = doc.currentScript;
+    const script = doc.createElement('script');
+    script.defer = true;
+    script.src = '/games/common/diag-core.js';
+    if (current && current.parentNode) {
+      current.parentNode.insertBefore(script, current.nextSibling);
+    } else {
+      (doc.head || doc.documentElement || doc.body || doc).appendChild(script);
+    }
+  } catch (err) {
+    console.warn('[diag-core proxy] failed to load /games/common/diag-core.js', err);
+  }
+})();

--- a/common/diagnostics/report-store.js
+++ b/common/diagnostics/report-store.js
@@ -1,0 +1,17 @@
+(function(){
+  try {
+    const doc = document;
+    if (!doc) return;
+    const current = doc.currentScript;
+    const script = doc.createElement('script');
+    script.defer = true;
+    script.src = '/games/common/diagnostics/report-store.js';
+    if (current && current.parentNode) {
+      current.parentNode.insertBefore(script, current.nextSibling);
+    } else {
+      (doc.head || doc.documentElement || doc.body || doc).appendChild(script);
+    }
+  } catch (err) {
+    console.warn('[diag-report proxy] failed to load /games/common/diagnostics/report-store.js', err);
+  }
+})();

--- a/gameshells/snake/index.html
+++ b/gameshells/snake/index.html
@@ -12,9 +12,10 @@
       }
     }
     </script>
+    <script id="gg-diag-autowire" data-shell-diag></script>
     <style>html,body{height:100%;margin:0;background:#000;overflow:hidden}</style>
   </head>
-  <body>
+  <body data-shell-diag>
     <canvas id="game-canvas" width="800" height="600" aria-label="Snake canvas"></canvas>
     <div id="hud">
       <div id="score" aria-live="polite">0</div>
@@ -30,6 +31,7 @@
         ensureElement("#score");
       });
     </script>
+    <script src="../../js/gameUtil.js"></script>
     <script type="module" src="../../games/snake/snake.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->


### PR DESCRIPTION
## Summary
- ensure the modern Snake shell loads `gameUtil.js` before the game module and marks itself as diagnostics-aware
- add `/common/*` proxy scripts that forward to the existing `/games/common/*` assets so the auto diagnostics loader no longer 404s

## Testing
- `npm run test:smoke` *(fails: known runner canvas ctx.translate issue)*
- Manual Playwright smoke of `game?slug=snake` (helpers loaded, GG counters increment)


------
https://chatgpt.com/codex/tasks/task_e_68df49e2de708327b23f5791603eb143