### PR TITLE
Refactor asteroids gameplay into ECS architecture

### DIFF
--- a/games/asteroids/waves.json
+++ b/games/asteroids/waves.json
@@ -1,0 +1,19 @@
+{
+  "waves": [
+    { "rocks": [ { "size": 3, "count": 2 } ] },
+    { "rocks": [ { "size": 3, "count": 3 } ] },
+    { "rocks": [ { "size": 3, "count": 3 }, { "size": 2, "count": 1 } ] },
+    { "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 1 } ] },
+    { "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 2 } ] },
+    { "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 2 }, { "size": 1, "count": 1 } ] },
+    { "rocks": [ { "size": 3, "count": 5 }, { "size": 2, "count": 2 }, { "size": 1, "count": 1 } ] },
+    { "rocks": [ { "size": 3, "count": 5 }, { "size": 2, "count": 3 }, { "size": 1, "count": 1 } ] },
+    { "rocks": [ { "size": 3, "count": 6 }, { "size": 2, "count": 3 }, { "size": 1, "count": 2 } ] },
+    { "rocks": [ { "size": 3, "count": 6 }, { "size": 2, "count": 4 }, { "size": 1, "count": 2 } ] }
+  ],
+  "splits": {
+    "3": [2, 2],
+    "2": [1, 1],
+    "1": []
+  }
+}


### PR DESCRIPTION
## Summary
- replace the monolithic asteroid update logic with a lightweight ECS that manages ship, rock, bullet, and particle components and keeps motion toroidal
- rebuild the AsteroidsGame loop around component systems for physics, collisions, rendering, and wave handling with pooled bullets and particles
- add a waves.json difficulty table that drives wave composition and asteroid split rules

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5e2fc29a08327b1e796d3791953c0