### PR TITLE
Add workflow to block placeholder PR titles

### DIFF
--- a/.github/workflows/pr-title-guard.yml
+++ b/.github/workflows/pr-title-guard.yml
@@ -1,0 +1,26 @@
+name: PR Title Guard
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  ensure-descriptive-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate pull request title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title.trim();
+            const bannedTitles = [
+              'Update name in Wrangler configuration file to match deployed Worker',
+            ];
+            if (bannedTitles.includes(title)) {
+              core.setFailed(
+                `Replace the placeholder PR title "${title}" with a concise summary of your changes.`
+              );
+            }
+            if (title.length < 10) {
+              core.setFailed('Provide a descriptive pull request title (at least 10 characters).');
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for considering a contribution.
 1. Fork the repository and create your branch.
 2. Run `npm test` to ensure the test suite passes.
 3. Submit a pull request using the template.
+   - Use a descriptive pull request title that summarizes your change. Avoid placeholder titles such as "Update name in Wrangler configuration file to match deployed Worker."
 
 By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
## Summary
- add a PR Title Guard workflow that fails on placeholder or too-short titles
- document the requirement for descriptive pull request titles in CONTRIBUTING.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e556908200832792a3192764259415