### PR TITLE
Add platformer diagnostics HUD, biome overlays, and audio controls

### DIFF
--- a/games/platformer/index.html
+++ b/games/platformer/index.html
@@ -62,6 +62,108 @@
       cursor: pointer;
       font-weight: 700;
     }
+    .btn.btn--small {
+      padding: 6px 10px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .hud__label {
+      font-weight: 600;
+      color: #d1e3ff;
+    }
+    .hud__value {
+      font-variant-numeric: tabular-nums;
+      color: #cfd9f8;
+    }
+    #soundHud {
+      top: auto;
+      bottom: 12px;
+      left: auto;
+      right: 12px;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+    }
+    #soundHud input[type="range"] {
+      width: 120px;
+      accent-color: #7ab9ff;
+      background: transparent;
+    }
+    #soundHud .btn {
+      margin-left: 4px;
+    }
+    #debugHud {
+      position: fixed;
+      bottom: 12px;
+      left: 12px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid #27314b;
+      background: rgba(14, 17, 27, 0.88);
+      box-shadow: 0 14px 28px rgba(2, 6, 23, 0.45);
+      max-width: 320px;
+      width: max-content;
+      color: #9fb3d0;
+      font-size: 12px;
+      line-height: 1.4;
+      z-index: 6;
+      pointer-events: none;
+    }
+    #debugHud.debugHud--warn {
+      border-color: rgba(244, 162, 97, 0.6);
+      box-shadow: 0 16px 32px rgba(244, 162, 97, 0.22);
+    }
+    #debugHud.debugHud--error {
+      border-color: rgba(239, 97, 97, 0.7);
+      box-shadow: 0 16px 36px rgba(239, 97, 97, 0.28);
+    }
+    .debugHud__title {
+      display: block;
+      margin-bottom: 4px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 11px;
+      color: #c7d7f2;
+    }
+    .debugHud__list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .debugHud__row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .debugHud__label {
+      color: #7b8aa8;
+    }
+    .debugHud__value {
+      color: #e2e8f0;
+      font-variant-numeric: tabular-nums;
+    }
+    .debugHud__value--warn {
+      color: #f4a261;
+    }
+    .debugHud__value--error {
+      color: #ef6161;
+    }
+    .debugHud__log {
+      margin-top: 6px;
+      color: #8ea4c8;
+      font-size: 11px;
+      max-width: 260px;
+      word-break: break-word;
+    }
+    .debugHud__log--warn {
+      color: #f4a261;
+    }
+    .debugHud__log--error {
+      color: #ef6161;
+    }
     .platformer-overlay {
       position: fixed;
       inset: 0;
@@ -150,9 +252,23 @@
       }
       #netHud {
         top: auto;
-        bottom: 72px;
+        bottom: 136px;
         left: 12px;
         right: 12px;
+      }
+      #soundHud {
+        bottom: 72px;
+        right: 12px;
+        left: 12px;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 6px;
+      }
+      #debugHud {
+        bottom: 200px;
+        left: 12px;
+        right: 12px;
+        max-width: none;
       }
     }
     @media (max-width: 560px) {
@@ -178,6 +294,17 @@
   <div class="hud" id="netHud">
     <span id="connStatus">Offline</span>
     <div class="btn" id="startCoop" style="display:inline-block; margin-left:6px; font-size:12px">Start Co-op</div>
+  </div>
+  <div class="hud" id="soundHud" aria-label="Audio controls">
+    <label for="soundVolume" class="hud__label">Sound</label>
+    <input type="range" id="soundVolume" name="soundVolume" min="0" max="100" value="100" />
+    <button class="btn btn--small" type="button" id="soundToggle" aria-pressed="false">Pause Audio</button>
+    <span class="hud__value" id="soundStatus">100%</span>
+  </div>
+  <div id="debugHud" aria-live="polite">
+    <strong class="debugHud__title">Diagnostics</strong>
+    <ul class="debugHud__list" id="debugHudList"></ul>
+    <div class="debugHud__log" id="debugHudLog">Logs clear</div>
   </div>
   <main class="game-shell__main">
     <div class="game-shell__surface">

--- a/games/platformer/tiles.js
+++ b/games/platformer/tiles.js
@@ -33,8 +33,8 @@ export const tiles = {
 
 // Level JSON files to be loaded at runtime.
 export const levels = [
-  'levels/level1.json',
-  'levels/level2.json',
+  { path: 'levels/level1.json', biome: 'forest' },
+  { path: 'levels/level2.json', biome: 'cavern' },
 ];
 
 export function isSolid(t){

--- a/shared/render/tileTextures.js
+++ b/shared/render/tileTextures.js
@@ -58,6 +58,73 @@ const imageCache = new Map();
 const imagePromises = new Map();
 const patternCache = new WeakMap();
 
+const biomeOverlayRegistry = Object.freeze({
+  default: Object.freeze({
+    tint: 'rgba(62, 90, 133, 0.24)',
+    topHighlight: 'rgba(214, 226, 255, 0.16)',
+    topHighlightHeight: 5,
+    bottomShade: 'rgba(8, 12, 21, 0.22)',
+    bottomShadeHeight: 5,
+  }),
+  'default-hazard': Object.freeze({
+    tint: 'rgba(199, 92, 92, 0.28)',
+    topHighlight: 'rgba(255, 222, 222, 0.18)',
+    topHighlightHeight: 4,
+  }),
+  forest: Object.freeze({
+    pattern: 'block',
+    patternAlpha: 0.16,
+    tint: 'rgba(64, 117, 86, 0.26)',
+    topHighlight: 'rgba(186, 238, 196, 0.2)',
+    topHighlightHeight: 6,
+    bottomShade: 'rgba(16, 24, 19, 0.24)',
+    bottomShadeHeight: 6,
+  }),
+  'forest-hazard': Object.freeze({
+    pattern: 'lava',
+    patternAlpha: 0.12,
+    tint: 'rgba(196, 96, 76, 0.3)',
+    topHighlight: 'rgba(255, 210, 190, 0.18)',
+    topHighlightHeight: 5,
+  }),
+  cavern: Object.freeze({
+    pattern: 'lava',
+    patternAlpha: 0.2,
+    tint: 'rgba(72, 86, 130, 0.28)',
+    topHighlight: 'rgba(164, 186, 230, 0.18)',
+    topHighlightHeight: 5,
+    bottomShade: 'rgba(10, 16, 28, 0.25)',
+    bottomShadeHeight: 7,
+  }),
+  'cavern-hazard': Object.freeze({
+    pattern: 'lava',
+    patternAlpha: 0.14,
+    tint: 'rgba(204, 108, 92, 0.3)',
+    topHighlight: 'rgba(255, 194, 176, 0.2)',
+    topHighlightHeight: 4,
+  }),
+  industrial: Object.freeze({
+    pattern: 'industrial',
+    patternAlpha: 0.18,
+    tint: 'rgba(164, 148, 112, 0.28)',
+    topHighlight: 'rgba(255, 224, 170, 0.18)',
+    topHighlightHeight: 5,
+    stripe: 'rgba(46, 42, 38, 0.3)',
+    stripeWidth: 6,
+    stripeAlpha: 0.24,
+  }),
+  'industrial-hazard': Object.freeze({
+    pattern: 'industrial',
+    patternAlpha: 0.16,
+    tint: 'rgba(210, 104, 96, 0.3)',
+    topHighlight: 'rgba(255, 206, 202, 0.18)',
+    topHighlightHeight: 4,
+    stripe: 'rgba(80, 30, 28, 0.32)',
+    stripeWidth: 5,
+    stripeAlpha: 0.26,
+  }),
+});
+
 function createImage(src) {
   if (imageCache.has(src)) {
     return Promise.resolve(imageCache.get(src));
@@ -175,5 +242,61 @@ export function getSpriteFrame(key) {
   return spriteRegistry[normalizedKey]?.frame ?? null;
 }
 
+function applyStripeOverlay(ctx, color, dx, dy, size, width, alpha) {
+  const stripeWidth = Math.max(2, Math.min(size, Math.floor(width ?? size / 5)));
+  ctx.globalAlpha = typeof alpha === 'number' ? alpha : 0.25;
+  ctx.fillStyle = color;
+  for (let x = 0; x < size; x += stripeWidth * 2) {
+    ctx.fillRect(dx + x, dy, stripeWidth, size);
+  }
+}
+
+export function drawTileOverlay(ctx, key, dx, dy, size, options = {}) {
+  if (!ctx || typeof ctx.fillRect !== 'function') return false;
+  const def = biomeOverlayRegistry[key] || biomeOverlayRegistry.default;
+  if (!def) return false;
+  let drawn = false;
+  ctx.save();
+  try {
+    if (def.pattern) {
+      const pattern = getTilePattern(ctx, def.pattern);
+      if (pattern) {
+        ctx.globalAlpha = typeof def.patternAlpha === 'number' ? def.patternAlpha : 0.18;
+        ctx.fillStyle = pattern;
+        ctx.fillRect(dx, dy, size, size);
+        drawn = true;
+      }
+    }
+    if (def.tint) {
+      ctx.globalAlpha = typeof def.tintAlpha === 'number' ? def.tintAlpha : 0.24;
+      ctx.fillStyle = def.tint;
+      ctx.fillRect(dx, dy, size, size);
+      drawn = true;
+    }
+    if (def.stripe) {
+      applyStripeOverlay(ctx, def.stripe, dx, dy, size, def.stripeWidth, def.stripeAlpha);
+      drawn = true;
+    }
+    if (def.topHighlight && options.topExposed) {
+      const height = Math.max(2, Math.min(size, def.topHighlightHeight ?? Math.ceil(size * 0.18)));
+      ctx.globalAlpha = typeof def.topHighlightAlpha === 'number' ? def.topHighlightAlpha : 0.4;
+      ctx.fillStyle = def.topHighlight;
+      ctx.fillRect(dx, dy, size, height);
+      drawn = true;
+    }
+    if (def.bottomShade) {
+      const height = Math.max(2, Math.min(size, def.bottomShadeHeight ?? Math.ceil(size * 0.18)));
+      ctx.globalAlpha = typeof def.bottomShadeAlpha === 'number' ? def.bottomShadeAlpha : 0.24;
+      ctx.fillStyle = def.bottomShade;
+      ctx.fillRect(dx, dy + size - height, size, height);
+      drawn = true;
+    }
+  } finally {
+    ctx.restore();
+  }
+  return drawn;
+}
+
 export const tileTextureDefinitions = textureRegistry;
 export const tileSpriteDefinitions = spriteRegistry;
+export const tileOverlayDefinitions = biomeOverlayRegistry;


### PR DESCRIPTION
## Summary
- surface boot snapshot diagnostics in a debug HUD with live watchdog and canvas telemetry
- add HUD audio slider and pause toggle backed by shared audio helpers and a master volume control
- load biome metadata for levels and draw biome-specific tile overlays using shared texture utilities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68a34b1b08327bea4e20c24641e33