### PR TITLE
Preserve host diagnostics options in autowire script

### DIFF
--- a/games/common/diag-autowire.js
+++ b/games/common/diag-autowire.js
@@ -163,7 +163,12 @@
 
     removeLegacyElements();
 
-    win.__GG_DIAG_OPTS = { suppressButton: true };
+    const existingOpts = (() => {
+      const opts = win.__GG_DIAG_OPTS;
+      if (!opts || typeof opts !== 'object') return {};
+      return opts;
+    })();
+    win.__GG_DIAG_OPTS = Object.assign({ suppressButton: true }, existingOpts);
 
     ensureScript(buildRootUrl('/games/common/diagnostics/report-store.js'), 'data-gg-diag-report');
     ensureScript(buildRootUrl('/games/common/diag-core.js'), 'data-gg-diag-core');


### PR DESCRIPTION
## Summary
- ensure the diagnostics autowire script merges into existing window.__GG_DIAG_OPTS
- keep host-provided configuration keys while still defaulting suppressButton to true

## Testing
- node <<'NODE'
const fs = require('fs');
const path = require('path');
const vm = require('vm');

function runAutowireWith(initialOpts) {
  const sandbox = {};
  const window = sandbox.window = {};
  const document = {
    readyState: 'complete',
    addEventListener: () => {},
    removeEventListener: () => {},
    querySelector: () => null,
    querySelectorAll: () => [],
    getElementById: () => null,
    getElementsByTagName: () => [],
    createElement: () => ({
      setAttribute: () => {},
      parentNode: null,
    }),
    head: { appendChild: () => {} },
    documentElement: null,
    body: null,
    baseURI: 'https://example.com/base',
  };
  window.document = document;
  window.__GG_DIAG_OPTS = initialOpts;
  window.location = { href: 'https://example.com/page' };
  document.currentScript = { src: 'https://example.com/games/common/diag-autowire.js' };

  const context = vm.createContext({ window, document, URL, console, setTimeout, clearTimeout });
  const scriptContent = fs.readFileSync(path.join(__dirname, 'games/common/diag-autowire.js'), 'utf8');
  vm.runInContext(scriptContent, context);
  return context.window.__GG_DIAG_OPTS;
}

console.log('No initial opts:', runAutowireWith(undefined));
console.log('With extra flag:', runAutowireWith({ extra: 'value' }));
console.log('Host opt-out:', runAutowireWith({ suppressButton: false, extra: 123 }));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e4471923d08327a9f53dc02f6dd2a8