### PR TITLE
Rename Code Doctor labels

### DIFF
--- a/tools/code-doctor.mjs
+++ b/tools/code-doctor.mjs
@@ -885,7 +885,7 @@ async function checkUnusedCode(files, result) {
 
 function buildMarkdownReport(generatedAt, overallStatus, exitCode, results, fatalError) {
   const lines = [];
-  lines.push('# Code Doctor Report');
+  lines.push('# Code Doctor');
   lines.push('');
   lines.push(`Generated: ${generatedAt}`);
   lines.push('');
@@ -905,7 +905,7 @@ function buildMarkdownReport(generatedAt, overallStatus, exitCode, results, fata
   if (fatalError) {
     lines.push('## Errors');
     lines.push('');
-    lines.push('The Code Doctor encountered a fatal error:');
+    lines.push('Code Doctor encountered a fatal error:');
     lines.push('');
     lines.push(formatMarkdownBlock(fatalError));
     lines.push('');


### PR DESCRIPTION
## Summary
- update the Code Doctor markdown report heading to remove the trailing "Report"
- adjust the fatal error message to use the new Code Doctor name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e593afd64083279f0c645694473b1a