### PR TITLE
Add advanced encounters and difficulty tuning to Asteroids

### DIFF
--- a/games/asteroids/waves.json
+++ b/games/asteroids/waves.json
@@ -1,15 +1,17 @@
 {
   "waves": [
-    { "rocks": [ { "size": 3, "count": 2 } ] },
-    { "rocks": [ { "size": 3, "count": 3 } ] },
-    { "rocks": [ { "size": 3, "count": 3 }, { "size": 2, "count": 1 } ] },
-    { "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 1 } ] },
-    { "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 2 } ] },
-    { "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 2 }, { "size": 1, "count": 1 } ] },
-    { "rocks": [ { "size": 3, "count": 5 }, { "size": 2, "count": 2 }, { "size": 1, "count": 1 } ] },
-    { "rocks": [ { "size": 3, "count": 5 }, { "size": 2, "count": 3 }, { "size": 1, "count": 1 } ] },
-    { "rocks": [ { "size": 3, "count": 6 }, { "size": 2, "count": 3 }, { "size": 1, "count": 2 } ] },
-    { "rocks": [ { "size": 3, "count": 6 }, { "size": 2, "count": 4 }, { "size": 1, "count": 2 } ] }
+    { "type": "asteroids", "rocks": [ { "size": 3, "count": 2 } ] },
+    { "type": "asteroids", "rocks": [ { "size": 3, "count": 3 } ] },
+    { "type": "asteroids", "rocks": [ { "size": 3, "count": 3 }, { "size": 2, "count": 1 } ] },
+    { "type": "objective", "label": "Disable the Beacons", "targets": 3, "targetHealth": 2, "rocks": [ { "size": 3, "count": 3 }, { "size": 2, "count": 1 } ] },
+    { "type": "asteroids", "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 2 } ] },
+    { "type": "asteroids", "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 2 }, { "size": 1, "count": 1 } ] },
+    { "type": "asteroids", "rocks": [ { "size": 3, "count": 5 }, { "size": 2, "count": 2 }, { "size": 1, "count": 1 } ] },
+    { "type": "boss", "label": "Rogue Hunter", "boss": { "hp": 18, "radius": 44, "speed": 140, "fireRate": 1.4, "score": 1500 }, "rocks": [ { "size": 2, "count": 2 }, { "size": 1, "count": 2 } ] },
+    { "type": "asteroids", "rocks": [ { "size": 3, "count": 6 }, { "size": 2, "count": 3 }, { "size": 1, "count": 2 } ] },
+    { "type": "objective", "label": "Secure Data Cores", "targets": 4, "targetHealth": 3, "rocks": [ { "size": 3, "count": 4 }, { "size": 2, "count": 2 }, { "size": 1, "count": 1 } ] },
+    { "type": "boss", "label": "Dreadnought Escort", "boss": { "hp": 24, "radius": 50, "speed": 160, "fireRate": 1.1, "score": 2200 }, "rocks": [ { "size": 2, "count": 3 }, { "size": 1, "count": 2 } ] },
+    { "type": "asteroids", "label": "Endless Siege", "rocks": [ { "size": 3, "count": 6 }, { "size": 2, "count": 4 }, { "size": 1, "count": 3 } ] }
   ],
   "splits": {
     "3": [2, 2],


### PR DESCRIPTION
## Summary
- add an in-shell difficulty slider that remaps ship speed, asteroid velocity, and scoring while surfacing the active setting in the HUD
- introduce objective and boss wave orchestration, including special targets, boss projectiles, and refreshed wave definitions
- layer comet and nebula parallax events over the starfield to break up long survival runs

## Testing
- npm run test:unit *(fails: runner smoke test lacks canvas drawImage in the mocked environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e689f0ccf48327963bd758d976e81d