### PR TITLE
Fix diagnostics adapter initialization timing

### DIFF
--- a/games/common/diag-core.js
+++ b/games/common/diag-core.js
@@ -28,6 +28,12 @@
     { id: "env", label: "Env" },
   ];
 
+  const ADAPTER_READY_TIMEOUT_MS = 5000;
+  const ADAPTER_READY_POLL_INTERVAL_MS = 50;
+  const adapterReadyWaiters = [];
+  let adapterReadyTimer = null;
+  let adapterReadyDeadline = 0;
+
   const state = {
     store: reportStore,
     maxLogs: reportStore?.config?.maxConsole || 500,
@@ -295,12 +301,6 @@
       return "";
     }
   }
-
-  const ADAPTER_READY_TIMEOUT_MS = 5000;
-  const ADAPTER_READY_POLL_INTERVAL_MS = 50;
-  const adapterReadyWaiters = [];
-  let adapterReadyTimer = null;
-  let adapterReadyDeadline = 0;
 
   function ensureDiagnosticsAdapterModule(){
     const resolved = resolveDiagnosticsAdapterModule();


### PR DESCRIPTION
## Summary
- declare diagnostics adapter readiness state before it is used during module initialization
- prevent runtime ReferenceError triggered by early diagnostics bootstrap calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ec5dfc108327aada335fd9bdded7