### PR TITLE
Handle BroadcastChannel fallback for platformer co-op

### DIFF
--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -822,6 +822,16 @@ export function boot() {
   function initNet() {
     if (!startCoopBtn || !connStatus) return;
 
+    if (!net.isAvailable()) {
+      startCoopBtn.textContent = 'Co-op unavailable';
+      startCoopBtn.style.pointerEvents = 'none';
+      startCoopBtn.style.opacity = '0.7';
+      startCoopBtn.setAttribute('aria-disabled', 'true');
+      startCoopBtn.title = 'Co-op mode requires BroadcastChannel support';
+      connStatus.textContent = 'Unavailable';
+      return;
+    }
+
     startCoopBtn.addEventListener('click', () => {
       if (net.isConnected()) return;
       startCoopBtn.textContent = 'Pairing…';

--- a/games/platformer/net.js
+++ b/games/platformer/net.js
@@ -1,14 +1,95 @@
-const channel = new BroadcastChannel('platformer-coop');
+import { pushEvent } from '../common/diag-adapter.js';
+
+const globalScope = typeof window !== 'undefined' ? window : undefined;
+const CHANNEL_NAME = 'platformer-coop';
+
+function createStubChannel() {
+  let onMessageHandler = null;
+  return {
+    postMessage() {},
+    close() {},
+    addEventListener() {},
+    removeEventListener() {},
+    get onmessage() {
+      return onMessageHandler;
+    },
+    set onmessage(handler) {
+      onMessageHandler = typeof handler === 'function' ? handler : null;
+    },
+  };
+}
+
+let warningEmitted = false;
+function warnCoopDisabled(reason) {
+  if (warningEmitted) return;
+  warningEmitted = true;
+  const detailMessage = reason instanceof Error
+    ? reason.message || reason.name || 'BroadcastChannel unavailable'
+    : (typeof reason === 'string' && reason) || 'BroadcastChannel unavailable';
+  const message = `[platformer] co-op disabled: ${detailMessage}`;
+
+  try {
+    if (globalScope?.console?.warn) {
+      if (reason instanceof Error) {
+        globalScope.console.warn(message, reason);
+      } else {
+        globalScope.console.warn(message);
+      }
+    }
+  } catch (_err) {
+    // Ignore console errors – diagnostics capture will still record the issue.
+  }
+
+  const payload = { level: 'warn', message };
+  if (reason instanceof Error) {
+    payload.detail = {
+      name: reason.name || 'Error',
+      message: reason.message || String(reason),
+    };
+  } else if (reason) {
+    payload.detail = { reason: typeof reason === 'string' ? reason : String(reason) };
+  }
+  pushEvent('network', payload);
+}
+
+const BroadcastChannelCtor = globalScope && typeof globalScope.BroadcastChannel === 'function'
+  ? globalScope.BroadcastChannel
+  : undefined;
+
+let realChannel = null;
+let fallbackReason = null;
+
+if (BroadcastChannelCtor) {
+  try {
+    realChannel = new BroadcastChannelCtor(CHANNEL_NAME);
+  } catch (err) {
+    fallbackReason = err instanceof Error ? err : new Error(String(err));
+  }
+} else if (globalScope) {
+  fallbackReason = 'BroadcastChannel unsupported';
+} else {
+  fallbackReason = 'Window scope unavailable';
+}
+
+const channel = realChannel || createStubChannel();
+const coopAvailable = !!realChannel;
+
+if (!coopAvailable) {
+  warnCoopDisabled(fallbackReason);
+}
+
 const myId = Math.random().toString(36).slice(2);
 let peerId = null;
 let connected = false;
 const handlers = {};
 
 export function connect(){
+  if (!coopAvailable) return;
   channel.postMessage({ type: 'hello', id: myId });
 }
 
 channel.onmessage = e => {
+  if (!coopAvailable) return;
   const msg = e.data;
   if (msg?.id === myId) return;
 
@@ -29,16 +110,20 @@ export function on(type, fn){
 }
 
 export function sendState(data){
-  if (connected) channel.postMessage({ type: 'state', data });
+  if (!coopAvailable || !connected) return;
+  channel.postMessage({ type: 'state', data });
 }
 export function sendCollect(data){
-  if (connected) channel.postMessage({ type: 'collect', data });
+  if (!coopAvailable || !connected) return;
+  channel.postMessage({ type: 'collect', data });
 }
 export function sendEnemy(data){
-  if (connected) channel.postMessage({ type: 'enemy', data });
+  if (!coopAvailable || !connected) return;
+  channel.postMessage({ type: 'enemy', data });
 }
 export function sendAssist(){
-  if (connected) channel.postMessage({ type: 'assist' });
+  if (!coopAvailable || !connected) return;
+  channel.postMessage({ type: 'assist' });
 }
 
 export function isConnected(){
@@ -48,4 +133,8 @@ export function isConnected(){
 export function amHost(){
   if (!connected) return true;
   return myId < peerId;
+}
+
+export function isAvailable(){
+  return coopAvailable;
 }


### PR DESCRIPTION
## Summary
- detect BroadcastChannel availability for the platformer co-op channel and emit a diagnostics warning when unavailable
- fall back to a stub implementation so networking exports no-op safely and expose an availability helper
- disable the co-op UI controls and show an unavailable status when BroadcastChannel support is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df7cb73bec832782cbaecc612270cf