### PR TITLE
Harden game iframe sandbox

### DIFF
--- a/game.html
+++ b/game.html
@@ -311,7 +311,7 @@
 
     <main>
       <section class="game-card" aria-live="polite">
-        <iframe id="game-frame" title="Game frame" sandbox="allow-scripts allow-same-origin allow-pointer-lock"></iframe>
+        <iframe id="game-frame" title="Game frame" sandbox="allow-scripts allow-pointer-lock"></iframe>
         <div class="overlay" id="overlay" aria-hidden="false">
           <div class="status" id="statusPanel" role="status" aria-live="polite" aria-atomic="true">
             <span class="sr-only" id="statusContext">Game status message</span>

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,9 @@
   for = "/*.js"
   [headers.values]
     Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Headers = "*"


### PR DESCRIPTION
## Summary
- remove the allow-same-origin permission from the embedded game iframe to reduce escape surface
- add permissive CORS headers for static assets so sandboxed module scripts continue to load

## Testing
- node - <<'NODE' … (Playwright smoke run for pong, asteroids, maze3d)

------
https://chatgpt.com/codex/tasks/task_e_68df4a0588588327bc7eca4a18edc6e9