### PR TITLE
Fix diagnostics loader paths

### DIFF
--- a/games/common/diag-autowire.js
+++ b/games/common/diag-autowire.js
@@ -138,12 +138,22 @@
     return '';
   };
 
-  const baseUrl = resolveBase();
-
-  const buildUrl = (path) => {
-    if (!path || !baseUrl) return null;
+  const buildRootUrl = (path) => {
+    if (!path) return null;
+    const getBase = () => {
+      try {
+        if (win && win.location && win.location.href) return win.location.href;
+      } catch (_err) {}
+      try {
+        if (doc && doc.baseURI) return doc.baseURI;
+      } catch (_err) {}
+      const base = resolveBase();
+      return base || null;
+    };
+    const base = getBase();
+    if (!base) return null;
     try {
-      return new URL(path, baseUrl).toString();
+      return new URL(path, base).toString();
     } catch (_err) {}
     return null;
   };
@@ -155,8 +165,8 @@
 
     win.__GG_DIAG_OPTS = { suppressButton: true };
 
-    ensureScript(buildUrl('diagnostics/report-store.js'), 'data-gg-diag-report');
-    ensureScript(buildUrl('diag-core.js'), 'data-gg-diag-core');
-    ensureScript(buildUrl('diag-capture.js'), 'data-gg-diag-capture');
+    ensureScript(buildRootUrl('/games/common/diagnostics/report-store.js'), 'data-gg-diag-report');
+    ensureScript(buildRootUrl('/games/common/diag-core.js'), 'data-gg-diag-core');
+    ensureScript(buildRootUrl('/games/common/diag-capture.js'), 'data-gg-diag-capture');
   });
 })();


### PR DESCRIPTION
## Summary
- update the diagnostics autowire loader to resolve assets from the site root
- ensure diag-core, diag-capture, and report-store scripts are injected with absolute /games/common URLs so modern shells load diagnostics correctly

## Testing
- Manual: `npx serve -l 4173` then load http://127.0.0.1:4173/game?slug=asteroids and confirm diagnostics assets load successfully

------
https://chatgpt.com/codex/tasks/task_e_68df4bc71bd48327bb8899b50eeefcc3