### PR TITLE
Fix syntax errors in shooter and diagnostics modules

### DIFF
--- a/games/common/diag-core.js
+++ b/games/common/diag-core.js
@@ -11,8 +11,6 @@
   const existingQueue = Array.isArray(global.__GG_DIAG_QUEUE) ? global.__GG_DIAG_QUEUE.splice(0) : [];
   global.__GG_DIAG_OPTS = Object.assign({}, { suppressButton: false }, global.__GG_DIAG_OPTS || {});
 
-  const ADAPTER_READY_TIMEOUT_MS = 5000;
-  const ADAPTER_READY_POLL_INTERVAL_MS = 50;
   const adapterReadyWaiters = [];
   let adapterReadyTimer = null;
   let adapterReadyDeadline = 0;
@@ -152,10 +150,6 @@
 
   const ADAPTER_READY_TIMEOUT_MS = 5000;
   const ADAPTER_READY_POLL_INTERVAL_MS = 50;
-  const adapterReadyWaiters = [];
-  let adapterReadyTimer = null;
-  let adapterReadyDeadline = 0;
-
   const state = {
     store: reportStore,
     maxLogs: reportStore?.config?.maxConsole || 500,

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1105,7 +1105,11 @@ export function boot() {
         spawnEnemy(wave.boss.type || 'overseer', { x: W - 120, y: H / 2 });
         wave.boss.spawned = true;
       }
-      if (!wave.boss && wave.spawns.every(spawn => spawn.spawned >= Math.max(1, Math.floor(spawn.config.count || 1))))) {
+      const allSpawnsCompleted = wave.spawns.every(spawn => {
+        const requiredCount = Math.max(1, Math.floor(spawn.config.count || 1));
+        return spawn.spawned >= requiredCount;
+      });
+      if (!wave.boss && allSpawnsCompleted) {
         if (!enemies.some(enemy => !enemy.dead)) {
           finished = true;
         } else {


### PR DESCRIPTION
## Summary
- replace the nested wave completion condition in Alien Shooter with a helper to avoid mismatched parentheses
- deduplicate diagnostics adapter constants so they are declared only once

## Testing
- node --check games/shooter/main.js
- node --check games/common/diag-core.js

------
https://chatgpt.com/codex/tasks/task_e_68e5ee4cca088327ae1ddd010cb95a1d