### PR TITLE
Respect scene input handler return values

### DIFF
--- a/src/engine/scenes.js
+++ b/src/engine/scenes.js
@@ -322,8 +322,8 @@ export function createSceneManager(options = {}) {
       const handler = current.inputHandlers.get(action);
       if (typeof handler === 'function') {
         try {
-          handler.call(current.instance, ctx, info);
-          handled = true;
+          const result = handler.call(current.instance, ctx, info);
+          if (result !== false) handled = true;
         } catch (err) {
           console.error(`[scene:${id}] input handler "${action}" failed`, err);
         }

--- a/tests/scenes.input.test.js
+++ b/tests/scenes.input.test.js
@@ -1,0 +1,21 @@
+/* @vitest-environment jsdom */
+import { test, expect, vi } from 'vitest';
+import { createSceneManager } from '../src/engine/scenes.js';
+
+test('scene input handlers can fall back when returning false', async () => {
+  const manager = createSceneManager();
+  const directHandler = vi.fn(() => false);
+  const fallbackHandler = vi.fn(() => true);
+  await manager.push({
+    input: {
+      pause: directHandler,
+    },
+    handleInput: fallbackHandler,
+  });
+
+  const handled = manager.handle('pause');
+
+  expect(directHandler).toHaveBeenCalledTimes(1);
+  expect(fallbackHandler).toHaveBeenCalledTimes(1);
+  expect(handled).toBe(true);
+});


### PR DESCRIPTION
## Summary
- treat registered scene input handlers returning false as unhandled so scene-level fallbacks run
- add a regression test ensuring scene input handlers can delegate to handleInput when returning false

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd969e6024832799181fd26ce99d39