### PR TITLE
Add PR comment reporting for Game Doctor workflow

### DIFF
--- a/.github/workflows/game-doctor.yml
+++ b/.github/workflows/game-doctor.yml
@@ -37,3 +37,98 @@ jobs:
           path: |
             health/report.json
             health/report.md
+
+      - name: Comment Game Doctor results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = 'health/report.json';
+            const marker = '<!-- game-doctor-report -->';
+
+            const formatTableRow = (cells) => `| ${cells.join(' | ')} |`;
+            const formatStatus = (ok) => ok ? '✅ Pass' : '❌ Fail';
+
+            let bodySections = [];
+            let summaryText = '⚠️ Game Doctor report was not generated.';
+            let table = '';
+
+            if (fs.existsSync(path)) {
+              try {
+                const report = JSON.parse(fs.readFileSync(path, 'utf8'));
+                const total = report?.summary?.total ?? report?.games?.length ?? 0;
+                const passing = report?.summary?.passing ?? report?.games?.filter(game => game.ok).length ?? 0;
+                const failing = report?.summary?.failing ?? total - passing;
+                summaryText = `**Summary:** ${passing}/${total} passing, ${failing} failing.`;
+
+                if (Array.isArray(report?.games) && report.games.length) {
+                  const header = formatTableRow(['Game', 'Status', 'Issues']);
+                  const separator = formatTableRow(['---', '---', '---']);
+                  const rows = report.games.map(game => {
+                    const title = game.title || game.slug || `#${game.index}`;
+                    const status = formatStatus(Boolean(game.ok));
+                    const issues = Array.isArray(game.issues) ? game.issues.length : 0;
+                    return formatTableRow([title, status, `${issues}`]);
+                  });
+                  table = [header, separator, ...rows].join('\n');
+                } else {
+                  table = '_No game entries were found in the report._';
+                }
+              } catch (error) {
+                summaryText = `⚠️ Failed to parse ${path}: ${error.message}`;
+              }
+            }
+
+            const { owner, repo } = context.repo;
+            const { data: artifactData } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: context.runId,
+            });
+
+            const artifact = artifactData.artifacts.find((artifact) => artifact.name === 'game-doctor-report');
+            let artifactSection = '_Artifact not available._';
+            if (artifact) {
+              const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}/artifacts/${artifact.id}`;
+              artifactSection = `📎 [Download Game Doctor artifact](${artifactUrl})`;
+            }
+
+            bodySections.push(summaryText);
+            if (table) bodySections.push(table);
+            bodySections.push(artifactSection);
+
+            const commentBody = [
+              marker,
+              '### 🩺 Game Doctor Report',
+              '',
+              ...bodySections,
+              '',
+              marker,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body: commentBody,
+              });
+            }

--- a/docs/game-doctor.md
+++ b/docs/game-doctor.md
@@ -10,6 +10,10 @@ npm run doctor
 
 The command generates `health/report.json` and `health/report.md` summaries. Use `--strict` (enabled in the npm script) to fail the run when new issues are introduced.
 
+## CI reporting
+
+Pull requests automatically surface Game Doctor results in a dedicated comment on the thread. The workflow parses `health/report.json` and renders a status table for every game, updating the same comment on reruns to avoid notification spam. A download link to the `game-doctor-report` workflow artifact (containing the JSON and Markdown outputs) is also included for deeper inspection.
+
 ## Schema validation
 
 Before any other check runs, Game Doctor validates `games.json` against [`tools/schemas/games.schema.json`](../tools/schemas/games.schema.json).


### PR DESCRIPTION
## Summary
- add a GitHub Script step to the Game Doctor workflow that posts an upserted report comment on pull requests
- render pass/fail status rows from health/report.json and surface the artifact download link
- document the new pull request comment behavior for contributors in docs/game-doctor.md

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e547ec98688327a1cb076e69176b70