### PR TITLE
Refactor circular import fixture generation

### DIFF
--- a/tests/code-doctor.circular.test.mjs
+++ b/tests/code-doctor.circular.test.mjs
@@ -19,16 +19,39 @@ describe('tools/code-doctor.mjs', () => {
       version: '1.0.0',
     });
 
+    const relative = (name) => `./${name}.js`;
+
     await fixture.writeFile(
       'src/a.js',
-      ["import './b.js';", "import './d.js';", ''].join('\n'),
+      [relative('b'), relative('d')]
+        .map((importPath) => `import '${importPath}';`)
+        .concat('')
+        .join('\n'),
     );
-    await fixture.writeFile('src/b.js', "import './c.js';\n");
-    await fixture.writeFile('src/c.js', "import './a.js';\n");
-    await fixture.writeFile('src/d.js', "import './e.js';\n");
-    await fixture.writeFile('src/e.js', "import './f.js';\n");
-    await fixture.writeFile('src/f.js', "import './a.js';\n");
-    await fixture.writeFile('src/self.js', "import './self.js';\n");
+    await fixture.writeFile(
+      'src/b.js',
+      `import '${relative('c')}';\n`,
+    );
+    await fixture.writeFile(
+      'src/c.js',
+      `import '${relative('a')}';\n`,
+    );
+    await fixture.writeFile(
+      'src/d.js',
+      `import '${relative('e')}';\n`,
+    );
+    await fixture.writeFile(
+      'src/e.js',
+      `import '${relative('f')}';\n`,
+    );
+    await fixture.writeFile(
+      'src/f.js',
+      `import '${relative('a')}';\n`,
+    );
+    await fixture.writeFile(
+      'src/self.js',
+      `import '${relative('self')}';\n`,
+    );
 
     const result = await fixture.runDoctor();
 


### PR DESCRIPTION
## Summary
- add a helper to generate relative module paths in the circular import fixture setup
- rewrite the circular test fixture files to use the helper and avoid hard coded missing paths

## Testing
- npx vitest run tests/code-doctor.circular.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e6940a9d908327af32ee0d2e58acf3