### PR TITLE
Wire Game Doctor into targeted and full CI workflows

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,0 +1,16 @@
+name: Full CI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  game-doctor:
+    uses: ./.github/workflows/game-doctor.yml
+    with:
+      mode: full
+    secrets: inherit

--- a/.github/workflows/ci-targeted.yml
+++ b/.github/workflows/ci-targeted.yml
@@ -1,0 +1,15 @@
+name: Targeted CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  game-doctor:
+    uses: ./.github/workflows/game-doctor.yml
+    with:
+      mode: targeted
+    secrets: inherit

--- a/.github/workflows/game-doctor.yml
+++ b/.github/workflows/game-doctor.yml
@@ -1,8 +1,13 @@
 name: Game Doctor
 
 on:
-  push:
-  pull_request:
+  workflow_call:
+    inputs:
+      mode:
+        description: 'CI surface invoking the doctor (targeted or full).'
+        required: false
+        type: string
+        default: 'targeted'
 
 jobs:
   check:
@@ -11,10 +16,15 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      GAME_DOCTOR_CI_MODE: ${{ inputs.mode }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Announce CI mode
+        run: echo "Running Game Doctor in ${{ inputs.mode }} mode"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,12 @@ npm test             # runs the test suite
 
 ## Game Doctor continuous integration check
 
-Every push and pull request triggers the **Game Doctor** GitHub Action, which runs `node tools/game-doctor.mjs --strict --baseline=health/baseline.json` and fails the
-check when any game needs attention. If you need to re-run the check, open your pull request, switch to the **Checks** tab,
-select **Game Doctor**, and click **Re-run**. The workflow uploads `health/report.json` and `health/report.md` as artifacts;
-download them from the same check summary to review the full report.
+Pull requests go through the **Targeted CI** workflow (`.github/workflows/ci-targeted.yml`), which calls the reusable Game Doctor
+job (`.github/workflows/game-doctor.yml`) with `node tools/game-doctor.mjs --strict --baseline=health/baseline.json`. Pushes to the
+`main` branch run the same job through **Full CI** (`.github/workflows/ci-full.yml`). Both surfaces fail when any game needs
+attention. To re-run the targeted check, open your pull request, switch to the **Checks** tab, select **Targeted CI**, and choose
+**Re-run**. The workflow uploads `health/report.json` and `health/report.md` as artifacts; download them from the check summary to
+review the full report.
 
 When the catalog is stable and you want to acknowledge the current results as the new baseline, run `npm run doctor` locally,
 review the generated `health/report.json`, then copy it to `health/baseline.json` and commit both files. This keeps the strict

--- a/docs/game-doctor.md
+++ b/docs/game-doctor.md
@@ -12,7 +12,7 @@ The command generates `health/report.json` and `health/report.md` summaries. Use
 
 ## CI reporting
 
-Pull requests automatically surface Game Doctor results in a dedicated comment on the thread. The workflow parses `health/report.json` and renders a status table for every game, updating the same comment on reruns to avoid notification spam. A download link to the `game-doctor-report` workflow artifact (containing the JSON and Markdown outputs) is also included for deeper inspection.
+Targeted CI (`.github/workflows/ci-targeted.yml`) runs on every pull request and automatically surfaces Game Doctor results in a dedicated comment on the thread. Full CI (`.github/workflows/ci-full.yml`) reuses the same job on pushes to `main` to guard the catalog after merges. The workflow parses `health/report.json` and renders a status table for every game, updating the same comment on reruns to avoid notification spam. A download link to the `game-doctor-report` workflow artifact (containing the JSON and Markdown outputs) is also included for deeper inspection.
 
 ## Schema validation
 


### PR DESCRIPTION
## Summary
- refactor the Game Doctor workflow into a reusable job callable from other pipelines
- add dedicated Targeted CI (pull requests) and Full CI (main pushes) workflows that invoke the shared Game Doctor run
- document the new CI surfaces in the contributing guide and doctor docs

## Testing
- not run (CI configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e55bd2b4248327be5b66c05311dd73