### PR TITLE
Ensure Game Doctor comments run for targeted mode

### DIFF
--- a/.github/workflows/game-doctor.yml
+++ b/.github/workflows/game-doctor.yml
@@ -42,7 +42,7 @@ jobs:
         run: node tools/game-doctor.mjs --strict --baseline=health/baseline.json
 
       - name: Comment Game Doctor results
-        if: github.event_name == 'pull_request'
+        if: inputs.mode == 'targeted'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node tools/comment-game-doctor.mjs
@@ -58,7 +58,7 @@ jobs:
             health/report.md
 
       - name: Comment Game Doctor results
-        if: github.event_name == 'pull_request'
+        if: inputs.mode == 'targeted'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- run Game Doctor commenting steps when invoked in targeted (pull request) mode rather than only when github.event_name is pull_request

## Testing
- not run (CI configuration only)

------
https://chatgpt.com/codex/tasks/task_e_68e55e04e8f083278b9b012cb22066c0