### PR TITLE
Update snake play URL to point to index.html

### DIFF
--- a/games.json
+++ b/games.json
@@ -32,7 +32,7 @@
     ],
     "difficulty": "easy",
     "released": "2025-08-25",
-    "playUrl": "/games/snake/",
+    "playUrl": "/games/snake/index.html",
     "firstFrame": {
       "sprites": [
         "/assets/sprites/coin.png"


### PR DESCRIPTION
## Summary
- update the snake entry in `games.json` so the playUrl points directly to the HTML entry point
- verified the catalog health check so tools ingesting `games.json` see the playable file

## Testing
- npm run health

------
https://chatgpt.com/codex/tasks/task_e_68df75e2b670832787e58d311db2e8f1