### PR TITLE
Fix runner game over menu handler context

### DIFF
--- a/games/runner/main.js
+++ b/games/runner/main.js
@@ -835,7 +835,7 @@ class RunnerGame {
           async menu(currentCtx) {
             try {
               await currentCtx.manager.pop({ resume: false });
-              await currentCtx.manager.replace(() => this.createTitleScene());
+              await currentCtx.manager.replace(() => game.createTitleScene());
             } catch (err) {
               console.error('[runner] return to menu failed', err);
             }


### PR DESCRIPTION
## Summary
- ensure the Runner game over menu handler uses the captured game instance when returning to the title scene

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5eeda53288327844739437d71a514